### PR TITLE
Optimize ltui Linear API usage

### DIFF
--- a/_opencode/commands/cmd:feeling-lucky-pr-os.md
+++ b/_opencode/commands/cmd:feeling-lucky-pr-os.md
@@ -110,14 +110,15 @@ If `PROJECT_REF` is empty, ask the user to provide the project id/key (list proj
 2) List issues:
 
 ```bash
-ltui --format json --fields key,title,url,updatedAt \
-  issues list --project "$PROJECT_REF" --state "Ready to pull" --label "FeelingLucky" --limit 50 \
+ltui --format json --fields identifier,title,updatedAt --limit 25 \
+  issues list --project "$PROJECT_REF" --state "Ready to pull" --label "FeelingLucky" \
   > /tmp/ltui-feeling-lucky-issues.json
 
 python3 - <<'PY'
 import json, random
 
-issues = json.load(open('/tmp/ltui-feeling-lucky-issues.json'))
+payload = json.load(open('/tmp/ltui-feeling-lucky-issues.json'))
+issues = payload.get('rows', []) if isinstance(payload, dict) else payload
 if not issues:
     print('NO_MATCHES')
     raise SystemExit(2)
@@ -125,7 +126,7 @@ if not issues:
 random.seed()  # FeelingLucky: non-deterministic is intentional
 pick = random.choice(issues)
 
-print('PICK_KEY=' + (pick.get('key') or ''))
+print('PICK_KEY=' + (pick.get('identifier') or pick.get('key') or ''))
 print('PICK_TITLE=' + (pick.get('title') or ''))
 print('PICK_URL=' + (pick.get('url') or ''))
 PY
@@ -140,7 +141,7 @@ Set:
 Fetch issue metadata in machine format:
 
 ```bash
-ltui --format json --fields key,title,url,project,state issues view "${ISSUE_KEY}" > /tmp/ltui-issue.json
+ltui --format json --fields identifier,title,url,state issues view "${ISSUE_KEY}" --no-attachment-probe > /tmp/ltui-issue.json
 
 ISSUE_TITLE="$(python3 -c 'import json; print(json.load(open("/tmp/ltui-issue.json")).get("title", ""))')"
 ISSUE_URL="$(python3 -c 'import json; print(json.load(open("/tmp/ltui-issue.json")).get("url", ""))')"

--- a/_opencode/commands/cmd:feeling-lucky-pr.md
+++ b/_opencode/commands/cmd:feeling-lucky-pr.md
@@ -110,14 +110,15 @@ If `PROJECT_REF` is empty, ask the user to provide the project id/key (list proj
 2) List issues:
 
 ```bash
-ltui --format json --fields key,title,url,updatedAt \
-  issues list --project "$PROJECT_REF" --state "Ready to pull" --label "FeelingLucky" --limit 50 \
+ltui --format json --fields identifier,title,updatedAt --limit 25 \
+  issues list --project "$PROJECT_REF" --state "Ready to pull" --label "FeelingLucky" \
   > /tmp/ltui-feeling-lucky-issues.json
 
 python3 - <<'PY'
 import json, random
 
-issues = json.load(open('/tmp/ltui-feeling-lucky-issues.json'))
+payload = json.load(open('/tmp/ltui-feeling-lucky-issues.json'))
+issues = payload.get('rows', []) if isinstance(payload, dict) else payload
 if not issues:
     print('NO_MATCHES')
     raise SystemExit(2)
@@ -125,7 +126,7 @@ if not issues:
 random.seed()  # FeelingLucky: non-deterministic is intentional
 pick = random.choice(issues)
 
-print('PICK_KEY=' + (pick.get('key') or ''))
+print('PICK_KEY=' + (pick.get('identifier') or pick.get('key') or ''))
 print('PICK_TITLE=' + (pick.get('title') or ''))
 print('PICK_URL=' + (pick.get('url') or ''))
 PY
@@ -140,7 +141,7 @@ Set:
 Fetch issue metadata in machine format:
 
 ```bash
-ltui --format json --fields key,title,url,project,state issues view "${ISSUE_KEY}" > /tmp/ltui-issue.json
+ltui --format json --fields identifier,title,url,state issues view "${ISSUE_KEY}" --no-attachment-probe > /tmp/ltui-issue.json
 
 ISSUE_TITLE="$(python3 -c 'import json; print(json.load(open("/tmp/ltui-issue.json")).get("title", ""))')"
 ISSUE_URL="$(python3 -c 'import json; print(json.load(open("/tmp/ltui-issue.json")).get("url", ""))')"

--- a/_opencode/commands/cmd:workplanner.md
+++ b/_opencode/commands/cmd:workplanner.md
@@ -103,11 +103,12 @@ If `PROJECT_REF` is empty, STOP and report the issue.
 
 ### 1) Select Candidate Issues
 
-List `Feeling Lucky` issues in `Backlog` and `Needs Feedback`:
+List `Feeling Lucky` issues in `Backlog` and `Needs Feedback` with server-side state filters:
 
 ```bash
-ltui --limit 100 --format json --fields identifier,title,state,updatedAt \
+ltui --limit 25 --format json --fields identifier,title,state,updatedAt \
   issues list --project "$PROJECT_REF" --label "Feeling Lucky" \
+  --state Backlog --state "Needs Feedback" \
   > "$OPENCODE_TMP/ltui-feeling-lucky-all.json" \
   || python3 - <<'PY' > "$OPENCODE_TMP/ltui-feeling-lucky-all.json"
 import json
@@ -118,13 +119,7 @@ python3 - <<'PY'
 import json
 
 payload = json.load(open('.opencode/tmp/ltui-feeling-lucky-all.json'))
-issues = payload.get('rows', []) if isinstance(payload, dict) else []
-
-def norm(v):
-    return (v or '').strip().lower()
-
-allowed_states = {'backlog', 'needs feedback'}
-candidates = [i for i in issues if norm(i.get('state')) in allowed_states]
+candidates = payload.get('rows', []) if isinstance(payload, dict) else []
 
 for i in sorted(candidates, key=lambda x: x.get('updatedAt') or ''):
     print(i.get('identifier') or '')
@@ -143,13 +138,7 @@ python3 - <<'PY' > "$OPENCODE_TMP/ltui-feeling-lucky-candidates.txt"
 import json
 
 payload = json.load(open('.opencode/tmp/ltui-feeling-lucky-all.json'))
-issues = payload.get('rows', []) if isinstance(payload, dict) else []
-
-def norm(v):
-    return (v or '').strip().lower()
-
-allowed_states = {'backlog', 'needs feedback'}
-candidates = [i for i in issues if norm(i.get('state')) in allowed_states]
+candidates = payload.get('rows', []) if isinstance(payload, dict) else []
 
 for i in sorted(candidates, key=lambda x: x.get('updatedAt') or ''):
     issue_key = (i.get('identifier') or '').strip()
@@ -178,7 +167,7 @@ Fetch full issue context with comments/history:
 
 ```bash
 ltui issues view "${ISSUE_KEY}" \
-  --include-comments --include-history \
+  --no-attachment-probe --include-comments --include-history \
   --max-description-chars 12000 --max-comment-chars 4000 \
   > "$OPENCODE_TMP/ltui-${ISSUE_KEY}.txt"
 ```

--- a/_pi/prompts/cmd:feeling-lucky-pr-os.md
+++ b/_pi/prompts/cmd:feeling-lucky-pr-os.md
@@ -118,16 +118,16 @@ If `PROJECT_REF` is empty, ask the user to provide the project id/key (list proj
 2) List issues:
 
 ```bash
-ltui --format json --fields key,title,url,updatedAt \
-  issues list --project "$PROJECT_REF" --state "Ready to pull" --label "Feeling Lucky" --limit 50 \
+ltui --format json --fields identifier,title,updatedAt --limit 25 \
+  issues list --project "$PROJECT_REF" --state "Ready to pull" --label "Feeling Lucky" \
   > "$OPENCODE_TMP/ltui-feeling-lucky-issues-1.json" \
   || python3 - <<'PY' > "$OPENCODE_TMP/ltui-feeling-lucky-issues-1.json"
 import json
 print(json.dumps([]))
 PY
 
-ltui --format json --fields key,title,url,updatedAt \
-  issues list --project "$PROJECT_REF" --state "Ready to pull" --label "FeelingLucky" --limit 50 \
+ltui --format json --fields identifier,title,updatedAt --limit 25 \
+  issues list --project "$PROJECT_REF" --state "Ready to pull" --label "FeelingLucky" \
   > "$OPENCODE_TMP/ltui-feeling-lucky-issues-2.json" \
   || python3 - <<'PY' > "$OPENCODE_TMP/ltui-feeling-lucky-issues-2.json"
 import json
@@ -174,7 +174,7 @@ if not issues:
 random.seed()  # FeelingLucky: non-deterministic is intentional
 pick = random.choice(issues)
 
-print('PICK_KEY=' + (pick.get('key') or ''))
+print('PICK_KEY=' + (pick.get('identifier') or pick.get('key') or ''))
 print('PICK_TITLE=' + (pick.get('title') or ''))
 print('PICK_URL=' + (pick.get('url') or ''))
 PY
@@ -189,7 +189,7 @@ Set:
 Fetch issue metadata in machine format:
 
 ```bash
-ltui --format json --fields key,title,url,project,state issues view "${ISSUE_KEY}" > "$OPENCODE_TMP/ltui-issue.json"
+ltui --format json --fields identifier,title,url,state issues view "${ISSUE_KEY}" --no-attachment-probe > "$OPENCODE_TMP/ltui-issue.json"
 
 ISSUE_TITLE="$(python3 -c 'import json; print(json.load(open(".opencode/tmp/ltui-issue.json")).get("title", ""))')"
 ISSUE_URL="$(python3 -c 'import json; print(json.load(open(".opencode/tmp/ltui-issue.json")).get("url", ""))')"

--- a/_pi/prompts/cmd:feeling-lucky-pr.md
+++ b/_pi/prompts/cmd:feeling-lucky-pr.md
@@ -110,14 +110,15 @@ If `PROJECT_REF` is empty, ask the user to provide the project id/key (list proj
 2) List issues:
 
 ```bash
-ltui --format json --fields key,title,url,updatedAt \
-  issues list --project "$PROJECT_REF" --state "Ready to pull" --label "FeelingLucky" --limit 50 \
+ltui --format json --fields identifier,title,updatedAt --limit 25 \
+  issues list --project "$PROJECT_REF" --state "Ready to pull" --label "FeelingLucky" \
   > /tmp/ltui-feeling-lucky-issues.json
 
 python3 - <<'PY'
 import json, random
 
-issues = json.load(open('/tmp/ltui-feeling-lucky-issues.json'))
+payload = json.load(open('/tmp/ltui-feeling-lucky-issues.json'))
+issues = payload.get('rows', []) if isinstance(payload, dict) else payload
 if not issues:
     print('NO_MATCHES')
     raise SystemExit(2)
@@ -125,7 +126,7 @@ if not issues:
 random.seed()  # FeelingLucky: non-deterministic is intentional
 pick = random.choice(issues)
 
-print('PICK_KEY=' + (pick.get('key') or ''))
+print('PICK_KEY=' + (pick.get('identifier') or pick.get('key') or ''))
 print('PICK_TITLE=' + (pick.get('title') or ''))
 print('PICK_URL=' + (pick.get('url') or ''))
 PY
@@ -140,7 +141,7 @@ Set:
 Fetch issue metadata in machine format:
 
 ```bash
-ltui --format json --fields key,title,url,project,state issues view "${ISSUE_KEY}" > /tmp/ltui-issue.json
+ltui --format json --fields identifier,title,url,state issues view "${ISSUE_KEY}" --no-attachment-probe > /tmp/ltui-issue.json
 
 ISSUE_TITLE="$(python3 -c 'import json; print(json.load(open("/tmp/ltui-issue.json")).get("title", ""))')"
 ISSUE_URL="$(python3 -c 'import json; print(json.load(open("/tmp/ltui-issue.json")).get("url", ""))')"

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -45,11 +45,12 @@ Linear rate limits apply to the authenticated user, shared across that user's AP
 
 For the Nodaste workspace checked on 2026-05-03, the live headers reported a 2,500 requests/hour request bucket and a 3,000,000 complexity/hour bucket for the current API user. Treat this as a live-header fact, not a permanent contract; Linear plan details and limits can change.
 
-Current `ltui` list operations can use more API requests than the row count suggests because the Linear SDK lazily fetches related entities such as team, state, project, assignee, labels, comments, or history. `--fields` reduces output tokens, but in the current implementation it does not necessarily reduce underlying Linear API requests. `--limit` and narrow filters are the best immediate controls for API spend.
+`ltui issues list` shapes its GraphQL request from `--fields`, so cheap field sets reduce both output tokens and relation fetching. Prefer `id,identifier,title,state,updatedAt` for grooming scans, and include `project`, `assignee`, or `labels` only when needed for the decision. Other commands may still use SDK convenience paths unless documented otherwise. Use `--show-rate-limit` when you need live budget metadata.
 
 Put global options before the subcommand:
 ```bash
 ltui --limit 5 --fields id,identifier,title,state issues list --team ENG
+ltui --format json --show-rate-limit --fields id,identifier,title issues list --team ENG
 ltui --format json issues view ENG-42
 ```
 
@@ -232,7 +233,7 @@ ltui issues relate ENG-43 --parent ENG-42
 3. **Use detail format sparingly** - Only when descriptions/comments needed
 4. **Filter early** - Use `--team`, `--project`, `--state` to reduce results
 5. **Keep list pages small** - Start with `--limit 5` or `--limit 10`; increase only when you truly need more rows
-6. **Use `--fields` for tokens, not API savings** - Select only needed columns to save context, but do not assume it reduces Linear requests in the current implementation
+6. **Use cheap `--fields` for list scans** - `issues list` fetches only supported requested fields; start with `id,identifier,title,state,updatedAt` and add relation fields only when needed
 7. **Avoid broad polling loops** - Do not repeatedly run unfiltered `issues list`, `projects list`, or search commands; reuse IDs and cached context from earlier output
 8. **Operate on many issues only with explicit intent** - Bulk reads or updates should start from a known issue ID list, use narrow filters, and pause/back off when rate headers are low
 9. **Parse errors first** - Don't proceed if output starts with `ERROR:`

--- a/skills/linear/references/ltui-command-reference.md
+++ b/skills/linear/references/ltui-command-reference.md
@@ -15,7 +15,7 @@ ltui issues list [options]
 Options:
   --team <key>           Filter by team key (e.g., ENG, PROD)
   --project <name|id>    Filter by project name or ID
-  --state <name|id>      Filter by state name or ID
+  --state <name|id>      Filter by state name or ID (repeatable)
   --assignee <email|id>  Filter by assignee (use "me" for yourself)
   --label <name>         Filter by label (can be used multiple times)
   --search <query>       Search issues by text
@@ -23,6 +23,7 @@ Options:
   --cursor <id>          Pagination cursor from previous response
   --fields <list>        Comma-separated field list (e.g., id,key,title,state)
   --format <fmt>         Output format: tsv, table, detail, json (default: tsv)
+  --show-rate-limit      Emit rate-limit metadata when available
   --profile <name>       Use specific profile
 ```
 
@@ -39,6 +40,7 @@ ltui issues list --project "Mobile App"
 
 # Filter by state
 ltui issues list --state "In Progress"
+ltui issues list --state "Todo" --state "In Progress"
 
 # Filter by assignee
 ltui issues list --assignee me
@@ -58,6 +60,7 @@ ltui issues list --limit 10
 
 # Get specific fields only
 ltui issues list --fields id,key,title,state
+ltui --format json --show-rate-limit --fields id,identifier,title issues list
 
 # Pagination
 ltui issues list --limit 50

--- a/skills/linear/references/ltui-command-reference.md
+++ b/skills/linear/references/ltui-command-reference.md
@@ -8,6 +8,8 @@ This document provides comprehensive command listings for ltui with all availabl
 
 List and filter issues with extensive options.
 
+Global options such as `--format`, `--fields`, `--limit`, `--cursor`, `--profile`, and `--show-rate-limit` must appear before the command path, for example `ltui --format json --fields id,title issues list --team ENG`.
+
 **All filter options:**
 ```bash
 ltui issues list [options]
@@ -19,12 +21,6 @@ Options:
   --assignee <email|id>  Filter by assignee (use "me" for yourself)
   --label <name>         Filter by label (can be used multiple times)
   --search <query>       Search issues by text
-  --limit <n>            Limit number of results (default: 50)
-  --cursor <id>          Pagination cursor from previous response
-  --fields <list>        Comma-separated field list (e.g., id,key,title,state)
-  --format <fmt>         Output format: tsv, table, detail, json (default: tsv)
-  --show-rate-limit      Emit rate-limit metadata when available
-  --profile <name>       Use specific profile
 ```
 
 **Examples:**
@@ -56,15 +52,15 @@ ltui issues list --search "login"
 ltui issues list --team ENG --state "Todo" --assignee me
 
 # Limit results
-ltui issues list --limit 10
+ltui --limit 10 issues list
 
 # Get specific fields only
-ltui issues list --fields id,key,title,state
+ltui --fields id,key,title,state issues list
 ltui --format json --show-rate-limit --fields id,identifier,title issues list
 
 # Pagination
-ltui issues list --limit 50
-ltui issues list --limit 50 --cursor xyz789
+ltui --limit 50 issues list
+ltui --limit 50 --cursor xyz789 issues list
 ```
 
 ### `ltui issues attachments`
@@ -94,7 +90,7 @@ Options:
 **Examples:**
 ```bash
 # Fetch image-like entries as JSON
-ltui issues attachments ENG-42 --only-images --format json
+ltui --format json issues attachments ENG-42 --only-images
 
 # Download images
 ltui issues attachments ENG-42 --only-images --download-dir ./.ltui-attachments/ENG-42
@@ -116,6 +112,7 @@ Arguments:
 Options:
   --include-comments         Include comments
   --include-history          Include history
+  --no-attachment-probe      Skip default attachment/comment scan for image guidance
   --max-description-chars <n> Max description chars (default: 4000)
   --max-comment-chars <n>     Max comment chars (default: 500)
 ```
@@ -154,8 +151,6 @@ Optional:
   --estimate <n>            Estimate in points
   --parent <identifier>     Parent issue identifier
   --cycle <name|id>         Cycle name or ID
-  --format <fmt>            Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>          Use specific profile
 ```
 
 **Examples:**
@@ -207,8 +202,6 @@ Options:
   --estimate <n>            Update estimate
   --project <name|id>       Move to different project
   --cycle <name|id>         Move to different cycle
-  --format <fmt>            Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>          Use specific profile
 ```
 
 **Examples:**
@@ -254,8 +247,7 @@ Required:
   --body <text|@file>  Comment text (use @file to read from file)
 
 Options:
-  --format <fmt>       Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>     Use specific profile
+  (none; use global options before the command path)
 ```
 
 **Examples:**
@@ -288,8 +280,6 @@ Required:
 
 Optional:
   --title <text>      Link title (defaults to URL)
-  --format <fmt>      Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>    Use specific profile
 ```
 
 **Examples:**
@@ -318,8 +308,7 @@ Required:
   --parent <id>       Parent issue identifier (e.g., ENG-42)
 
 Options:
-  --format <fmt>      Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>    Use specific profile
+  (none; use global options before the command path)
 ```
 
 **Examples:**
@@ -343,8 +332,7 @@ Required:
   --blocked-by <id>     Issue that blocks this one (e.g., ENG-40)
 
 Options:
-  --format <fmt>        Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>      Use specific profile
+  (none; use global options before the command path)
 ```
 
 **Examples:**
@@ -394,8 +382,6 @@ ltui projects list [options]
 
 Options:
   --team <key>         Filter by team
-  --format <fmt>       Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>     Use specific profile
 ```
 
 **Examples:**
@@ -407,7 +393,7 @@ ltui projects list
 ltui projects list --team ENG
 
 # Human-readable format
-ltui projects list --format table
+ltui --format table projects list
 ```
 
 ### `ltui projects view`
@@ -422,8 +408,7 @@ Arguments:
   <name|id>           Project name or ID
 
 Options:
-  --format <fmt>      Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>    Use specific profile
+  (none; use global options before the command path)
 ```
 
 **Examples:**
@@ -435,7 +420,7 @@ ltui projects view "Mobile App"
 ltui projects view abc123-def-456
 
 # Detail format
-ltui projects view "Mobile App" --format detail
+ltui --format detail projects view "Mobile App"
 ```
 
 ### `ltui projects align`
@@ -483,14 +468,13 @@ List all teams.
 ltui teams list [options]
 
 Options:
-  --format <fmt>       Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>     Use specific profile
+  (none; use global options before the command path)
 ```
 
 **Examples:**
 ```bash
 ltui teams list
-ltui teams list --format table
+ltui --format table teams list
 ```
 
 ### `ltui teams view`
@@ -505,14 +489,13 @@ Arguments:
   <key|id>            Team key (e.g., ENG) or ID
 
 Options:
-  --format <fmt>      Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>    Use specific profile
+  (none; use global options before the command path)
 ```
 
 **Examples:**
 ```bash
 ltui teams view ENG
-ltui teams view ENG --format detail
+ltui --format detail teams view ENG
 ```
 
 ## Labels Commands
@@ -527,8 +510,6 @@ ltui labels list [options]
 
 Options:
   --team <key>         Filter by team
-  --format <fmt>       Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>     Use specific profile
 ```
 
 **Examples:**
@@ -540,7 +521,7 @@ ltui labels list
 ltui labels list --team ENG
 
 # Human-readable
-ltui labels list --format table
+ltui --format table labels list
 ```
 
 ### `ltui labels create`
@@ -558,8 +539,6 @@ Optional:
   --color <hex>        Hex color code (e.g., #FF5733)
   --description <text> Label description
   --team <key>         Team to create label for
-  --format <fmt>       Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>     Use specific profile
 ```
 
 **Examples:**
@@ -589,8 +568,6 @@ ltui users list [options]
 
 Options:
   --search <text>      Search users by name or email
-  --format <fmt>       Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>     Use specific profile
 ```
 
 **Examples:**
@@ -602,7 +579,7 @@ ltui users list
 ltui users list --search alice
 
 # Human-readable
-ltui users list --format table
+ltui --format table users list
 ```
 
 ## Cycles Commands
@@ -620,8 +597,6 @@ Required:
 
 Optional:
   --current            Only show current cycle
-  --format <fmt>       Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>     Use specific profile
 ```
 
 **Examples:**
@@ -633,7 +608,7 @@ ltui cycles list --team ENG
 ltui cycles list --team ENG --current
 
 # Human-readable
-ltui cycles list --team ENG --format table
+ltui --format table cycles list --team ENG
 ```
 
 ## Documents Commands
@@ -647,8 +622,7 @@ List documents.
 ltui documents list [options]
 
 Options:
-  --format <fmt>       Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>     Use specific profile
+  (none; use global options before the command path)
 ```
 
 ### `ltui documents view`
@@ -663,8 +637,7 @@ Arguments:
   <id>                Document ID
 
 Options:
-  --format <fmt>      Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>    Use specific profile
+  (none; use global options before the command path)
 ```
 
 ## Roadmaps Commands
@@ -678,8 +651,7 @@ List roadmaps.
 ltui roadmaps list [options]
 
 Options:
-  --format <fmt>       Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>     Use specific profile
+  (none; use global options before the command path)
 ```
 
 ### `ltui roadmaps view`
@@ -694,8 +666,7 @@ Arguments:
   <id>                Roadmap ID
 
 Options:
-  --format <fmt>      Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>    Use specific profile
+  (none; use global options before the command path)
 ```
 
 ## Milestones Commands
@@ -709,8 +680,7 @@ List milestones.
 ltui milestones list [options]
 
 Options:
-  --format <fmt>       Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>     Use specific profile
+  (none; use global options before the command path)
 ```
 
 ### `ltui milestones view`
@@ -725,24 +695,21 @@ Arguments:
   <id>                Milestone ID
 
 Options:
-  --format <fmt>      Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>    Use specific profile
+  (none; use global options before the command path)
 ```
 
 ## Notifications Commands
 
-### `ltui notifications list`
+### `ltui notifications`
 
 List notifications.
 
 **Options:**
 ```bash
-ltui notifications list [options]
+ltui notifications [options]
 
 Options:
-  --unread             Only show unread notifications
-  --format <fmt>       Output format: tsv, table, detail, json (default: tsv)
-  --profile <name>     Use specific profile
+  --unread-only        Only show unread notifications
 ```
 
 ## Auth Commands

--- a/thoughts/plans/ltui-linear-api-usage-optimization.md
+++ b/thoughts/plans/ltui-linear-api-usage-optimization.md
@@ -1,0 +1,482 @@
+# ltui Linear API Usage Optimization
+
+Status: execution-ready
+
+## Goal
+
+Reduce Linear API request usage for `ltui` issue grooming workflows, especially large candidate scans, by making high-volume reads query-shaped, surfacing live rate-limit state, and updating agent workflows so they select narrowly before fetching expensive issue context.
+
+## Why this plan exists
+
+Recent Linear grooming runs are hitting request limits. The repo has already documented rate-limit guidance, but the implementation still has request-amplifying paths:
+
+- `ltui issues list` fetches a page, then eagerly resolves related SDK objects for every row.
+- `ltui issues list --search` performs an additional `client.issue(node.id)` lookup per search result.
+- `ltui issues view` always probes attachments/comments for image guidance.
+- `_opencode/commands/cmd:workplanner.md` lists up to 100 issues and filters some state locally before fetching full comments/history per candidate.
+
+The research artifact at `thoughts/research/2026-05-04-linear-api-usage-and-ltui-grooming.md` establishes that the highest-impact fix is to make list queries select only the fields the caller requested and to make grooming workflows avoid broad local filtering and broad detail loops.
+
+## Authority and inputs
+
+- User request: manifest a plan from the Linear API usage research.
+- Research artifact: `thoughts/research/2026-05-04-linear-api-usage-and-ltui-grooming.md`.
+- Repo guidance: `AGENTS.md`.
+- Planning doctrine: `planning-workflow` and `dev-plan` skills.
+- Product workflow doctrine: `product-principles` skill.
+- Implementation surfaces:
+  - `tools/ltui/src/commands/issues.ts`
+  - `tools/ltui/src/linear.ts`
+  - `tools/ltui/src/client.ts`
+  - `tools/ltui/src/options.ts`
+  - `tools/ltui/src/format.ts`
+  - `tools/ltui/src/test-utils/mockLinearClient.ts`
+  - `tools/ltui/src/__tests__/cli-regression.test.ts`
+  - `tools/ltui/src/__tests__/cli-args.test.ts`
+  - `tools/ltui/src/__tests__/output.test.ts`
+  - `tools/ltui/SPEC.md`
+  - `tools/ltui/README.md`
+  - `skills/linear/SKILL.md`
+  - `_opencode/commands/cmd:workplanner.md`
+  - `_pi/prompts/cmd:feeling-lucky-pr*.md`
+  - `_opencode/commands/cmd:feeling-lucky-pr*.md`
+
+Product-intent docs are absent (`thoughts/specs/product_intent.md` and `thoughts/plans/AGENTS.md` were not present), so this plan aligns to validated repo guidance, ltui docs, and the user’s API-budget goal.
+
+## Current implementation reality
+
+- `tools/ltui/src/commands/issues.ts` builds issue list filters, calls `client.issues(...)` or `client.searchIssues(...)`, then maps nodes through `mapIssueToRow(...)`.
+- `mapIssueToRow(...)` awaits `issue.team`, `issue.state`, `issue.project`, `issue.assignee`, and `issue.labels(...)` regardless of the caller’s selected fields.
+- `tools/ltui/src/format.ts` applies `--fields` after rows are mapped, so fields are currently output-only.
+- The installed Linear SDK exposes `client.client.rawRequest(...)`, and the raw response type includes `headers`, so ltui can use custom GraphQL without adding a new HTTP stack.
+- `tools/ltui/src/linear.ts` already contains one raw GraphQL lookup pattern for teams, which is a useful local precedent.
+- `tools/ltui/src/test-utils/mockLinearClient.ts` does not currently expose `client.client.rawRequest(...)` or request-count assertions, so tests need a small mock upgrade before the implementation can prove API-request reductions.
+- `tools/ltui/SPEC.md`, `tools/ltui/README.md`, and `skills/linear/SKILL.md` already warn that `--fields` saves tokens but not necessarily API requests; those warnings should change once the implementation makes `--fields` an API-efficiency control.
+
+## Progress
+
+- [x] P1 - Add request-shape test support and rate-header plumbing contracts.
+- [x] P2 - Make `issues list` query-shaped by requested fields and remove N+1 row mapping.
+- [x] P3 - Add multi-state filtering and API-budget controls for issue detail reads.
+- [x] P4 - Update grooming workflows and docs to use the cheaper API paths.
+- [x] P5 - Run full ltui verification and final consistency review.
+
+## Resume instructions (agent)
+
+Read this document fully, then start with the first unchecked item in `## Progress`. Keep edits scoped to the files named in the active phase unless implementation evidence shows a directly required adjacent file. After completing a phase, immediately mark that phase’s progress item complete and verify the completed marker is present in this file before moving on. Use `/skill:adn-dev-wf thoughts/plans/ltui-linear-api-usage-optimization.md` for the repo’s canonical reviewed-plan workflow if starting from the top.
+
+Ask the user only if implementation evidence contradicts a locked decision below or if Linear SDK behavior makes a query-shaped list impossible without changing dependencies.
+
+## Product intent alignment
+
+The default agent workflow should be cheap and safe by default:
+
+- Agents should be able to request a compact list without accidentally spending one request per row.
+- `--fields` should mean “only fetch what is needed” for high-volume list paths, not just “hide extra output after fetching it.”
+- Broad grooming should begin from server-side filters and small pages, then fetch expensive context only for a bounded candidate set.
+- Rate-limit pressure should be visible in command output when requested, with agent-legible guidance about reset/backoff state.
+- Routine API-budget awareness should live in ltui and workflow prompts, not in hidden operator folklore.
+
+Fail-closed boundaries:
+
+- Do not infer or mutate many issues unless a command has an explicit target set, preview, and bounded execution contract.
+- Do not silently skip requested fields; unknown fields must keep producing a validation error.
+- Do not remove attachment discovery entirely from normal single-issue viewing; make the API-saving path explicit with flags.
+
+## Locked decisions
+
+1. The first implementation target is `issues list`; it is the dominant request multiplier and already called out in `tools/ltui/SPEC.md`.
+2. Use `@linear/sdk`’s existing `client.client.rawRequest(...)` for custom GraphQL instead of introducing another GraphQL or HTTP dependency.
+3. `--fields` must shape the GraphQL selection set for `issues list`.
+4. Preserve existing output field names and JSON envelope shape for compatible fields.
+5. Keep default `issues list` output compatible enough for existing tests and users, but avoid N+1 by selecting all default output relations in one GraphQL query.
+6. Do not add a general-purpose `ltui graphql` command in this plan; custom GraphQL remains internal to typed ltui commands.
+7. Add repeatable `--state` for OR state filtering rather than a new state-set syntax.
+8. Add an opt-out flag for expensive default attachment probing on `issues view`; do not remove existing attachment guidance by default.
+9. Bulk mutation primitives are out of scope for this plan. The required grooming improvement is bounded reads and workflow guidance, not a new bulk mutation surface.
+10. Rate-limit visibility uses a global opt-in flag named `--show-rate-limit`. In this plan it is required for raw GraphQL-backed `issues list` paths, including search. For JSON list output, include a `meta.rateLimit` object with `requests.limit`, `requests.remaining`, `requests.reset`, `complexity.limit`, and `complexity.remaining` string-or-null values. For TSV, table, and detail output, preserve normal stdout and emit one stderr line beginning `RATE_LIMIT` with stable `requestsLimit=`, `requestsRemaining=`, `requestsReset=`, `complexityLimit=`, and `complexityRemaining=` key/value pairs. Rate-limit failures should keep the existing `ERROR: api_error rate_limited` shape and append agent-readable reset/backoff guidance when headers are available.
+
+## Acceptance criteria
+
+1. `ltui issues list --fields id,identifier,title` does not fetch team, state, project, assignee, labels, comments, history, or attachments.
+2. Default `ltui issues list` output remains compatible in field names and envelope shape while avoiding per-row SDK relation requests.
+3. `ltui issues list --search ...` avoids per-result `client.issue(node.id)` lookups.
+4. Repeated `--state` filters are supported and compiled into a Linear OR state filter.
+5. Unknown or unsupported fields still fail with an actionable validation error before misleading output is emitted.
+6. ltui can expose live rate-limit headers for raw GraphQL-backed commands when the user asks for them.
+7. `issues view` has an API-budget-saving path that avoids default attachment/comment probing unless requested.
+8. Grooming prompt/docs use narrow server-side filters and bounded detail reads instead of broad list plus local filtering.
+9. Tests prove API request-shape behavior, not only output token shape.
+10. `bun run test` passes in `tools/ltui`.
+
+## BDD scenarios
+
+### B1 - Scalar-only issue list
+
+Given an authenticated ltui profile and several Linear issues
+When an agent runs `ltui --format json --fields id,identifier,title issues list --team ENG --limit 10`
+Then ltui returns only `id`, `identifier`, and `title` rows
+And the underlying query does not request or resolve team, state, project, assignee, labels, comments, history, or attachments.
+
+### B2 - Default list compatibility without N+1
+
+Given an agent runs `ltui issues list --team ENG`
+When ltui produces default TSV output
+Then the output still includes the documented default list columns
+And relation fields needed for default output are fetched in one shaped GraphQL operation rather than through per-row lazy SDK calls.
+
+### B3 - Search results stay bounded
+
+Given an agent searches issues with `ltui --fields identifier,title issues list --search login --limit 10`
+When Linear returns matching issue nodes
+Then ltui maps the search result fields directly from the shaped query
+And does not call `client.issue(...)` once per result.
+
+### B4 - Multi-state grooming filter
+
+Given a grooming command only needs `Backlog` and `Needs Feedback`
+When it runs `ltui --fields identifier,title,state,updatedAt issues list --project <project> --label "Feeling Lucky" --state Backlog --state "Needs Feedback"`
+Then Linear receives an OR state filter
+And the command does not fetch unrelated state rows for local filtering.
+
+### B5 - Rate-limit header visibility
+
+Given Linear returns request and complexity rate-limit headers
+When an agent runs a supported command with the rate-limit display flag
+Then ltui emits those header values in a stable agent-readable form
+And rate-limit errors include reset/backoff guidance when available.
+
+### B5b - Rate-limit failure guidance
+
+Given Linear rejects a raw GraphQL-backed list request because a request or complexity budget is exhausted
+When ltui receives rate-limit headers with reset or remaining values
+Then it exits non-zero with `ERROR: api_error rate_limited`
+And the error output includes reset/backoff guidance using the captured header values.
+
+### B6 - Cheap issue view path
+
+Given an agent needs only title/state/url for a candidate issue
+When it runs `ltui --format json --fields identifier,title,state,url issues view ENG-1 --no-attachment-probe`
+Then ltui does not scan attachments or comments for image guidance
+And the returned fields remain parseable JSON.
+
+### B7 - Grooming workflow bounded detail fetch
+
+Given the workplanner needs to groom many issues
+When it selects candidates
+Then it uses server-side state filters, smaller pages, and cheap fields first
+And it fetches comments/history only for the next bounded candidate that needs full review.
+
+## Phase-by-phase execution plan
+
+## Phase 1: Add request-shape test support and rate-header plumbing contracts
+
+### End State
+
+The test harness can prove whether a command used raw GraphQL, which fields were selected, and whether relation resolvers were invoked. Rate-limit metadata has a small internal representation ready for command output in later phases.
+
+### Tests first
+
+Add failing tests that demonstrate the desired contract before implementation:
+
+- A harness-level test proves relation resolver calls for team/state/project/assignee/labels are counted when a mock issue row resolves them.
+- A harness-level test proves `client.issue(...)` calls are counted when the mock resolves an issue by id or key.
+- A unit or regression test confirms mock raw GraphQL responses can carry rate-limit headers.
+- A unit or regression test confirms the mock can surface a raw GraphQL rate-limit failure with captured headers.
+
+### Expected files
+
+- `tools/ltui/src/test-utils/mockLinearClient.ts`
+- `tools/ltui/src/__tests__/cli-regression.test.ts`
+- `tools/ltui/src/__tests__/output.test.ts`
+- likely `tools/ltui/src/linear.ts`
+- optional new helper file under `tools/ltui/src/`
+
+### Work
+
+- Extend the mock Linear client with a `client.rawRequest(...)` or `client.client.rawRequest(...)` surface matching the installed SDK shape.
+- Add mock request accounting for high-risk calls:
+  - raw GraphQL requests
+  - `client.issue(...)`
+  - per-issue relation access for team/state/project/assignee/labels
+  - attachments/comments/history probes where useful
+- Provide deterministic mock raw GraphQL responses for `issues` and `searchIssues` query shapes used by later phases.
+- Add a small internal type/helper for rate-limit headers, including:
+  - `x-ratelimit-requests-limit`
+  - `x-ratelimit-requests-remaining`
+  - `x-ratelimit-requests-reset`
+  - `x-ratelimit-complexity-limit`
+  - `x-ratelimit-complexity-remaining`
+- Add a small formatter contract for `--show-rate-limit` metadata so Phase 2 can attach it to list output without inventing the output shape during implementation.
+- Keep this phase focused on tests and plumbing; product behavior can still fail until Phase 2.
+
+### Verify
+
+```bash
+cd tools/ltui && bun run test
+```
+
+Expected before implementation in this phase: newly added tests fail for missing raw request/accounting behavior. Expected after implementation: the harness-level tests pass, while later behavior tests may still be pending.
+
+## Phase 2: Make `issues list` query-shaped by requested fields
+
+### End State
+
+`ltui issues list` uses explicit GraphQL selection sets derived from the requested output fields. Scalar-only field requests avoid relation fetching, default list output remains compatible, and search no longer performs one issue lookup per result.
+
+### Tests first
+
+Add or complete failing tests for these outcomes:
+
+- `--fields id,identifier,title` produces the same rows as before but records no relation resolver calls.
+- Default TSV output includes `id`, `key`, `identifier`, `title`, `state`, `priority`, `assignee`, `labels`, `project`, and `updatedAt`.
+- `--fields labels` selects labels, while omitting `labels` does not select labels.
+- `--search` with cheap fields uses one raw search/list query and no per-result `client.issue(...)` calls.
+- Unknown fields still fail with `ERROR: validation_error Unknown field(s): ...`.
+- `--show-rate-limit` on `issues list` emits the locked JSON `meta.rateLimit` shape and, for non-JSON formats, the locked stderr `RATE_LIMIT ...` line.
+- A raw GraphQL rate-limit failure preserves `ERROR: api_error rate_limited` and includes reset/backoff guidance when headers are present.
+
+### Expected files
+
+- `tools/ltui/src/commands/issues.ts`
+- `tools/ltui/src/linear.ts`
+- `tools/ltui/src/cli.ts`
+- `tools/ltui/src/options.ts`
+- `tools/ltui/src/format.ts`
+- `tools/ltui/src/__tests__/cli-regression.test.ts`
+- `tools/ltui/src/__tests__/cli-args.test.ts`
+- `tools/ltui/src/__tests__/output.test.ts`
+- `tools/ltui/src/test-utils/mockLinearClient.ts`
+
+### Work
+
+- Introduce a field registry for issue list output fields. Each field should define:
+  - output key/header
+  - GraphQL selection requirements
+  - row extraction from raw GraphQL data
+- Build GraphQL selection sets from `globalOpts.fields`; if no fields are specified, select the existing default columns in one query.
+- Preserve the existing JSON envelope shape from `renderPaginatedList`.
+- Replace the current list data path with raw GraphQL for both normal issue list and search list.
+- Keep the existing `buildIssueFilter(...)` behavior, but pass the filter variables to the shaped GraphQL query.
+- Remove or bypass `mapIssueToRow(...)` for list commands once raw rows are available.
+- Ensure selected relation fields are fetched as nested GraphQL fields, not as SDK lazy promises.
+- Add global `--show-rate-limit` parsing and apply it to raw GraphQL-backed `issues list` output:
+  - JSON: add `meta.rateLimit` with the locked shape from decision 10.
+  - TSV/table/detail: preserve stdout and emit the locked `RATE_LIMIT ...` stderr line.
+  - Rate-limit errors: preserve `ERROR: api_error rate_limited` while appending reset/backoff guidance when headers are present.
+- Keep detail/create/update/comment/link/relationship commands on existing SDK paths unless directly required for compatibility.
+
+### Verify
+
+```bash
+cd tools/ltui && bun run test
+```
+
+Manual spot checks with the mock client:
+
+```bash
+cd tools/ltui
+tmp_config=$(mktemp -d)
+export LTUI_CONFIG_DIR="$tmp_config"
+export LINEAR_API_KEY=lin_api_test
+export LTUI_TEST_CLIENT_MODULE="$PWD/dist/test-utils/mockLinearClient.js"
+node bin/ltui --format json --fields id,identifier,title issues list --team ENG
+node bin/ltui --format json --fields identifier,title issues list --search login --limit 5
+node bin/ltui --format json --show-rate-limit --fields id,identifier,title issues list --team ENG
+node bin/ltui issues list --team ENG --limit 5
+rm -rf "$tmp_config"
+```
+
+## Phase 3: Add multi-state filtering and API-budget controls for issue detail reads
+
+### End State
+
+Grooming commands can express multiple wanted states server-side, and `issues view` has a cheap path that avoids default attachment/comment probing when agents only need selected issue fields.
+
+### Tests first
+
+Add failing tests for:
+
+- Repeatable `--state` appears in `issues list --help`.
+- Multiple states compile into an OR state filter and return only matching mock issues.
+- `issues view --no-attachment-probe` omits attachment probe work while preserving selected JSON/detail output.
+- `issues view` without `--no-attachment-probe` preserves existing attachment guidance behavior.
+
+### Expected files
+
+- `tools/ltui/src/commands/issues.ts`
+- `tools/ltui/src/options.ts`
+- `tools/ltui/src/__tests__/cli-args.test.ts`
+- `tools/ltui/src/__tests__/cli-regression.test.ts`
+- `tools/ltui/src/test-utils/mockLinearClient.ts`
+- `tools/ltui/SPEC.md`
+
+### Work
+
+- Change `issues list --state` to be collectable/repeatable while preserving compatibility for a single state.
+- Update `IssueListCommandOptions`, saved query merging, and `buildIssueFilter(...)` to support state arrays.
+- Compile multiple states into a Linear OR filter. Preserve ID matching for UUID state refs.
+- Add `--no-attachment-probe` to `issues view`.
+- When attachment probing is disabled, do not call `probeIssueAssets(...)`; set attachment guidance fields to absent or omit them consistently for JSON/detail according to the existing output style.
+- Make sure `--include-comments` and `--include-history` still explicitly fetch those sections even when attachment probing is disabled.
+- Keep error messages actionable if a state filter is malformed or an unknown field is requested.
+
+### Verify
+
+```bash
+cd tools/ltui && bun run test
+```
+
+Manual spot checks with the mock client:
+
+```bash
+cd tools/ltui
+tmp_config=$(mktemp -d)
+export LTUI_CONFIG_DIR="$tmp_config"
+export LINEAR_API_KEY=lin_api_test
+export LTUI_TEST_CLIENT_MODULE="$PWD/dist/test-utils/mockLinearClient.js"
+node bin/ltui issues list --help | rg -- '--state'
+node bin/ltui --format json --fields identifier,title,state issues list --state Todo --state "In Progress"
+node bin/ltui --format json --fields identifier,title,state,url issues view ENG-1 --no-attachment-probe
+rm -rf "$tmp_config"
+```
+
+## Phase 4: Update grooming workflows and docs to use the cheaper API paths
+
+### End State
+
+Repo guidance and grooming prompts teach agents to use server-side filters, cheap fields, bounded pages, and cheap issue views before expensive comment/history fetches. Warnings that `--fields` is output-only are replaced or narrowed to reflect the new implementation.
+
+### Tests first
+
+Use static checks to define the desired documentation and prompt contract before editing:
+
+- Existing docs still mention live Linear rate headers.
+- Docs and help mention `--show-rate-limit` and describe the JSON `meta.rateLimit` plus stderr `RATE_LIMIT` forms.
+- Workplanner no longer relies on a broad 100-row query plus local state filtering.
+- Agent guidance no longer says `--fields` is token-only for `issues list` after implementation.
+
+### Expected files
+
+- `tools/ltui/SPEC.md`
+- `tools/ltui/README.md`
+- `skills/linear/SKILL.md`
+- `skills/linear/references/ltui-command-reference.md`
+- `_opencode/commands/cmd:workplanner.md`
+- likely `_pi/prompts/cmd:feeling-lucky-pr*.md`
+- likely `_opencode/commands/cmd:feeling-lucky-pr*.md`
+- optional `CHANGELOG.md`
+
+### Work
+
+- Update ltui docs to state that `issues list --fields` now shapes API requests for supported fields.
+- Preserve guidance that other commands may still use SDK convenience paths unless explicitly optimized.
+- Update examples to put global options before subcommands, matching existing repo guidance.
+- Update the Linear skill to recommend cheap list fields for grooming:
+  - `id,identifier,title,state,updatedAt`
+  - include `project`, `assignee`, or `labels` only when needed for output.
+- Update `_opencode/commands/cmd:workplanner.md` to:
+  - use repeated `--state` filters for `Backlog` and `Needs Feedback`
+  - reduce initial page size unless a larger limit is explicitly justified
+  - avoid local state filtering as the primary selector
+  - use `issues view --no-attachment-probe` for cheap metadata checks where full attachment guidance is not needed
+  - fetch comments/history only for the next candidate being actively reviewed
+- Update Feeling Lucky prompts that list ready issues so they use cheap fields and avoid unnecessary project/state fields in issue view unless needed.
+- Add a changelog entry if this repo’s convention expects one for ltui behavior changes.
+
+### Verify
+
+```bash
+rg -n -- '--fields|--show-rate-limit|rate-limit|RATE_LIMIT|x-ratelimit|--state|no-attachment-probe|issues list' tools/ltui/SPEC.md tools/ltui/README.md skills/linear/SKILL.md skills/linear/references/ltui-command-reference.md _opencode/commands/cmd:workplanner.md _pi/prompts _opencode/commands
+```
+
+```bash
+rg -n "fields.*tokens|output only|not necessarily API|local state|allowed_states|--limit 100" tools/ltui/README.md skills/linear/SKILL.md _opencode/commands/cmd:workplanner.md
+```
+
+Review any matches from the second command and confirm they are either removed, intentionally scoped to non-optimized commands, or still accurate.
+
+## Phase 5: Run full ltui verification and final consistency review
+
+### End State
+
+All tests pass, high-volume issue-list behavior is measurably request-shaped in tests, and docs/prompts consistently steer agents toward API-efficient grooming.
+
+### Tests first
+
+No new RED tests are expected in this phase. If a behavior or docs gap is found during verification, add the smallest regression test or static check that would have caught it, then fix the gap.
+
+### Expected files
+
+- Any files touched in Phases 1 through 4.
+- This plan file, with completed checkboxes as phases finish.
+
+### Work
+
+- Run the full ltui test suite.
+- Run targeted static searches for stale guidance.
+- Inspect the final diff for consistency across CLI help, README, skill docs, SPEC, and grooming prompts.
+- Confirm no unrelated dirty worktree changes were modified or reverted.
+- Update this plan’s progress checkboxes and append to the decisions/deviations log only if execution diverged from locked decisions.
+
+### Verify
+
+```bash
+cd tools/ltui && bun run test
+```
+
+```bash
+git diff -- tools/ltui/src tools/ltui/README.md tools/ltui/SPEC.md skills/linear _opencode/commands/cmd:workplanner.md _pi/prompts _opencode/commands thoughts/plans/ltui-linear-api-usage-optimization.md
+```
+
+```bash
+rg -n "fields.*tokens|output only|not necessarily API|broad polling|--limit 100|allowed_states" tools/ltui/README.md tools/ltui/SPEC.md skills/linear _opencode/commands/cmd:workplanner.md _pi/prompts _opencode/commands
+```
+
+## Verification strategy
+
+- Unit and CLI regression tests prove output compatibility and request-shape behavior.
+- Mock request accounting proves the API usage reduction directly instead of relying on token output as a proxy.
+- CLI help tests prove new flags are discoverable.
+- Static docs/prompt checks catch stale guidance that would cause agents to keep expensive grooming habits.
+- Final `bun run test` in `tools/ltui` is the primary implementation gate.
+
+## Delivery order
+
+1. Add test/mock observability for request shape.
+2. Implement query-shaped `issues list`.
+3. Add multi-state filters and cheap detail-read controls.
+4. Update grooming prompts and docs.
+5. Run tests and consistency review.
+
+## Non-goals
+
+- Adding a generic GraphQL CLI.
+- Adding a new dependency for GraphQL or HTTP.
+- Implementing bulk mutation commands.
+- Rewriting all ltui commands to raw GraphQL.
+- Changing Linear authentication or API-key storage.
+- Removing default attachment guidance from normal single-issue views.
+- Solving Linear rate limits by rotating API keys; Linear request limits apply to the authenticated user and are shared across that user’s keys/tools.
+
+## Test coverage matrix
+
+| Acceptance / scenario | Planned evidence |
+| --- | --- |
+| AC1, B1 | CLI regression with mock request accounting for scalar-only `issues list` |
+| AC2, B2 | Existing and updated output tests for default TSV/JSON list shape plus no per-row relation calls |
+| AC3, B3 | Search regression proving no per-result `client.issue(...)` calls |
+| AC4, B4 | CLI args and regression tests for repeatable `--state` and OR filter behavior |
+| AC5 | Unknown-field regression against shaped field registry |
+| AC6, B5, B5b | Rate-header helper/unit test, CLI regression for `--show-rate-limit` requested display, and raw GraphQL rate-limit failure guidance |
+| AC7, B6 | `issues view --no-attachment-probe` regression with attachment/comment probe accounting |
+| AC8, B7 | Static prompt/doc checks for server-side state filters and bounded detail fetch |
+| AC9 | Mock accounting assertions in cli regression tests |
+| AC10 | `cd tools/ltui && bun run test` |
+
+## Decisions / Deviations log
+
+- 2026-05-04: Plan locks `issues list` raw GraphQL as the primary implementation path because the installed SDK exposes `client.client.rawRequest(...)` with headers and the repo already uses a raw GraphQL team lookup pattern.
+- 2026-05-04: Plan excludes bulk mutation primitives to keep scope focused on the observed grooming request pressure. Bulk work remains a future explicit feature with preview/backoff requirements.
+- 2026-05-04: Integrated read-only Codex and Claude plan review feedback by locking the `--show-rate-limit` flag and output contract, adding rate-limit failure guidance coverage, fixing mock-backed manual verification commands, and restoring the cited research artifact in this worktree.
+- 2026-05-04: Integrated second Codex plan review feedback by keeping Phase 1 limited to mock/accounting/header harness tests and moving end-to-end request-shape behavior tests into Phase 2.

--- a/thoughts/research/2026-05-04-linear-api-usage-and-ltui-grooming.md
+++ b/thoughts/research/2026-05-04-linear-api-usage-and-ltui-grooming.md
@@ -1,0 +1,183 @@
+---
+date: 2026-05-04T00:28:58Z
+author: codex
+git_commit: 6cec7d64266f492942ecc5e671f6b77328e39c29
+branch: main
+repository: ai-configs
+type: research
+status: complete
+tags: [linear, ltui, api-usage, rate-limits, grooming]
+last_updated: 2026-05-04
+---
+
+# Research: Linear API Usage and ltui Grooming
+
+## Research Question
+
+Investigate how to reduce Linear API usage, especially for grooming large numbers of issues through `ltui`, using the current ltui implementation and Linear API docs.
+
+## Summary
+
+The largest API request multiplier is `ltui issues list`. It currently asks the SDK for an issue page, then maps every issue row by awaiting relation promises for team, state, project, assignee, and labels. Search is even more expensive because `client.searchIssues(...)` is followed by `client.issue(node.id)` for every search result before the same relation mapping runs.
+
+Linear's API is GraphQL, with both request and complexity budgets. The practical optimization is to move high-volume read paths away from SDK-lazy entity access and toward explicit GraphQL selection sets shaped by the requested fields. `--fields id,identifier,title` should translate into a query that only selects those fields and should not touch team, state, project, assignee, labels, comments, history, or attachments.
+
+## Detailed Findings
+
+### Linear API Constraints
+
+- Linear documents GraphQL rate limiting with request and complexity dimensions, surfaced through response headers.
+- Linear documents filtering on paginated results, including nested filters and logical operators.
+- Linear's GraphQL model lets clients request exactly the fields needed. This is the main lever `ltui` should use for large list/audit/grooming workflows.
+- The installed `@linear/sdk` exposes `client.client.rawRequest(...)`, whose raw response includes headers. That means ltui can use the existing SDK dependency for custom GraphQL and live rate-limit visibility without introducing a separate HTTP client.
+
+Sources:
+- https://linear.app/developers/rate-limiting
+- https://linear.app/developers/filtering
+- https://linear.app/developers/graphql
+- `tools/ltui/node_modules/@linear/sdk/dist/index.d.mts`
+
+### Current `issues list` Request Shape
+
+`issues list` builds a Linear filter, requests issues or search results, and then maps rows:
+
+- `tools/ltui/src/commands/issues.ts:92` builds effective filters.
+- `tools/ltui/src/commands/issues.ts:101` calls `client.searchIssues(...)` or `client.issues(...)`.
+- `tools/ltui/src/commands/issues.ts:105` turns each search result into `client.issue(node.id)`, adding one request per result for search.
+- `tools/ltui/src/commands/issues.ts:109` maps all nodes through `mapIssueToRow(...)`.
+- `tools/ltui/src/commands/issues.ts:1112` awaits team, state, project, assignee, and labels for every row.
+
+This means `--fields id,identifier,title` saves output tokens but does not prevent relation fetches, because field filtering happens after rows are already fully mapped.
+
+### Current `issues view` Request Shape
+
+`issues view` resolves a single issue, then always resolves related state/team/project/assignee and probes attachments/comments for image guidance:
+
+- `tools/ltui/src/commands/issues.ts:262` resolves the issue.
+- `tools/ltui/src/commands/issues.ts:272` resolves state/team/project/assignee.
+- `tools/ltui/src/commands/issues.ts:294` probes assets, which can call `issue.attachments(...)` and `issue.comments(...)`.
+- `tools/ltui/src/commands/issues.ts:331` fetches comments when requested.
+- `tools/ltui/src/commands/issues.ts:345` fetches history when requested.
+
+This is reasonable for a single selected issue, but it is costly inside loops across many candidate issues.
+
+### Grooming Workflow Amplifier
+
+`_opencode/commands/cmd:workplanner.md` is a representative large-grooming workflow:
+
+- It lists up to 100 issues with `--fields identifier,title,state,updatedAt`.
+- It filters candidate states locally after the list.
+- It then loops candidates and runs `ltui issues view --include-comments --include-history` for each candidate until a terminal decision.
+
+This pattern can spend many requests before doing useful work, especially when the issue list includes many candidates or comments/history/attachments are present.
+
+## Recommendations
+
+### 1. Make `issues list` Query-Shaped
+
+Implement custom GraphQL for `issues list` using the selected fields. Use SDK `client.client.rawRequest` or `request` with explicit selection sets.
+
+Examples:
+
+- `--fields id,identifier,title,updatedAt` selects only scalar issue fields.
+- `--fields state` adds `state { name }`.
+- `--fields team` or `key` adds `team { key }`.
+- `--fields project` adds `project { name slugId id }` only as needed.
+- `--fields assignee` adds `assignee { name id email }` only as needed.
+- `--fields labels` adds `labels(first: N) { nodes { name id } }` only as needed.
+
+This is the highest-impact change.
+
+### 2. Split "light list" From "rich list"
+
+Make lightweight fields the default for list output, then require an explicit flag or field request for relation-heavy columns. A good default for grooming is:
+
+```bash
+ltui --limit 25 --format json --fields id,identifier,title,state,updatedAt issues list ...
+```
+
+`state` is usually useful for grooming, but labels/project/assignee should not be fetched unless they are filters or requested output.
+
+### 3. Push More Grooming Filters Into Linear
+
+When a grooming loop only wants `Backlog` and `Needs Feedback`, avoid fetching all project/label rows then filtering locally. ltui currently supports one `--state`; add one of:
+
+- repeatable `--state`, compiled as `state: { or: [...] }`
+- `--state-type`
+- saved query definitions that support OR state sets
+
+For the workplanner pattern, this turns one broad 100-row query into one or two narrow queries and reduces follow-up issue views.
+
+### 4. Add a Two-Stage Context Command
+
+Large grooming should select candidates from cheap fields, then fetch expensive context only for a bounded subset. ltui could expose:
+
+```bash
+ltui issues context ENG-123 --comments --history --attachments
+```
+
+or extend `issues view` with opt-in flags such as `--no-attachment-probe`. Today the attachment probe happens on every default view, which is useful but not free.
+
+### 5. Expose Rate Headers
+
+Add global options like:
+
+```bash
+ltui --show-rate-limit ...
+ltui --rate-limit-json ...
+```
+
+Implementation path: use `rawRequest` for custom GraphQL paths and capture headers from `LinearRawResponse.headers`. For SDK convenience calls that do not expose headers directly, prefer custom GraphQL on high-volume commands.
+
+### 6. Add Bounded Bulk Primitives
+
+If agents need to groom or migrate many issues, make bulk operations explicit:
+
+- require narrow filter or known ID list
+- preview target count before mutation
+- apply max default, for example 25
+- sequential or very low concurrency
+- stop/back off when remaining requests or complexity falls below a threshold
+- write progress to a resumable local file
+
+Do not rely on shell loops around `issues view` and `issues update` for high-volume operations.
+
+### 7. Cache Stable Lookup Data Longer
+
+The existing cache has a 300 second TTL for teams, projects, workflow states, labels, and users. For grooming, teams/states/labels/project refs are stable enough to cache longer, especially if cache invalidation is available:
+
+- teams/states/labels/users: 1 to 24 hours
+- projects by id/slug/name: 10 to 60 minutes
+- issue list pages: optional, only for explicit `--cache`/`--cache-ttl`
+
+Avoid caching issue detail by default unless stale reads are acceptable.
+
+## Immediate Agent Guidance
+
+Until ltui changes:
+
+- Use narrow Linear filters before reading many rows.
+- Keep `--limit` low while exploring.
+- Do not assume `--fields` saves API requests.
+- Avoid `--search` for bulk grooming if regular filters can express the target set, because search currently adds per-result issue lookups.
+- Do not run `issues view --include-comments --include-history` across a broad candidate set. First select a tiny candidate batch from `issues list`.
+- Prefer known ID/key lists for bulk operations.
+
+## Code References
+
+- `tools/ltui/src/commands/issues.ts:101` - issue list/search API call.
+- `tools/ltui/src/commands/issues.ts:105` - search result per-node issue fetch.
+- `tools/ltui/src/commands/issues.ts:1112` - row mapping awaits relation promises for every issue.
+- `tools/ltui/src/commands/issues.ts:294` - default issue view probes assets.
+- `tools/ltui/src/commands/issues.ts:331` - optional comments fetch.
+- `tools/ltui/src/commands/issues.ts:345` - optional history fetch.
+- `tools/ltui/src/linear.ts:21` - existing custom team lookup query pattern.
+- `tools/ltui/src/cache.ts:1` - current local cache implementation.
+- `_opencode/commands/cmd:workplanner.md:109` - broad candidate list.
+- `_opencode/commands/cmd:workplanner.md:180` - per-candidate full context fetch.
+
+## Open Questions
+
+- Should `issues list` preserve the current relation-heavy default output for compatibility, or should the default become cheap and require explicit rich fields?
+- Should attachment probing remain default on `issues view`, or become opt-in for API-budget-sensitive workflows?
+- Should ltui add a general `graphql` command for debugging, or keep custom GraphQL internal to typed commands?

--- a/tools/ltui/README.md
+++ b/tools/ltui/README.md
@@ -196,12 +196,15 @@ Linear rate limits are attached to the authenticated Linear user and are shared 
 
 As checked against the Nodaste workspace on 2026-05-03, Linear reported a 2,500 requests/hour request bucket and a 3,000,000 complexity/hour bucket for the current API user. Treat those as live-header facts, not permanent product guarantees.
 
-`ltui` is token-efficient, but some commands are not yet API-request-efficient. In particular, `issues list` fetches a page of issues and then may resolve related team, state, project, assignee, and labels for each row through the Linear SDK. That means a small-looking list command can spend many Linear API requests. `--fields` currently trims output only; it should not be treated as an API-request savings control until the implementation is query-shaped by requested fields.
+`ltui` is token-efficient, but API request budget still matters. `issues list` is query-shaped by requested fields, so `--fields id,identifier,title` avoids fetching relation-heavy fields such as team, state, project, assignee, and labels. Other commands may still use SDK convenience paths unless their docs say otherwise.
+
+Use `--show-rate-limit` on raw GraphQL-backed list paths when you need live budget visibility. JSON output includes `meta.rateLimit`; TSV/table output keeps normal stdout parseable and emits a `RATE_LIMIT ...` line on stderr.
 
 Use global options before the subcommand:
 
 ```bash
 ltui --limit 5 --fields id,identifier,title,state issues list --team ENG
+ltui --format json --show-rate-limit --fields id,identifier,title issues list --team ENG
 ltui --format detail issues view ENG-123
 ```
 

--- a/tools/ltui/SPEC.md
+++ b/tools/ltui/SPEC.md
@@ -178,6 +178,7 @@ The CLI is organized by top‑level noun commands. Every command:
 - `--fields <comma-separated>` – limit fields included in output.
 - `--limit <n>` – limit item count for list operations (default 20).
 - `--cursor <cursor>` – pagination cursor for list operations.
+- `--show-rate-limit` – for commands that can access response headers, emit Linear rate-limit metadata on request.
 - `--agent` / `--no-agent` – force agent mode on/off.
 
 ### 5.2 Issues
@@ -190,7 +191,7 @@ The CLI is organized by top‑level noun commands. Every command:
   - Filters (all optional, combinable):
     - `--team <key-or-id>`
     - `--project <key-or-id>`
-    - `--state <name-or-id>` (e.g. `"Todo"`, `"In Progress"`, `"Done"`)
+    - `--state <name-or-id>` (repeatable; e.g. `"Todo"`, `"In Progress"`, `"Done"`)
     - `--assignee <me|email|id>`
     - `--label <name-or-id>` (repeatable)
     - `--search <query>` (Linear search syntax, if available)
@@ -212,7 +213,7 @@ id	key	identifier	title	state	priority	assignee	labels	project	updatedAt
 
 #### 5.2.2 View Issue
 
-- `ltui issues view <issue-id-or-key> [--include-comments] [--include-history]`
+- `ltui issues view <issue-id-or-key> [--include-comments] [--include-history] [--no-attachment-probe]`
 
 **Agent detail format (default in agent mode):**
 
@@ -400,6 +401,7 @@ For `--format json`, output is a single JSON object envelope on `stdout` (no pla
 ### 6.4 Field Selection
 
 - `--fields` applies to `table`, `tsv`, and `json` list formats.
+- For `issues list`, `--fields` shapes the GraphQL selection set for supported fields, so scalar-only requests avoid relation fields.
 - Values outside the supported set are rejected with `validation_error`.
 - Each command defines its own allowed field names (documented in `--help`).
 
@@ -461,6 +463,7 @@ Where the SDK exposes higher‑level helpers (e.g. by key or identifier), prefer
   - Limit concurrency for bulk operations.
   - Surface rate limit errors clearly with `ERROR: api_error rate_limited`.
   - Read and expose useful response headers where available: `x-ratelimit-requests-limit`, `x-ratelimit-requests-remaining`, `x-ratelimit-requests-reset`, `x-ratelimit-complexity-limit`, and `x-ratelimit-complexity-remaining`.
+  - `--show-rate-limit` includes these values as JSON `meta.rateLimit` for JSON output and as a `RATE_LIMIT requestsLimit=...` stderr line for TSV/table output.
   - Treat request limits as per authenticated Linear user, shared across that user's API keys and agent tools.
 - Optionally cache stable lookups (e.g. team key → id, label name → id) in memory per process, and on disk in `~/.config/ltui/cache.json` with short TTL.
 - Avoid N+1 SDK access patterns in list commands. `issues list` should shape its GraphQL selection to the requested columns instead of fetching each issue and then lazily resolving team/state/project/assignee/labels for every row.

--- a/tools/ltui/src/__tests__/cli-args.test.ts
+++ b/tools/ltui/src/__tests__/cli-args.test.ts
@@ -34,7 +34,7 @@ function runLtui(args: string[], env?: Record<string, string | undefined>) {
 const globalHelpCase: HelpCase = {
   title: 'global options',
   args: ['--help'],
-  expectOptions: ['--profile <name>', '--format <fmt>', '--fields <fields>', '--limit <n>', '--cursor <cursor>', '--agent', '--no-agent'],
+  expectOptions: ['--profile <name>', '--format <fmt>', '--fields <fields>', '--limit <n>', '--cursor <cursor>', '--show-rate-limit', '--agent', '--no-agent'],
 };
 
 const helpCases: HelpCase[] = [
@@ -46,7 +46,7 @@ const helpCases: HelpCase[] = [
   { title: 'auth test', args: ['auth', 'test', '--help'], expectOptions: ['--profile <name>'] },
   { title: 'issues list', args: ['issues', 'list', '--help'], expectOptions: ['--team <key-or-id>', '--project <key-or-id>', '--state <name-or-id>', '--assignee <me|email|id>', '--label <name-or-id>', '--search <query>', '--updated-since <iso>', '--created-since <iso>', '--saved <name>'] },
   { title: 'issues attachments', args: ['issues', 'attachments', '--help'], expectOptions: ['--only-images', '--download-dir <dir>', '--overwrite', '--no-linear-attachments', '--no-upload-urls', '--no-scan-comments'] },
-  { title: 'issues view', args: ['issues', 'view', '--help'], expectOptions: ['--include-comments', '--include-history', '--max-description-chars <n>', '--max-comment-chars <n>'] },
+  { title: 'issues view', args: ['issues', 'view', '--help'], expectOptions: ['--include-comments', '--include-history', '--no-attachment-probe', '--max-description-chars <n>', '--max-comment-chars <n>'] },
   { title: 'issues create', args: ['issues', 'create', '--help'], expectOptions: ['--team <key>', '--project <key-or-id>', '--title <title>', '--description <text-or-@path>', '--state <name-or-id>', '--label <name-or-id>', '--assignee <me|email|id>', '--priority <0-4>'] },
   { title: 'issues update', args: ['issues', 'update', '--help'], expectOptions: ['--team <key>', '--project <key-or-id>', '--title <title>', '--description <text-or-@path>', '--state <name-or-id>', '--label <name-or-id>', '--add-label <name-or-id>', '--remove-label <name-or-id>', '--assignee <me|email|id>', '--priority <0-4>', '--estimate <number>', '--due <iso>'] },
   { title: 'issues comment', args: ['issues', 'comment', '--help'], expectOptions: ['--body <text-or-@path>'] },

--- a/tools/ltui/src/__tests__/cli-regression.test.ts
+++ b/tools/ltui/src/__tests__/cli-regression.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync, SpawnSyncReturns } from 'node:child_process';
@@ -69,6 +69,10 @@ function expectPureJsonOutput(result: SpawnSyncReturns<string>, commandLabel: st
   const first = trimmed[0];
   assert.ok(first === '{' || first === '[', `${commandLabel}: stdout must start with JSON token`);
   return JSON.parse(trimmed);
+}
+
+function readMockLog(pathName: string): any {
+  return JSON.parse(readFileSync(pathName, 'utf8'));
 }
 
 test('json mode emits pure JSON suitable for jq parsing', () => {
@@ -283,6 +287,151 @@ test('issues commands including relationships succeed', () => {
 
     result = runCli(ctx, ['issues', 'saved', 'remove', '--name', 'default']);
     assertOk(result, 'issues saved remove');
+  } finally {
+    cleanupContext(ctx);
+  }
+});
+
+test('issues list shapes raw GraphQL requests from requested fields', () => {
+  const ctx = createContext();
+  ensureLtuiDefaults(ctx);
+  try {
+    const scalarLog = path.join(ctx.baseDir, 'scalar-log.json');
+    let result = runCli(
+      ctx,
+      ['--format', 'json', '--fields', 'id,identifier,title', 'issues', 'list', '--team', 'ENG'],
+      { LTUI_MOCK_REQUEST_LOG: scalarLog }
+    );
+    const scalarJson = expectPureJsonOutput(result, 'issues list scalar raw graphql') as {
+      rows: Array<Record<string, string>>;
+    };
+    assert.deepEqual(Object.keys(scalarJson.rows[0]).sort(), ['id', 'identifier', 'title']);
+    const scalarRequests = readMockLog(scalarLog);
+    assert.equal(scalarRequests.counts.rawRequests, 1);
+    assert.equal(scalarRequests.counts.issue, 0);
+    assert.equal(scalarRequests.counts.team, 0);
+    assert.equal(scalarRequests.counts.state, 0);
+    assert.equal(scalarRequests.counts.project, 0);
+    assert.equal(scalarRequests.counts.assignee, 0);
+    assert.equal(scalarRequests.counts.labels, 0);
+    assert.ok(!scalarRequests.rawRequests[0].query.includes('labels('));
+    assert.ok(!scalarRequests.rawRequests[0].query.includes('team {'));
+
+    const labelLog = path.join(ctx.baseDir, 'label-log.json');
+    result = runCli(ctx, ['--format', 'json', '--fields', 'labels', 'issues', 'list', '--team', 'ENG'], {
+      LTUI_MOCK_REQUEST_LOG: labelLog,
+    });
+    const labelJson = expectPureJsonOutput(result, 'issues list labels raw graphql') as {
+      rows: Array<Record<string, string>>;
+    };
+    assert.deepEqual(Object.keys(labelJson.rows[0]), ['labels']);
+    assert.ok(readMockLog(labelLog).rawRequests[0].query.includes('labels(first: 25)'));
+
+    const searchLog = path.join(ctx.baseDir, 'search-log.json');
+    result = runCli(
+      ctx,
+      ['--format', 'json', '--fields', 'identifier,title', '--limit', '5', 'issues', 'list', '--search', 'Fix'],
+      { LTUI_MOCK_REQUEST_LOG: searchLog }
+    );
+    expectPureJsonOutput(result, 'issues search raw graphql');
+    const searchRequests = readMockLog(searchLog);
+    assert.equal(searchRequests.counts.rawRequests, 1);
+    assert.equal(searchRequests.counts.issue, 0);
+    assert.ok(searchRequests.rawRequests[0].query.includes('searchIssues'));
+
+    result = runCli(ctx, ['--format', 'json', '--fields', 'notAField', 'issues', 'list']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /ERROR: validation_error Unknown field\(s\): notAField/);
+  } finally {
+    cleanupContext(ctx);
+  }
+});
+
+test('issues list exposes raw GraphQL rate-limit metadata when requested', () => {
+  const ctx = createContext();
+  ensureLtuiDefaults(ctx);
+  try {
+    let result = runCli(ctx, ['--format', 'json', '--show-rate-limit', '--fields', 'id,identifier,title', 'issues', 'list']);
+    const json = expectPureJsonOutput(result, 'issues list json rate limit') as any;
+    assert.equal(json.meta.rateLimit.requests.limit, '2500');
+    assert.equal(json.meta.rateLimit.requests.remaining, '2499');
+    assert.equal(json.meta.rateLimit.complexity.remaining, '2999000');
+
+    result = runCli(ctx, ['--show-rate-limit', '--fields', 'id,identifier,title', 'issues', 'list']);
+    assertOk(result, 'issues list tsv rate limit');
+    assert.match(result.stderr, /^RATE_LIMIT requestsLimit=2500 requestsRemaining=2499 requestsReset=1714852800 complexityLimit=3000000 complexityRemaining=2999000/m);
+
+    result = runCli(ctx, ['--show-rate-limit', 'issues', 'list'], {
+      LTUI_MOCK_RAW_RATE_LIMIT: '1',
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /ERROR: api_error rate_limited/);
+    assert.match(result.stderr, /requestsRemaining=0/);
+    assert.match(result.stderr, /wait until reset before retrying/);
+  } finally {
+    cleanupContext(ctx);
+  }
+});
+
+test('issues list supports repeatable state filters and cheap issue views', () => {
+  const ctx = createContext();
+  ensureLtuiDefaults(ctx);
+  try {
+    const stateLog = path.join(ctx.baseDir, 'state-log.json');
+    let result = runCli(
+      ctx,
+      [
+        '--format',
+        'json',
+        '--fields',
+        'identifier,title,state',
+        'issues',
+        'list',
+        '--state',
+        'Todo',
+        '--state',
+        'In Progress',
+      ],
+      { LTUI_MOCK_REQUEST_LOG: stateLog }
+    );
+    const list = expectPureJsonOutput(result, 'issues list repeatable state') as {
+      rows: Array<Record<string, string>>;
+    };
+    assert.ok(list.rows.length >= 1);
+    const stateRequest = readMockLog(stateLog).rawRequests[0];
+    assert.deepEqual(stateRequest.variables.filter.state.or, [
+      { name: { eq: 'Todo' } },
+      { name: { eq: 'In Progress' } },
+    ]);
+
+    const cheapViewLog = path.join(ctx.baseDir, 'cheap-view-log.json');
+    result = runCli(
+      ctx,
+      [
+        '--format',
+        'json',
+        '--fields',
+        'identifier,title,state,url',
+        'issues',
+        'view',
+        'ENG-1',
+        '--no-attachment-probe',
+      ],
+      { LTUI_MOCK_REQUEST_LOG: cheapViewLog }
+    );
+    const cheapView = expectPureJsonOutput(result, 'issues view no attachment probe') as Record<string, unknown>;
+    assert.deepEqual(Object.keys(cheapView).sort(), ['identifier', 'state', 'title', 'url']);
+    const cheapCounts = readMockLog(cheapViewLog).counts;
+    assert.equal(cheapCounts.attachments, 0);
+    assert.equal(cheapCounts.comments, 0);
+
+    const normalViewLog = path.join(ctx.baseDir, 'normal-view-log.json');
+    result = runCli(ctx, ['--format', 'json', 'issues', 'view', 'ENG-1'], {
+      LTUI_MOCK_REQUEST_LOG: normalViewLog,
+    });
+    expectPureJsonOutput(result, 'issues view default attachment probe');
+    const normalCounts = readMockLog(normalViewLog).counts;
+    assert.ok(normalCounts.attachments > 0);
   } finally {
     cleanupContext(ctx);
   }

--- a/tools/ltui/src/__tests__/cli-regression.test.ts
+++ b/tools/ltui/src/__tests__/cli-regression.test.ts
@@ -429,9 +429,22 @@ test('issues list supports repeatable state filters and cheap issue views', () =
     result = runCli(ctx, ['--format', 'json', 'issues', 'view', 'ENG-1'], {
       LTUI_MOCK_REQUEST_LOG: normalViewLog,
     });
-    expectPureJsonOutput(result, 'issues view default attachment probe');
+    const normalView = expectPureJsonOutput(result, 'issues view default attachment probe') as Record<string, unknown>;
+    assert.equal(normalView.imageAttachmentsFetchCmd, 'ltui --format json issues attachments ENG-1 --only-images');
     const normalCounts = readMockLog(normalViewLog).counts;
     assert.ok(normalCounts.attachments > 0);
+
+    const contextViewLog = path.join(ctx.baseDir, 'context-view-log.json');
+    result = runCli(
+      ctx,
+      ['issues', 'view', 'ENG-1', '--no-attachment-probe', '--include-comments', '--include-history'],
+      { LTUI_MOCK_REQUEST_LOG: contextViewLog }
+    );
+    assertOk(result, 'issues view comments and history request counts');
+    const contextCounts = readMockLog(contextViewLog).counts;
+    assert.equal(contextCounts.attachments, 0);
+    assert.equal(contextCounts.comments, 1);
+    assert.equal(contextCounts.history, 1);
   } finally {
     cleanupContext(ctx);
   }
@@ -525,8 +538,39 @@ test('documents, roadmaps, milestones, and notifications', () => {
     result = runCli(ctx, ['milestones', 'view', 'milestone-1']);
     assertOk(result, 'milestones view');
 
-    result = runCli(ctx, ['notifications', '--unread-only']);
+    result = runCli(ctx, [
+      '--format',
+      'json',
+      '--fields',
+      'id,type,read,createdAt',
+      '--limit',
+      '1',
+      'notifications',
+      '--unread-only',
+    ]);
     assertOk(result, 'notifications');
+    const notifications = JSON.parse(result.stdout);
+    assert.equal(notifications.rows.length, 1);
+    assert.equal(notifications.rows[0].id, 'notif-2');
+    assert.equal(notifications.rows[0].read, 'false');
+    assert.equal(notifications.rows[0].createdAt, '2024-02-02T00:00:00Z');
+    const notificationCursor = notifications.meta.cursorNext;
+
+    result = runCli(ctx, [
+      '--format',
+      'json',
+      '--limit',
+      '1',
+      '--cursor',
+      notificationCursor,
+      'notifications',
+      '--unread-only',
+    ]);
+    assertOk(result, 'notifications unread pagination');
+    const nextNotifications = JSON.parse(result.stdout);
+    assert.equal(nextNotifications.rows.length, 1);
+    assert.equal(nextNotifications.rows[0].id, 'notif-3');
+    assert.equal(nextNotifications.meta.cursorNext, '');
   } finally {
     cleanupContext(ctx);
   }

--- a/tools/ltui/src/__tests__/output.test.ts
+++ b/tools/ltui/src/__tests__/output.test.ts
@@ -7,6 +7,8 @@ import {
   emitPaginationMeta,
   truncateMultiline,
 } from '../format.js';
+import { extractRateLimitInfo, formatRateLimitLine } from '../rateLimit.js';
+import { createMockLinearClient } from '../test-utils/mockLinearClient.js';
 
 test('auth command emits deterministic list and detail formats', () => {
   const lines = ['id\tworkspace\thasKey', 'default\tworkspace-a\ttrue'];
@@ -179,4 +181,54 @@ test('paginated JSON output is JSON-only envelope', () => {
   const out = renderPaginatedList(rows, columns, { next: 'after', prev: 'before', count: 1 }, { format: 'json' });
   assert.equal(out, '{"meta":{"cursorNext":"after","cursorPrev":"before","count":1},"rows":[{"id":"123"}]}');
   assert.ok(!out.includes('CURSOR_NEXT'));
+});
+
+test('paginated JSON can include rate-limit metadata', () => {
+  const columns = [{ key: 'id', header: 'id', value: (row: any) => row.id }];
+  const rows = [{ id: '123' }];
+  const rateLimit = {
+    requests: { limit: '2500', remaining: '2499', reset: '1714852800' },
+    complexity: { limit: '3000000', remaining: '2999000' },
+  };
+  const out = renderPaginatedList(
+    rows,
+    columns,
+    { next: null, prev: null, count: 1, rateLimit },
+    { format: 'json' }
+  );
+  assert.deepEqual(JSON.parse(out), {
+    meta: {
+      cursorNext: '',
+      cursorPrev: '',
+      count: 1,
+      rateLimit,
+    },
+    rows: [{ id: '123' }],
+  });
+  assert.equal(
+    formatRateLimitLine(rateLimit),
+    'RATE_LIMIT requestsLimit=2500 requestsRemaining=2499 requestsReset=1714852800 complexityLimit=3000000 complexityRemaining=2999000'
+  );
+});
+
+test('mock Linear client records request-shape counters and rate-limit headers', async () => {
+  const client = createMockLinearClient({} as any);
+  const issue = await client.issue('ENG-1');
+  await issue.team;
+  await issue.state;
+  await issue.project;
+  await issue.assignee;
+  await issue.labels();
+  assert.equal(client.__ltuiRequestCounts.issue, 1);
+  assert.equal(client.__ltuiRequestCounts.team, 1);
+  assert.equal(client.__ltuiRequestCounts.state, 1);
+  assert.equal(client.__ltuiRequestCounts.project, 1);
+  assert.equal(client.__ltuiRequestCounts.assignee, 1);
+  assert.equal(client.__ltuiRequestCounts.labels, 1);
+
+  const response = await client.client.rawRequest('query { issues { nodes { id } } }', { first: 1 });
+  const rateLimit = extractRateLimitInfo(response.headers);
+  assert.equal(client.__ltuiRequestCounts.rawRequests, 1);
+  assert.equal(rateLimit?.requests.limit, '2500');
+  assert.equal(rateLimit?.complexity.remaining, '2999000');
 });

--- a/tools/ltui/src/cli.ts
+++ b/tools/ltui/src/cli.ts
@@ -23,6 +23,7 @@ export async function main(argv: string[] = process.argv.slice(2)) {
     .option('--fields <fields>', 'comma-separated list of fields')
     .option('--limit <n>', 'limit item count', (value: string) => parseInt(value, 10))
     .option('--cursor <cursor>', 'pagination cursor')
+    .option('--show-rate-limit', 'emit Linear rate-limit metadata when available')
     .option('--agent', 'enable agent mode', true)
     .option('--no-agent', 'disable agent mode');
   program.enablePositionalOptions();

--- a/tools/ltui/src/commands/issues.ts
+++ b/tools/ltui/src/commands/issues.ts
@@ -20,6 +20,7 @@ import {
   findProjectByKeyOrId,
   findTeamByKeyOrId,
   findWorkflowStateByNameOrId,
+  executeRawGraphQL,
   parseLinearError,
   readTextOrPath,
   resolveAssigneeId,
@@ -28,6 +29,7 @@ import {
   isUuid,
 } from '../linear.js';
 import { getSavedQuery, listSavedQueries, removeQuery, saveQuery, SavedQueryDefinition } from '../queries.js';
+import { extractRateLimitInfo, formatRateLimitLine, RateLimitInfo } from '../rateLimit.js';
 
 interface IssueListRow {
   id: string;
@@ -59,7 +61,7 @@ interface IssueAssetRow {
 interface IssueListCommandOptions {
   team?: string;
   project?: string;
-  state?: string;
+  state?: string | string[];
   assignee?: string;
   label?: string[];
   search?: string;
@@ -67,6 +69,47 @@ interface IssueListCommandOptions {
   updatedSince?: string;
   createdSince?: string;
 }
+
+type IssueListField = keyof IssueListRow;
+
+const ISSUE_LIST_FIELD_ORDER: IssueListField[] = [
+  'id',
+  'key',
+  'identifier',
+  'title',
+  'state',
+  'priority',
+  'assignee',
+  'labels',
+  'project',
+  'updatedAt',
+];
+
+const ISSUE_LIST_COLUMNS: ColumnDefinition<IssueListRow>[] = [
+  { key: 'id', header: 'id', value: row => row.id },
+  { key: 'key', header: 'key', value: row => row.key },
+  { key: 'identifier', header: 'identifier', value: row => row.identifier },
+  { key: 'title', header: 'title', value: row => row.title },
+  { key: 'state', header: 'state', value: row => row.state },
+  { key: 'priority', header: 'priority', value: row => row.priority },
+  { key: 'assignee', header: 'assignee', value: row => row.assignee },
+  { key: 'labels', header: 'labels', value: row => row.labels },
+  { key: 'project', header: 'project', value: row => row.project },
+  { key: 'updatedAt', header: 'updatedAt', value: row => row.updatedAt },
+];
+
+const ISSUE_LIST_SELECTIONS: Record<IssueListField, string[]> = {
+  id: ['id'],
+  key: ['team { key }'],
+  identifier: ['identifier'],
+  title: ['title'],
+  state: ['state { name }'],
+  priority: ['priority'],
+  assignee: ['assignee { name }'],
+  labels: ['labels(first: 25) { nodes { name } }'],
+  project: ['project { name }'],
+  updatedAt: ['updatedAt'],
+};
 
 export function runIssuesCommands(program: Command): void {
   const issues = program.command('issues').description('Issue operations');
@@ -76,7 +119,7 @@ export function runIssuesCommands(program: Command): void {
     .description('List issues')
     .option('--team <key-or-id>', 'Team key or id')
     .option('--project <key-or-id>', 'Project key or id')
-    .option('--state <name-or-id>', 'State name or id')
+    .option('--state <name-or-id>', 'State name or id', collect)
     .option('--assignee <me|email|id>', 'Assignee')
     .option('--label <name-or-id>', 'Label', collect, [])
     .option('--search <query>', 'Search query')
@@ -91,44 +134,20 @@ export function runIssuesCommands(program: Command): void {
 
         const effectiveOptions = mergeSavedQueryOptions(options);
         const filter = await buildIssueFilter(effectiveOptions);
-        const params: Record<string, unknown> = {
-          first: globalOpts.limit,
-          after: globalOpts.cursor,
-          filter,
-          sort: { updatedAt: { order: 'Descending' } },
-        };
-
-        const data = effectiveOptions.search
-          ? await client.searchIssues(effectiveOptions.search, params)
-          : await client.issues(params);
-
-        const issueNodes = effectiveOptions.search
-          ? await Promise.all(data.nodes.map((node: any) => client.issue(node.id)))
-          : data.nodes;
-
-        const rows: IssueListRow[] = await Promise.all(
-          issueNodes.map((node: any) => mapIssueToRow(node))
-        );
-        const columns: ColumnDefinition<IssueListRow>[] = [
-          { key: 'id', header: 'id', value: row => row.id },
-          { key: 'key', header: 'key', value: row => row.key },
-          { key: 'identifier', header: 'identifier', value: row => row.identifier },
-          { key: 'title', header: 'title', value: row => row.title },
-          { key: 'state', header: 'state', value: row => row.state },
-          { key: 'priority', header: 'priority', value: row => row.priority },
-          { key: 'assignee', header: 'assignee', value: row => row.assignee },
-          { key: 'labels', header: 'labels', value: row => row.labels },
-          { key: 'project', header: 'project', value: row => row.project },
-          { key: 'updatedAt', header: 'updatedAt', value: row => row.updatedAt },
-        ];
+        const data = await fetchIssueListRows(client, effectiveOptions, {
+          fields: globalOpts.fields,
+          limit: globalOpts.limit,
+          cursor: globalOpts.cursor,
+        });
 
         const out = renderPaginatedList(
-          rows,
-          columns,
+          data.rows,
+          ISSUE_LIST_COLUMNS,
           {
             next: data.pageInfo?.endCursor ?? null,
             prev: data.pageInfo?.startCursor ?? null,
-            count: rows.length,
+            count: data.rows.length,
+            rateLimit: globalOpts.showRateLimit ? data.rateLimit : undefined,
           },
           {
             format: globalOpts.format,
@@ -136,6 +155,9 @@ export function runIssuesCommands(program: Command): void {
           }
         );
         process.stdout.write(out + '\n');
+        if (globalOpts.showRateLimit && globalOpts.format !== 'json' && data.rateLimit) {
+          process.stderr.write(formatRateLimitLine(data.rateLimit) + '\n');
+        }
       } catch (error) {
         writeError(error);
       }
@@ -252,6 +274,7 @@ export function runIssuesCommands(program: Command): void {
     .argument('<id>', 'Issue id or key')
     .option('--include-comments', 'Include comments')
     .option('--include-history', 'Include history')
+    .option('--no-attachment-probe', 'Skip default attachment/comment scan for image guidance')
     .option('--max-description-chars <n>', 'Max description chars', parseNumber, 4000)
     .option('--max-comment-chars <n>', 'Max comment chars', parseNumber, 500)
     .action(async (ref: string, options) => {
@@ -291,13 +314,18 @@ export function runIssuesCommands(program: Command): void {
           UPDATED_AT: issue.updatedAt?.toISOString?.() ?? '',
         };
 
-        const probe = await probeIssueAssets(issue);
-        fields.ATTACHMENTS_PRESENT = probe.attachmentsPresent ? 'true' : 'false';
-        fields.IMAGE_ATTACHMENTS_PRESENT = probe.imageAttachmentsPresent ? 'true' : 'false';
-        if (probe.imageAttachmentsPresent) {
-          const issueRef = issue.identifier ?? ref;
-          fields.IMAGE_ATTACHMENTS_FETCH_CMD = `ltui issues attachments ${issueRef} --only-images --format json`;
-          fields.IMAGE_ATTACHMENTS_DOWNLOAD_CMD = `ltui issues attachments ${issueRef} --only-images --download-dir ./.ltui-attachments/${issueRef}`;
+        const probe =
+          options.attachmentProbe === false
+            ? null
+            : await probeIssueAssets(issue);
+        if (probe) {
+          fields.ATTACHMENTS_PRESENT = probe.attachmentsPresent ? 'true' : 'false';
+          fields.IMAGE_ATTACHMENTS_PRESENT = probe.imageAttachmentsPresent ? 'true' : 'false';
+          if (probe.imageAttachmentsPresent) {
+            const issueRef = issue.identifier ?? ref;
+            fields.IMAGE_ATTACHMENTS_FETCH_CMD = `ltui issues attachments ${issueRef} --only-images --format json`;
+            fields.IMAGE_ATTACHMENTS_DOWNLOAD_CMD = `ltui issues attachments ${issueRef} --only-images --download-dir ./.ltui-attachments/${issueRef}`;
+          }
         }
 
         const jsonPayload: Record<string, unknown> = {
@@ -314,19 +342,21 @@ export function runIssuesCommands(program: Command): void {
           labels: extractLabelNames(issue),
           createdAt: issue.createdAt?.toISOString?.() ?? '',
           updatedAt: issue.updatedAt?.toISOString?.() ?? '',
-          attachmentsPresent: probe.attachmentsPresent,
-          imageAttachmentsPresent: probe.imageAttachmentsPresent,
-          imageAttachmentsFetchCmd: probe.imageAttachmentsPresent
-            ? fields.IMAGE_ATTACHMENTS_FETCH_CMD
-            : '',
-          imageAttachmentsDownloadCmd: probe.imageAttachmentsPresent
-            ? fields.IMAGE_ATTACHMENTS_DOWNLOAD_CMD
-            : '',
           description: {
             text: descriptionInfo.text,
             truncated: descriptionInfo.truncated,
           },
         };
+        if (probe) {
+          jsonPayload.attachmentsPresent = probe.attachmentsPresent;
+          jsonPayload.imageAttachmentsPresent = probe.imageAttachmentsPresent;
+          jsonPayload.imageAttachmentsFetchCmd = probe.imageAttachmentsPresent
+            ? fields.IMAGE_ATTACHMENTS_FETCH_CMD
+            : '';
+          jsonPayload.imageAttachmentsDownloadCmd = probe.imageAttachmentsPresent
+            ? fields.IMAGE_ATTACHMENTS_DOWNLOAD_CMD
+            : '';
+        }
 
         if (options.includeComments) {
           const comments = await issue.comments({ first: 50 });
@@ -1029,17 +1059,104 @@ function mergeSavedQueryOptions(options: IssueListCommandOptions): IssueListComm
     throw new Error(`not_found Saved query '${options.saved}' not found`);
   }
   const labelValues = options.label && options.label.length > 0 ? options.label : saved.labels ?? [];
+  const stateValues = Array.isArray(options.state) && options.state.length === 0 ? undefined : options.state;
   return {
     ...options,
     team: options.team ?? saved.team,
     project: options.project ?? saved.project,
-    state: options.state ?? saved.state,
+    state: stateValues ?? saved.state,
     assignee: options.assignee ?? saved.assignee,
     label: labelValues,
     search: options.search ?? saved.search,
     updatedSince: options.updatedSince ?? saved.updatedSince,
     createdSince: options.createdSince ?? saved.createdSince,
   };
+}
+
+async function fetchIssueListRows(
+  client: any,
+  options: IssueListCommandOptions,
+  queryOptions: { fields?: string[]; limit: number; cursor: string | null }
+): Promise<{ rows: IssueListRow[]; pageInfo: any; rateLimit?: RateLimitInfo }> {
+  const selectedFields = selectIssueListFields(queryOptions.fields);
+  const selection = buildIssueListSelection(selectedFields);
+  const isSearch = !!options.search;
+  const query = isSearch ? buildIssueSearchQuery(selection) : buildIssueListQuery(selection);
+  const variables: Record<string, unknown> = {
+    first: queryOptions.limit,
+    after: queryOptions.cursor,
+    filter: await buildIssueFilter(options),
+  };
+  if (isSearch) {
+    variables.term = options.search;
+  } else {
+    variables.sort = [{ updatedAt: { order: 'Descending' } }];
+  }
+
+  const response = await executeRawGraphQL(client, query, variables);
+  const connection = isSearch ? response.data?.searchIssues : response.data?.issues;
+  const nodes = connection?.nodes ?? [];
+  return {
+    rows: nodes.map(mapRawIssueToRow),
+    pageInfo: connection?.pageInfo ?? {},
+    rateLimit: extractRateLimitInfo(response.headers),
+  };
+}
+
+function selectIssueListFields(fields?: string[]): IssueListField[] {
+  const selected = fields && fields.length > 0 ? fields : ISSUE_LIST_FIELD_ORDER;
+  const available = new Set<string>(ISSUE_LIST_FIELD_ORDER);
+  const missing = selected.filter(field => !available.has(field));
+  if (missing.length > 0) {
+    throw new Error(`validation_error Unknown field(s): ${missing.join(', ')}`);
+  }
+  return selected as IssueListField[];
+}
+
+function buildIssueListSelection(fields: IssueListField[]): string {
+  const selections = new Set<string>();
+  for (const field of fields) {
+    for (const selection of ISSUE_LIST_SELECTIONS[field]) {
+      selections.add(selection);
+    }
+  }
+  return Array.from(selections).join('\n');
+}
+
+function buildIssueListQuery(selection: string): string {
+  return `
+    query LtuiIssueList($first: Int, $after: String, $filter: IssueFilter, $sort: [IssueSortInput!]) {
+      issues(first: $first, after: $after, filter: $filter, sort: $sort) {
+        nodes {
+          ${selection}
+        }
+        pageInfo {
+          endCursor
+          startCursor
+          hasNextPage
+          hasPreviousPage
+        }
+      }
+    }
+  `;
+}
+
+function buildIssueSearchQuery(selection: string): string {
+  return `
+    query LtuiIssueSearch($term: String!, $first: Int, $after: String, $filter: IssueFilter) {
+      searchIssues(term: $term, first: $first, after: $after, filter: $filter) {
+        nodes {
+          ${selection}
+        }
+        pageInfo {
+          endCursor
+          startCursor
+          hasNextPage
+          hasPreviousPage
+        }
+      }
+    }
+  `;
 }
 
 async function buildIssueFilter(options: Record<string, any>): Promise<Record<string, unknown>> {
@@ -1069,11 +1186,19 @@ async function buildIssueFilter(options: Record<string, any>): Promise<Record<st
     filter.project = { or: projectFilters };
   }
 
-  if (options.state) {
-    const stateValue = String(options.state);
-    const stateFilters: any[] = [{ name: { eq: stateValue } }];
-    if (isUuid(stateValue)) {
-      stateFilters.unshift({ id: { eq: stateValue } });
+  const stateValues = Array.isArray(options.state)
+    ? options.state
+    : options.state
+      ? [String(options.state)]
+      : [];
+  if (stateValues.length > 0) {
+    const stateFilters: any[] = [];
+    for (const stateValue of stateValues) {
+      if (isUuid(stateValue)) {
+        stateFilters.push({ id: { eq: stateValue } });
+      } else {
+        stateFilters.push({ name: { eq: stateValue } });
+      }
     }
     filter.state = { or: stateFilters };
   }
@@ -1139,6 +1264,28 @@ async function mapIssueToRow(issue: any): Promise<IssueListRow> {
     assignee: assignee?.name ?? '-',
     labels: labelNames.join(','),
     project: project?.name ?? '-',
+    updatedAt,
+  };
+}
+
+function mapRawIssueToRow(issue: any): IssueListRow {
+  const labels = Array.isArray(issue.labels?.nodes)
+    ? issue.labels.nodes.map((label: any) => label.name).filter(Boolean)
+    : [];
+  const updatedAt =
+    typeof issue.updatedAt?.toISOString === 'function'
+      ? issue.updatedAt.toISOString()
+      : issue.updatedAt ?? '';
+  return {
+    id: issue.id ?? '',
+    key: issue.team?.key ?? '',
+    identifier: issue.identifier ?? '',
+    title: sanitizeSingleLine(issue.title ?? ''),
+    state: issue.state?.name ?? '',
+    priority: issue.priority?.toString() ?? '',
+    assignee: issue.assignee?.name ?? '-',
+    labels: labels.join(','),
+    project: issue.project?.name ?? '-',
     updatedAt,
   };
 }
@@ -1810,7 +1957,7 @@ function parseNumber(value: string): number {
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
-function collect(value: string, previous: string[]): string[] {
+function collect(value: string, previous: string[] = []): string[] {
   return [...previous, value];
 }
 

--- a/tools/ltui/src/commands/issues.ts
+++ b/tools/ltui/src/commands/issues.ts
@@ -323,7 +323,7 @@ export function runIssuesCommands(program: Command): void {
           fields.IMAGE_ATTACHMENTS_PRESENT = probe.imageAttachmentsPresent ? 'true' : 'false';
           if (probe.imageAttachmentsPresent) {
             const issueRef = issue.identifier ?? ref;
-            fields.IMAGE_ATTACHMENTS_FETCH_CMD = `ltui issues attachments ${issueRef} --only-images --format json`;
+            fields.IMAGE_ATTACHMENTS_FETCH_CMD = `ltui --format json issues attachments ${issueRef} --only-images`;
             fields.IMAGE_ATTACHMENTS_DOWNLOAD_CMD = `ltui issues attachments ${issueRef} --only-images --download-dir ./.ltui-attachments/${issueRef}`;
           }
         }
@@ -358,9 +358,11 @@ export function runIssuesCommands(program: Command): void {
             : '';
         }
 
+        let comments: any[] = [];
         if (options.includeComments) {
-          const comments = await issue.comments({ first: 50 });
-          jsonPayload.comments = comments.nodes.map((comment: any) => {
+          const commentsConnection = await issue.comments({ first: 50 });
+          comments = commentsConnection.nodes ?? [];
+          jsonPayload.comments = comments.map((comment: any) => {
             const truncated = truncateMultiline(comment.body ?? '', options.maxCommentChars);
             return {
               id: comment.id ?? '',
@@ -372,12 +374,14 @@ export function runIssuesCommands(program: Command): void {
           });
         }
 
+        let historyEntries: any[] = [];
         if (options.includeHistory) {
           const historyConnection = await issue.history({
             first: 50,
             sort: { createdAt: { order: 'Ascending' } },
           });
-          jsonPayload.history = historyConnection.nodes.map((entry: any) => {
+          historyEntries = historyConnection.nodes ?? [];
+          jsonPayload.history = historyEntries.map((entry: any) => {
             const actor = entry.actor?.name ?? entry.actorId ?? '';
             return {
               createdAt: entry.createdAt?.toISOString?.() ?? '',
@@ -408,9 +412,8 @@ export function runIssuesCommands(program: Command): void {
         }
 
         if (options.includeComments) {
-          const comments = await issue.comments({ first: 50 });
           const lines: string[] = ['COMMENTS_START'];
-          for (const comment of comments.nodes) {
+          for (const comment of comments) {
             const truncated = truncateMultiline(comment.body ?? '', options.maxCommentChars);
             const row = [
               comment.id,
@@ -428,12 +431,8 @@ export function runIssuesCommands(program: Command): void {
         }
 
         if (options.includeHistory) {
-          const historyConnection = await issue.history({
-            first: 50,
-            sort: { createdAt: { order: 'Ascending' } },
-          });
           const lines: string[] = ['HISTORY_START'];
-          for (const entry of historyConnection.nodes) {
+          for (const entry of historyEntries) {
             const actor = entry.actor?.name ?? entry.actorId ?? '';
             const changeType = determineHistoryType(entry);
             const fromValue = historyFromValue(entry);

--- a/tools/ltui/src/commands/notifications.ts
+++ b/tools/ltui/src/commands/notifications.ts
@@ -6,8 +6,8 @@ import {
   emitError,
   renderPaginatedList,
 } from '../format.js';
-import { getGlobalOptions } from '../options.js';
-import { parseLinearError } from '../linear.js';
+import { getGlobalOptions, type GlobalOptions } from '../options.js';
+import { executeRawGraphQL, parseLinearError } from '../linear.js';
 
 interface NotificationRow {
   id: string;
@@ -27,22 +27,13 @@ export function runNotificationsCommands(program: Command): void {
         const resolved = resolveConfig(program.opts<{ profile?: string }>().profile);
         const client = createLinearClient(resolved);
 
-        const filter: Record<string, unknown> = {};
-        if (options.unreadOnly) {
-          filter.readAt = { isNull: true };
-        }
-
-        const data = await client.notifications({
-          first: globalOpts.limit,
-          after: globalOpts.cursor,
-          filter,
-        });
+        const data = await fetchNotifications(client, globalOpts, options.unreadOnly === true);
 
         const rows: NotificationRow[] = data.nodes.map((notification: any) => ({
           id: notification.id ?? '',
           type: notification.type ?? '',
           read: notification.readAt ? 'true' : 'false',
-          createdAt: notification.createdAt?.toISOString?.() ?? '',
+          createdAt: formatDateTime(notification.createdAt),
         }));
 
         const columns: ColumnDefinition<NotificationRow>[] = [
@@ -70,4 +61,95 @@ export function runNotificationsCommands(program: Command): void {
         process.exitCode = 1;
       }
     });
+}
+
+async function fetchNotifications(
+  client: any,
+  globalOpts: GlobalOptions,
+  unreadOnly: boolean
+): Promise<{ nodes: any[]; pageInfo: any }> {
+  if (!unreadOnly) {
+    return client.notifications({
+      first: globalOpts.limit,
+      after: globalOpts.cursor,
+    });
+  }
+
+  if (globalOpts.limit <= 0) {
+    return { nodes: [], pageInfo: { endCursor: null, startCursor: null } };
+  }
+
+  const nodes: any[] = [];
+  let cursor = globalOpts.cursor;
+  let pageInfo: any = {};
+  let firstReturnedCursor: string | null = null;
+  let lastReturnedCursor: string | null = null;
+  let nextCursor: string | null = null;
+  const batchSize = Math.max(globalOpts.limit, 25);
+
+  do {
+    const response = await executeRawGraphQL(client, buildNotificationsQuery(), {
+      first: batchSize,
+      after: cursor,
+    });
+    const page = response.data?.notifications ?? {};
+    pageInfo = page.pageInfo ?? {};
+
+    for (const edge of page.edges ?? []) {
+      const notification = edge.node;
+      if (notification?.readAt) {
+        continue;
+      }
+      if (nodes.length < globalOpts.limit) {
+        firstReturnedCursor ??= edge.cursor ?? null;
+        lastReturnedCursor = edge.cursor ?? lastReturnedCursor;
+        nodes.push(notification);
+      } else {
+        nextCursor = lastReturnedCursor;
+        break;
+      }
+    }
+    cursor = pageInfo.endCursor ?? null;
+  } while (!nextCursor && pageInfo.hasNextPage && cursor);
+
+  return {
+    nodes,
+    pageInfo: {
+      ...pageInfo,
+      endCursor: nextCursor,
+      startCursor: firstReturnedCursor,
+    },
+  };
+}
+
+function buildNotificationsQuery(): string {
+  return `
+    query LtuiNotifications($first: Int, $after: String) {
+      notifications(first: $first, after: $after) {
+        edges {
+          cursor
+          node {
+            id
+            type
+            readAt
+            createdAt
+          }
+        }
+        pageInfo {
+          endCursor
+          startCursor
+          hasNextPage
+          hasPreviousPage
+        }
+      }
+    }
+  `;
+}
+
+function formatDateTime(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value && typeof (value as { toISOString?: unknown }).toISOString === 'function') {
+    return (value as { toISOString: () => string }).toISOString();
+  }
+  return '';
 }

--- a/tools/ltui/src/format.ts
+++ b/tools/ltui/src/format.ts
@@ -1,3 +1,5 @@
+import type { RateLimitInfo } from './rateLimit.js';
+
 export type OutputFormat = 'tsv' | 'table' | 'detail' | 'json';
 
 export interface AgentOutputOptions {
@@ -9,6 +11,7 @@ export interface PaginationMeta {
   cursorNext: string;
   cursorPrev: string;
   count: number;
+  rateLimit?: RateLimitInfo;
 }
 
 export interface ColumnDefinition<T> {
@@ -36,7 +39,7 @@ export function emitPaginationMeta(next: string | null, prev: string | null, cou
 export function renderPaginatedList<T>(
   rows: T[],
   columns: ColumnDefinition<T>[],
-  meta: { next: string | null; prev: string | null; count: number },
+  meta: { next: string | null; prev: string | null; count: number; rateLimit?: RateLimitInfo },
   options: AgentOutputOptions & { allowedFormats?: OutputFormat[] }
 ): string {
   const allowedFormats = options.allowedFormats ?? ['tsv', 'table', 'json'];
@@ -58,6 +61,7 @@ export function renderPaginatedList<T>(
         cursorNext: meta.next ?? '',
         cursorPrev: meta.prev ?? '',
         count: meta.count,
+        ...(meta.rateLimit ? { rateLimit: meta.rateLimit } : {}),
       },
       rows: jsonRows,
     };

--- a/tools/ltui/src/linear.ts
+++ b/tools/ltui/src/linear.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { getCachedValue, setCachedValue } from './cache.js';
+import { extractRateLimitInfoFromError, formatRateLimitBackoffHint } from './rateLimit.js';
 
 const CACHE_TTL_SECONDS = 300;
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -283,10 +284,10 @@ export function parseLinearError(error: unknown): { code: string; message: strin
   const message = err?.message ?? 'Unknown error';
   const linearType = (error as { type?: string })?.type;
   if (linearType && String(linearType).toLowerCase().includes('rate')) {
-    return { code: 'api_error', message: 'rate_limited' };
+    return { code: 'api_error', message: rateLimitedMessage(error) };
   }
   if (/rate.?limit/i.test(message)) {
-    return { code: 'api_error', message: 'rate_limited' };
+    return { code: 'api_error', message: rateLimitedMessage(error) };
   }
   const parts = message.split(' ');
   if (parts.length > 1 && /^[a-z_]+$/i.test(parts[0])) {
@@ -294,4 +295,37 @@ export function parseLinearError(error: unknown): { code: string; message: strin
     return { code, message: parts.join(' ') };
   }
   return { code: 'api_error', message };
+}
+
+export async function executeRawGraphQL(
+  client: any,
+  query: string,
+  variables: Record<string, unknown>
+): Promise<{ data: any; headers?: Headers | Record<string, string> }> {
+  if (typeof client?.client?.rawRequest === 'function') {
+    const response = await client.client.rawRequest(query, variables);
+    if (response?.errors?.length || response?.error) {
+      const error = new Error(response.error ?? response.errors?.[0]?.message ?? 'GraphQL request failed') as Error & {
+        raw?: { response: typeof response };
+        response?: typeof response;
+        type?: string;
+      };
+      error.raw = { response };
+      error.response = response;
+      error.type = response.errors?.[0]?.extensions?.type;
+      throw error;
+    }
+    return { data: response?.data, headers: response?.headers };
+  }
+
+  if (typeof client?.client?.request === 'function') {
+    return { data: await client.client.request(query, variables) };
+  }
+
+  throw new Error('api_error Raw GraphQL request support is unavailable for this Linear client');
+}
+
+function rateLimitedMessage(error: unknown): string {
+  const hint = formatRateLimitBackoffHint(extractRateLimitInfoFromError(error));
+  return hint ? `rate_limited ${hint}` : 'rate_limited';
 }

--- a/tools/ltui/src/options.ts
+++ b/tools/ltui/src/options.ts
@@ -7,6 +7,7 @@ export interface GlobalOptions {
   limit: number;
   cursor: string | null;
   agentMode: boolean;
+  showRateLimit: boolean;
 }
 
 export function getGlobalOptions(program: Command): GlobalOptions {
@@ -16,6 +17,7 @@ export function getGlobalOptions(program: Command): GlobalOptions {
     limit?: number;
     cursor?: string;
     agent?: boolean;
+    showRateLimit?: boolean;
   }>();
 
   const format = (opts.format ?? 'tsv').toLowerCase() as OutputFormat;
@@ -29,6 +31,7 @@ export function getGlobalOptions(program: Command): GlobalOptions {
   const limit = typeof opts.limit === 'number' && !Number.isNaN(opts.limit) ? opts.limit : 20;
   const cursor = opts.cursor ?? null;
   const agentMode = opts.agent !== undefined ? opts.agent : true;
+  const showRateLimit = opts.showRateLimit === true;
 
   return {
     format,
@@ -36,5 +39,6 @@ export function getGlobalOptions(program: Command): GlobalOptions {
     limit,
     cursor,
     agentMode,
+    showRateLimit,
   };
 }

--- a/tools/ltui/src/rateLimit.ts
+++ b/tools/ltui/src/rateLimit.ts
@@ -1,0 +1,85 @@
+export interface RateLimitInfo {
+  requests: {
+    limit: string | null;
+    remaining: string | null;
+    reset: string | null;
+  };
+  complexity: {
+    limit: string | null;
+    remaining: string | null;
+  };
+}
+
+type HeadersLike = {
+  get?: (name: string) => string | null;
+};
+
+const HEADER_KEYS = {
+  requestsLimit: 'x-ratelimit-requests-limit',
+  requestsRemaining: 'x-ratelimit-requests-remaining',
+  requestsReset: 'x-ratelimit-requests-reset',
+  complexityLimit: 'x-ratelimit-complexity-limit',
+  complexityRemaining: 'x-ratelimit-complexity-remaining',
+};
+
+export function extractRateLimitInfo(headers: HeadersLike | Record<string, string> | undefined): RateLimitInfo | undefined {
+  if (!headers) return undefined;
+  const info: RateLimitInfo = {
+    requests: {
+      limit: headerValue(headers, HEADER_KEYS.requestsLimit),
+      remaining: headerValue(headers, HEADER_KEYS.requestsRemaining),
+      reset: headerValue(headers, HEADER_KEYS.requestsReset),
+    },
+    complexity: {
+      limit: headerValue(headers, HEADER_KEYS.complexityLimit),
+      remaining: headerValue(headers, HEADER_KEYS.complexityRemaining),
+    },
+  };
+  if (
+    info.requests.limit === null &&
+    info.requests.remaining === null &&
+    info.requests.reset === null &&
+    info.complexity.limit === null &&
+    info.complexity.remaining === null
+  ) {
+    return undefined;
+  }
+  return info;
+}
+
+export function extractRateLimitInfoFromError(error: unknown): RateLimitInfo | undefined {
+  const err = error as {
+    raw?: { response?: { headers?: HeadersLike | Record<string, string> } };
+    response?: { headers?: HeadersLike | Record<string, string> };
+  };
+  return extractRateLimitInfo(err?.raw?.response?.headers ?? err?.response?.headers);
+}
+
+export function formatRateLimitLine(info: RateLimitInfo): string {
+  return [
+    'RATE_LIMIT',
+    `requestsLimit=${info.requests.limit ?? ''}`,
+    `requestsRemaining=${info.requests.remaining ?? ''}`,
+    `requestsReset=${info.requests.reset ?? ''}`,
+    `complexityLimit=${info.complexity.limit ?? ''}`,
+    `complexityRemaining=${info.complexity.remaining ?? ''}`,
+  ].join(' ');
+}
+
+export function formatRateLimitBackoffHint(info: RateLimitInfo | undefined): string | undefined {
+  if (!info) return undefined;
+  const parts = [
+    `requestsRemaining=${info.requests.remaining ?? ''}`,
+    `requestsReset=${info.requests.reset ?? ''}`,
+    `complexityRemaining=${info.complexity.remaining ?? ''}`,
+  ];
+  return `${parts.join(' ')}; wait until reset before retrying, and retry with a smaller --limit or narrower filters.`;
+}
+
+function headerValue(headers: HeadersLike | Record<string, string>, name: string): string | null {
+  if (typeof (headers as HeadersLike).get === 'function') {
+    return (headers as HeadersLike).get?.(name) ?? null;
+  }
+  const record = headers as Record<string, string>;
+  return record[name] ?? record[name.toLowerCase()] ?? null;
+}

--- a/tools/ltui/src/test-utils/mockLinearClient.ts
+++ b/tools/ltui/src/test-utils/mockLinearClient.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import type { ResolvedConfig } from '../config.js';
 
 interface WorkflowState {
@@ -109,6 +110,50 @@ type PageInfo = {
   hasNextPage: boolean;
   hasPreviousPage: boolean;
 };
+
+interface MockRequestCounts {
+  rawRequests: number;
+  issues: number;
+  searchIssues: number;
+  issue: number;
+  team: number;
+  state: number;
+  project: number;
+  assignee: number;
+  labels: number;
+  attachments: number;
+  comments: number;
+  history: number;
+}
+
+const RATE_LIMIT_HEADERS: Record<string, string> = {
+  'x-ratelimit-requests-limit': '2500',
+  'x-ratelimit-requests-remaining': '2499',
+  'x-ratelimit-requests-reset': '1714852800',
+  'x-ratelimit-complexity-limit': '3000000',
+  'x-ratelimit-complexity-remaining': '2999000',
+};
+
+function createCounts(): MockRequestCounts {
+  return {
+    rawRequests: 0,
+    issues: 0,
+    searchIssues: 0,
+    issue: 0,
+    team: 0,
+    state: 0,
+    project: 0,
+    assignee: 0,
+    labels: 0,
+    attachments: 0,
+    comments: 0,
+    history: 0,
+  };
+}
+
+function makeHeaders(values: Record<string, string> = RATE_LIMIT_HEADERS): Headers {
+  return new Headers(values);
+}
 
 function parseCursor(cursor: string): number | null {
   const match = /^cursor:(\d+)$/.exec(cursor);
@@ -276,10 +321,34 @@ function buildData() {
 class MockLinearClient {
   private data: ReturnType<typeof buildData>;
   public viewer: any;
+  public client: any;
+  public __ltuiRequestCounts: MockRequestCounts;
+  public __ltuiRawRequests: Array<{ query: string; variables: Record<string, unknown> }>;
 
   constructor(data: ReturnType<typeof buildData>) {
     this.data = data;
+    this.__ltuiRequestCounts = createCounts();
+    this.__ltuiRawRequests = [];
     this.viewer = this.decorateUser(data.users[0]);
+    this.client = {
+      rawRequest: async (query: string, variables?: Record<string, unknown>) =>
+        this.rawRequest(query, variables ?? {}),
+    };
+
+    const logPath = process.env.LTUI_MOCK_REQUEST_LOG;
+    if (logPath) {
+      const writeLog = () => {
+        fs.writeFileSync(
+          logPath,
+          JSON.stringify({
+            counts: this.__ltuiRequestCounts,
+            rawRequests: this.__ltuiRawRequests,
+          })
+        );
+      };
+      process.on('beforeExit', writeLog);
+      process.on('exit', writeLog);
+    }
   }
 
   async teams(variables?: any): Promise<any> {
@@ -300,16 +369,50 @@ class MockLinearClient {
   }
 
   async issues(variables?: any): Promise<any> {
+    this.__ltuiRequestCounts.issues += 1;
     return connection(this.data.issues.map(issue => this.decorateIssue(issue)), variables);
   }
 
   async searchIssues(_term?: string, variables?: any): Promise<any> {
+    this.__ltuiRequestCounts.searchIssues += 1;
     return connection(this.data.issues.map(issue => ({ id: issue.id })), variables);
   }
 
   async issue(ref: string): Promise<any> {
+    this.__ltuiRequestCounts.issue += 1;
     const match = this.data.issues.find(issue => issue.id === ref || issue.identifier === ref);
     return match ? this.decorateIssue(match) : null;
+  }
+
+  async rawRequest(query: string, variables: Record<string, unknown>): Promise<any> {
+    this.__ltuiRequestCounts.rawRequests += 1;
+    this.__ltuiRawRequests.push({ query, variables });
+    if (process.env.LTUI_MOCK_RAW_RATE_LIMIT === '1') {
+      const error = new Error('rate limited') as Error & {
+        type?: string;
+        raw?: { response: { headers: Headers; status: number; error: string } };
+        response?: { headers: Headers; status: number; error: string };
+      };
+      const response = {
+        headers: makeHeaders({ ...RATE_LIMIT_HEADERS, 'x-ratelimit-requests-remaining': '0' }),
+        status: 429,
+        error: 'rate_limited',
+      };
+      error.type = 'Ratelimited';
+      error.raw = { response };
+      error.response = response;
+      throw error;
+    }
+
+    const nodes = this.filterIssues(variables, query).map(issue => this.rawIssue(issue));
+    const page = connection(nodes, variables);
+    const field = query.includes('searchIssues') ? 'searchIssues' : 'issues';
+    return {
+      data: {
+        [field]: page,
+      },
+      headers: makeHeaders(),
+    };
   }
 
   async createIssue(input: Record<string, unknown>): Promise<any> {
@@ -461,6 +564,103 @@ class MockLinearClient {
     );
   }
 
+  private filterIssues(variables: Record<string, unknown>, query: string): IssueData[] {
+    let working = this.data.issues;
+    const filter = variables.filter as any;
+    const term = typeof variables.term === 'string' ? variables.term.toLowerCase() : '';
+    if (term) {
+      working = working.filter(issue =>
+        issue.identifier.toLowerCase().includes(term) || issue.title.toLowerCase().includes(term)
+      );
+    }
+    if (query.includes('searchIssues') && !term) {
+      return working;
+    }
+    if (filter?.team?.or) {
+      const teamRefs = filter.team.or
+        .flatMap((clause: any) => [clause?.id?.eq, clause?.key?.eq, clause?.name?.eq])
+        .filter(Boolean);
+      working = working.filter(issue => {
+        const team = this.data.teams.find(item => item.id === issue.teamId);
+        return teamRefs.some((ref: string) => ref === team?.id || ref === team?.key || ref === team?.name);
+      });
+    }
+    if (filter?.project?.or) {
+      const projectRefs = filter.project.or
+        .flatMap((clause: any) => [clause?.id?.eq, clause?.slugId?.eq, clause?.name?.eq])
+        .filter(Boolean);
+      working = working.filter(issue => {
+        const project = this.data.projects.find(item => item.id === issue.projectId);
+        return projectRefs.some((ref: string) => ref === project?.id || ref === project?.slugId || ref === project?.name);
+      });
+    }
+    if (filter?.state?.or) {
+      const stateRefs = filter.state.or
+        .flatMap((clause: any) => [clause?.id?.eq, clause?.name?.eq])
+        .filter(Boolean);
+      working = working.filter(issue => {
+        const state = this.data.states.find(item => item.id === issue.stateId);
+        return stateRefs.some((ref: string) => ref === state?.id || ref === state?.name);
+      });
+    }
+    if (filter?.assignee?.isMe?.eq === true) {
+      working = working.filter(issue => issue.assigneeId === this.data.users[0]?.id);
+    } else if (filter?.assignee?.email?.eq) {
+      working = working.filter(issue => this.data.users.find(user => user.id === issue.assigneeId)?.email === filter.assignee.email.eq);
+    } else if (filter?.assignee?.or) {
+      const assigneeRefs = filter.assignee.or
+        .flatMap((clause: any) => [clause?.id?.eq, clause?.name?.eq])
+        .filter(Boolean);
+      working = working.filter(issue => {
+        const assignee = this.data.users.find(item => item.id === issue.assigneeId);
+        return assigneeRefs.some((ref: string) => ref === assignee?.id || ref === assignee?.name);
+      });
+    }
+    if (filter?.labels?.and) {
+      const labels = filter.labels.and
+        .map((clause: any) => clause?.some?.name?.eq)
+        .filter(Boolean);
+      working = working.filter(issue => {
+        const issueLabels = issue.labelIds
+          .map(id => this.data.labels.find(label => label.id === id)?.name)
+          .filter(Boolean);
+        return labels.every((label: string) => issueLabels.includes(label));
+      });
+    }
+    if (filter?.updatedAt?.gte) {
+      working = working.filter(issue => issue.updatedAt >= filter.updatedAt.gte);
+    }
+    if (filter?.createdAt?.gte) {
+      working = working.filter(issue => issue.createdAt >= filter.createdAt.gte);
+    }
+    return working;
+  }
+
+  private rawIssue(issue: IssueData): any {
+    const labels = issue.labelIds
+      .map(id => this.data.labels.find(label => label.id === id))
+      .filter(Boolean) as LabelData[];
+    const team = this.data.teams.find(t => t.id === issue.teamId)!;
+    const project = this.data.projects.find(p => p.id === issue.projectId)!;
+    const state = this.data.states.find(s => s.id === issue.stateId)!;
+    const assignee = this.data.users.find(u => u.id === issue.assigneeId)!;
+    return {
+      id: issue.id,
+      identifier: issue.identifier,
+      url: issue.url,
+      number: issue.number,
+      title: issue.title,
+      state: { id: state.id, name: state.name, type: state.type },
+      team: { id: team.id, key: team.key, name: team.name },
+      project: { id: project.id, name: project.name, slugId: project.slugId },
+      priority: issue.priority,
+      assignee: { id: assignee.id, name: assignee.name, email: assignee.email },
+      labels: { nodes: labels.map(label => ({ id: label.id, name: label.name })) },
+      createdAt: issue.createdAt,
+      updatedAt: issue.updatedAt,
+    };
+  }
+
   private decorateTeam(team: TeamData) {
     return {
       ...team,
@@ -486,6 +686,7 @@ class MockLinearClient {
   }
 
   private decorateIssue(issue: IssueData) {
+    const self = this;
     const labels = issue.labelIds
       .map(id => this.data.labels.find(label => label.id === id))
       .filter(Boolean) as LabelData[];
@@ -518,24 +719,31 @@ class MockLinearClient {
           'Looks good. Another screenshot: https://uploads.linear.app/6db02bb9-fba2-473b-8f9d-f38188e84813/d20adbea-186d-4643-ad07-004bda7d099d',
       },
     ];
-    return {
+    const decorated: any = {
       id: issue.id,
       identifier: issue.identifier,
       url: issue.url,
       number: issue.number,
       title: issue.title,
-      state,
-      team: this.decorateTeam(team),
-      project: this.decorateProject(project),
       priority: issue.priority,
-      assignee: this.decorateUser(assignee),
-      labels,
+      labels: async () => {
+        self.__ltuiRequestCounts.labels += 1;
+        return connection(labels.map(label => ({ ...label })));
+      },
       description: issue.description,
       createdAt: new Date(issue.createdAt),
       updatedAt: new Date(issue.updatedAt),
-      attachments: async (variables?: any) => connection(attachmentNodes, variables),
-      comments: async (variables?: any) => connection(commentNodes, variables),
-      history: async () =>
+      attachments: async (variables?: any) => {
+        self.__ltuiRequestCounts.attachments += 1;
+        return connection(attachmentNodes, variables);
+      },
+      comments: async (variables?: any) => {
+        self.__ltuiRequestCounts.comments += 1;
+        return connection(commentNodes, variables);
+      },
+      history: async () => {
+        self.__ltuiRequestCounts.history += 1;
+        return (
         connection([
           {
             id: 'history-1',
@@ -543,8 +751,37 @@ class MockLinearClient {
             createdAt: new Date('2024-01-07T00:00:00Z'),
             toState: this.decorateState('state-2'),
           },
-        ]),
+        ])
+        );
+      },
     };
+    Object.defineProperties(decorated, {
+      state: {
+        get() {
+          self.__ltuiRequestCounts.state += 1;
+          return { ...state };
+        },
+      },
+      team: {
+        get() {
+          self.__ltuiRequestCounts.team += 1;
+          return self.decorateTeam(team);
+        },
+      },
+      project: {
+        get() {
+          self.__ltuiRequestCounts.project += 1;
+          return self.decorateProject(project);
+        },
+      },
+      assignee: {
+        get() {
+          self.__ltuiRequestCounts.assignee += 1;
+          return self.decorateUser(assignee);
+        },
+      },
+    });
+    return decorated;
   }
 
   private decorateUser(user: UserData) {

--- a/tools/ltui/src/test-utils/mockLinearClient.ts
+++ b/tools/ltui/src/test-utils/mockLinearClient.ts
@@ -165,7 +165,7 @@ function parseCursor(cursor: string): number | null {
 function connection<T>(
   allNodes: T[],
   variables?: { first?: number; after?: string; last?: number; before?: string }
-): { nodes: T[]; pageInfo: PageInfo } {
+): { nodes: T[]; edges: Array<{ cursor: string; node: T }>; pageInfo: PageInfo } {
   const first =
     typeof variables?.first === 'number' && !Number.isNaN(variables.first)
       ? variables.first
@@ -178,8 +178,13 @@ function connection<T>(
   const endCursor = nodes.length > 0 ? `cursor:${endIndex}` : null;
   const hasNextPage = endIndex >= 0 ? endIndex < allNodes.length - 1 : false;
   const hasPreviousPage = startIndex > 0;
+  const edges = nodes.map((node, index) => ({
+    cursor: `cursor:${startIndex + index}`,
+    node,
+  }));
   return {
     nodes,
+    edges,
     pageInfo: {
       startCursor,
       endCursor,
@@ -302,7 +307,10 @@ function buildData() {
     { id: 'milestone-1', name: 'Milestone 1', projectId: 'proj-1', targetDate: '2024-10-01' },
   ];
   const notifications: NotificationData[] = [
-    { id: 'notif-1', type: 'issue_created', readAt: null, createdAt: '2024-02-01T00:00:00Z' },
+    { id: 'notif-1', type: 'issue_created', readAt: '2024-02-01T01:00:00Z', createdAt: '2024-02-01T00:00:00Z' },
+    { id: 'notif-2', type: 'issue_updated', readAt: null, createdAt: '2024-02-02T00:00:00Z' },
+    { id: 'notif-3', type: 'issue_commented', readAt: null, createdAt: '2024-02-03T00:00:00Z' },
+    { id: 'notif-4', type: 'issue_updated', readAt: '2024-02-04T01:00:00Z', createdAt: '2024-02-04T00:00:00Z' },
   ];
   return {
     teams,
@@ -402,6 +410,17 @@ class MockLinearClient {
       error.raw = { response };
       error.response = response;
       throw error;
+    }
+
+    if (query.includes('notifications')) {
+      const nodes = this.data.notifications.map(notification => ({ ...notification }));
+      const page = connection(nodes, variables);
+      return {
+        data: {
+          notifications: page,
+        },
+        headers: makeHeaders(),
+      };
     }
 
     const nodes = this.filterIssues(variables, query).map(issue => this.rawIssue(issue));


### PR DESCRIPTION
## Summary
- Reuse `issues view` comment/history fetches so detail output no longer performs duplicate Linear API calls.
- Replace the invalid notification unread server filter with cursor-safe raw GraphQL edge scanning, including `createdAt` handling for raw DateTime strings.
- Fix generated/docs command guidance so global options such as `--format`, `--fields`, `--limit`, and `--cursor` are placed before the command path.
- Extend ltui regression coverage for request counts, unread notification pagination, terminal cursors, raw DateTime output, and generated helper commands.

## Verification
- `cd tools/ltui && bun run test` — 53 tests passing
- `git diff --check`
- Live Linear manual regression across auth, teams, projects, cycles, labels, users, documents, roadmaps, milestones, notifications, issue list/view/create/update/comment/link/relate/block/attachments/saved queries, pagination, rate-limit, validation errors, and attachment download
- Live unread notification pagination smoke with `--format json --fields id,type,read,createdAt --limit ... notifications --unread-only`
- Live `issues view` helper command output checked for global `--format` placement

## Reviews
- Codex implementation reviews found and confirmed fixes for unread pagination limits, terminal cursor behavior, raw `createdAt`, docs drift, and generated helper command placement.
- Claude follow-up review confirmed notification terminal cursor and raw `createdAt` fixes; its stale helper-command note was rechecked against current source/dist/live output.

## Cleanup
- Disposable Linear regression issues `NOD-642` through `NOD-645` were moved to `Canceled`.

## Residual risk
- `notifications --unread-only` scans unfiltered notification pages client-side because Linear rejects `readAt` filtering; sparse unread inboxes can require extra API calls, but pagination now preserves limit and cursor contracts.
