### PR TITLE
Add HTML plan review service

### DIFF
--- a/Formula/plan-reviewer.rb
+++ b/Formula/plan-reviewer.rb
@@ -1,0 +1,43 @@
+class PlanReviewer < Formula
+  desc "Local HTML plan review daemon and CLI for agent comment workflows"
+  homepage "https://github.com/adnichols/ai-configs"
+  tap_root = File.expand_path("..", __dir__)
+  tap_branch = Utils.safe_popen_read("git", "-C", tap_root, "branch", "--show-current").strip
+  tap_branch = "main" if tap_branch.empty?
+  url "file://#{tap_root}", using: :git, branch: tap_branch
+  version "0.1.0"
+
+  depends_on "node"
+
+  def install
+    cd "tools/plan-reviewer" do
+      system "npm", "ci", "--include=dev"
+      system "npx", "tsc"
+      system "npm", "prune", "--omit=dev"
+      libexec.install Dir["*"]
+    end
+    bin.install_symlink libexec/"bin/plan-review" => "plan-review"
+  end
+
+  service do
+    run [opt_bin/"plan-review", "serve", "--host", "0.0.0.0", "--port", "4317", "--db", "#{Dir.home}/.plan-reviewer/plan-reviewer.sqlite"]
+    keep_alive true
+    log_path var/"log/plan-reviewer.log"
+    error_log_path var/"log/plan-reviewer.err.log"
+  end
+
+  def caveats
+    <<~EOS
+      Stop the persistent service with:
+        brew services stop plan-reviewer
+
+      Uninstalling the formula does not delete review data. To remove stored
+      plans, comments, assets, and watch state manually:
+        rm -rf ~/.plan-reviewer
+    EOS
+  end
+
+  test do
+    assert_match "plan-review", shell_output("#{bin}/plan-review --help")
+  end
+end

--- a/thoughts/plans/html-plan-review-service.html
+++ b/thoughts/plans/html-plan-review-service.html
@@ -572,7 +572,7 @@ bun run build
 node dist/bin/plan-review.js serve --db /tmp/plan-reviewer.sqlite --host 0.0.0.0 --port 4317
 node dist/bin/plan-review.js register ../../thoughts/plans/html-plan-review-service.html --url http://127.0.0.1:4317 --json
 node dist/bin/plan-review.js index --url http://127.0.0.1:4317 --json
-curl -fsS http://127.0.0.1:4317/ >/tmp/plan-reviewer-index.html</code></pre>
+curl -fsS http://127.0.0.1:4317/ &gt;/tmp/plan-reviewer-index.html</code></pre>
     </section>
 
     <section id="phase-p3">

--- a/thoughts/plans/html-plan-review-service.html
+++ b/thoughts/plans/html-plan-review-service.html
@@ -1,0 +1,810 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>HTML Plan Review Service</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b1020;
+      --panel: #111827;
+      --panel-2: #182235;
+      --text: #e5e7eb;
+      --muted: #a7b0c0;
+      --accent: #7dd3fc;
+      --accent-2: #c084fc;
+      --good: #86efac;
+      --warn: #fbbf24;
+      --bad: #fca5a5;
+      --border: #2b364d;
+      --code: #0f172a;
+    }
+    body {
+      margin: 0;
+      background: radial-gradient(circle at top left, rgba(125, 211, 252, 0.12), transparent 36rem), var(--bg);
+      color: var(--text);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+    main { max-width: 1080px; margin: 0 auto; padding: 48px 24px 80px; }
+    h1, h2, h3 { line-height: 1.2; margin-top: 1.8em; }
+    h1 { font-size: clamp(2rem, 4vw, 3.5rem); margin-top: 0; }
+    h2 { border-top: 1px solid var(--border); padding-top: 1.2em; color: #f8fafc; }
+    h3 { color: var(--accent); }
+    a { color: var(--accent); }
+    p, li { color: var(--text); }
+    .muted { color: var(--muted); }
+    .badge { display: inline-block; padding: 0.2rem 0.55rem; border: 1px solid var(--border); border-radius: 999px; background: var(--panel-2); color: var(--accent); font-size: 0.85rem; }
+    .card { background: rgba(17, 24, 39, 0.88); border: 1px solid var(--border); border-radius: 16px; padding: 18px 20px; margin: 18px 0; box-shadow: 0 18px 60px rgba(0,0,0,0.25); }
+    code, pre { background: var(--code); color: #dbeafe; border-radius: 8px; }
+    code { padding: 0.12rem 0.28rem; }
+    pre { padding: 16px; overflow-x: auto; border: 1px solid var(--border); }
+    table { width: 100%; border-collapse: collapse; margin: 16px 0; }
+    th, td { border: 1px solid var(--border); padding: 10px 12px; vertical-align: top; }
+    th { background: var(--panel-2); color: #f8fafc; text-align: left; }
+    .good { color: var(--good); }
+    .warn { color: var(--warn); }
+    .bad { color: var(--bad); }
+    .mock-flow { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr); gap: 16px; align-items: stretch; margin: 18px 0; }
+    .mock-browser, .mock-conversation { border: 1px solid var(--border); border-radius: 14px; background: rgba(15, 23, 42, 0.92); overflow: hidden; }
+    .mock-topbar { display: flex; gap: 6px; align-items: center; padding: 10px 12px; background: #111827; border-bottom: 1px solid var(--border); color: var(--muted); font-size: 0.85rem; }
+    .mock-dot { width: 9px; height: 9px; border-radius: 50%; background: #64748b; }
+    .mock-plan { position: relative; padding: 18px; min-height: 360px; }
+    .mock-plan-section { border: 1px solid var(--border); border-radius: 10px; padding: 14px; background: #0b1220; margin-bottom: 12px; }
+    .mock-plan-section h4, .mock-comment-box h4, .mock-message strong { margin: 0 0 8px; color: #f8fafc; }
+    .mock-selected { border: 2px solid #38bdf8; background: rgba(56, 189, 248, 0.12); box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.1); }
+    .mock-pin { position: absolute; top: 116px; right: 166px; width: 26px; height: 26px; border-radius: 50%; background: #0ea5e9; color: white; display: grid; place-items: center; font-weight: 700; border: 2px solid #dbeafe; }
+    .mock-comment-box { position: absolute; top: 84px; right: 18px; width: 220px; padding: 12px; border: 1px solid #38bdf8; border-radius: 10px; background: #0f172a; box-shadow: 0 18px 45px rgba(0,0,0,0.35); }
+    .mock-comment-box textarea { box-sizing: border-box; width: 100%; min-height: 72px; resize: none; border: 1px solid var(--border); border-radius: 8px; background: #020617; color: var(--text); padding: 8px; font: inherit; }
+    .mock-button { display: inline-block; margin-top: 8px; padding: 6px 10px; border-radius: 8px; background: #0ea5e9; color: white; font-weight: 700; font-size: 0.85rem; }
+    .mock-sidebar { border-left: 1px solid var(--border); background: rgba(17, 24, 39, 0.9); padding: 14px; }
+    .mock-comment-row { border: 1px solid var(--border); border-radius: 10px; padding: 10px; background: #0b1220; margin-bottom: 10px; }
+    .mock-message-list { padding: 14px; display: grid; gap: 10px; }
+    .mock-message { border: 1px solid var(--border); border-radius: 10px; padding: 10px; background: #0b1220; }
+    .mock-message.agent { border-color: rgba(134, 239, 172, 0.55); background: rgba(22, 101, 52, 0.16); }
+    .mock-message .meta { color: var(--muted); font-size: 0.82rem; margin-bottom: 4px; }
+    .flow-steps { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin-top: 14px; }
+    .flow-step { border: 1px solid var(--border); border-radius: 10px; padding: 10px; background: rgba(24, 34, 53, 0.72); }
+    @media (max-width: 860px) {
+      .mock-flow { grid-template-columns: 1fr; }
+      .flow-steps { grid-template-columns: 1fr 1fr; }
+      .mock-comment-box { position: static; width: auto; margin-top: 12px; }
+      .mock-pin { top: 136px; right: 28px; }
+    }
+    @media (max-width: 560px) {
+      .flow-steps { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <p class="badge">Status: execution-ready plan</p>
+  <h1>HTML Plan Review Service</h1>
+  <p class="muted">A local-network review surface for HTML development plans stored in <code>thoughts/plans</code>, with a browsable plan index, DOM/image-anchored comments, and comments delivered back to coding agents through REST, CLI, and near-real-time streams.</p>
+
+  <section id="goal">
+    <h2>Goal</h2>
+    <p>Build a simple unauthenticated local-network service where agents register HTML development plans from any repo, users browse an index of registered plans, review a plan in a browser by selecting DOM elements or images and leaving comments, and agents can monitor, claim, and process those comments as a durable queue.</p>
+    <p>The golden path should be:</p>
+    <pre><code>brew tap local/ai-configs &lt;repo-checkout-path&gt;
+brew install local/ai-configs/plan-reviewer
+brew services start plan-reviewer
+plan-review register thoughts/plans/my-plan.html --repo auto --branch auto --commit auto
+plan-review watch &lt;plan-id-or-slug&gt; --mode queue</code></pre>
+    <p>The reviewer opens <code>http://&lt;host&gt;:4317/</code>, chooses a plan from the index, clicks a plan section/component or image, comments, and the watching agent receives a structured event without needing manual refresh.</p>
+  </section>
+
+  <section id="why">
+    <h2>Why this plan exists</h2>
+    <p>Current plan review workflows rely on inline text comments inside plan files. That works for markdown review, but HTML plans can express richer structure, UI mockups, status dashboards, diagrams, and interactive sections. The review system needs to preserve that context: not just “line 80,” but “this card/button/phase/scenario element, with its DOM path, surrounding text, screenshot coordinates, and stable plan node identity.”</p>
+  </section>
+
+  <section id="authority-inputs">
+    <h2>Authority and inputs</h2>
+    <ul>
+      <li>User request in this session.</li>
+      <li>Root <code>AGENTS.md</code>: plans belong under <code>thoughts/plans</code>, multi-surface parity must be explicit, and plan execution should be resumable.</li>
+      <li>Shared planning workflow: HTML plans need explicit dark-mode styling and canonical execution-plan sections.</li>
+      <li>Shared product principles: golden path first, safe defaults, self-healing, actionable errors.</li>
+      <li>Dependency-selection doctrine: reuse maintained libraries and document any custom implementation over 100 lines.</li>
+      <li>Prior art observed during discovery: DOM/comment overlay tools commonly use CSS selector + DOM path + coordinates; SSE is a good default for server-to-agent/server-to-browser one-way events, with polling fallback.</li>
+    </ul>
+  </section>
+
+  <section id="current-reality">
+    <h2>Current implementation reality</h2>
+    <ul>
+      <li>This repo stores working plans under <code>thoughts/plans</code>, currently mostly markdown.</li>
+      <li>No existing plan-review service code is present in this repo.</li>
+      <li>The repo has a TypeScript CLI precedent under <code>tools/ltui</code>, using Node 20, ESM, <code>commander</code>, <code>typescript</code>, and <code>node --test</code>.</li>
+      <li>No product-intent document exists under <code>thoughts/specs/product_intent.md</code>; this plan aligns directly to the user request and repo instructions.</li>
+    </ul>
+  </section>
+
+  <section id="progress">
+    <h2>Progress</h2>
+    <ul>
+      <li><input type="checkbox" checked /> P1 Bootstrap package, Homebrew, and launchctl service</li>
+      <li><input type="checkbox" checked /> P2 Register plans and build browsable index</li>
+      <li><input type="checkbox" checked /> P3 Add DOM and image annotation UI</li>
+      <li><input type="checkbox" checked /> P4 Implement comment queue, streaming, and CLI watch</li>
+      <li><input type="checkbox" checked /> P5 Add agent action lifecycle and bulk processing</li>
+      <li><input type="checkbox" checked /> P6 Dogfood docs and future security seams</li>
+    </ul>
+  </section>
+
+  <section id="resume">
+    <h2>Resume instructions (agent)</h2>
+    <p>Read this document fully. Start with the first unchecked item in <a href="#progress">Progress</a>. Execute phases in order. Do not implement adjacent collaboration features beyond HTML plan registration, DOM-anchored comments, and agent comment consumption unless the user explicitly expands scope. Update only this plan’s progress checkboxes when completing phases.</p>
+  </section>
+
+  <section id="product-intent">
+    <h2>Product intent alignment</h2>
+    <ul>
+      <li><strong>Default workflow:</strong> the Homebrew-installed daemon starts persistently with launchctl, listens on <code>0.0.0.0:4317</code>, and exposes an index where anyone on the reachable network can browse registered plans and comment.</li>
+      <li><strong>Safe inference:</strong> CLI infers repo name, branch, commit, remote URL, plan slug, and file hash from the current git workspace when possible.</li>
+      <li><strong>Self-healing:</strong> re-registering the same plan path updates the existing plan version instead of creating duplicates, unless the user asks for a new review thread.</li>
+      <li><strong>Fail-closed boundaries:</strong> ambiguous repo identity, invalid HTML, dangerous inline script, unavailable image assets, or corrupt image metadata should stop with a clear error rather than guessing.</li>
+      <li><strong>Actionable errors:</strong> every CLI/API failure should say what failed, what was inferred or retried, and the exact command or input needed next.</li>
+      <li><strong>Agent-friendly state:</strong> comments are durable queue items with sequence IDs, claim/ack semantics, and a replayable event stream so an agent can recover after disconnecting.</li>
+    </ul>
+  </section>
+
+  <section id="locked-decisions">
+    <h2>Locked decisions</h2>
+    <ol>
+      <li><strong>MVP shape:</strong> create a repo-owned TypeScript package at <code>tools/plan-reviewer</code> containing the daemon and CLI, plus Homebrew formula/install wiring in this <code>ai-configs</code> repo.</li>
+      <li><strong>Scope approval:</strong> the user request is explicit approval to build a new service/CLI in this repo even though the implementation will exceed 100 lines of custom code. The dependency-selection rule still applies to reusable libraries; do not hand-roll package-manager, HTTP, SQLite, selector, screenshot, or browser-test primitives.</li>
+      <li><strong>Deployment topology:</strong> MVP is one shared local-network service instance that can register plans from many repos. It listens on <code>0.0.0.0:4317</code> by default with SQLite at <code>~/.plan-reviewer/plan-reviewer.sqlite</code>. Local-only binding is an optional override, not the default.</li>
+      <li><strong>Persistent install:</strong> install via Homebrew from a repo checkout for now. The formula lives at <code>Formula/plan-reviewer.rb</code>; because Homebrew 5.1 requires local formulae to live in a tap, <code>brew tap local/ai-configs &lt;repo-checkout-path&gt;</code> followed by <code>brew install local/ai-configs/plan-reviewer</code> installs the CLI/daemon, and <code>brew services start plan-reviewer</code> installs the formula service through launchctl. The formula service block must set <code>run [opt_bin/"plan-review", "serve", "--host", "0.0.0.0", "--port", "4317", "--db", "#{Dir.home}/.plan-reviewer/plan-reviewer.sqlite"]</code>, <code>keep_alive true</code>, <code>log_path var/"log/plan-reviewer.log"</code>, and <code>error_log_path var/"log/plan-reviewer.err.log"</code>. MVP service management is macOS/Homebrew-only; Linux service units are future work.</li>
+      <li><strong>CLI service discovery:</strong> resolve service URL in this order: <code>--url</code> flag, <code>PLAN_REVIEW_URL</code>, project <code>.plan-reviewer.json</code>, user config <code>~/.config/plan-reviewer/config.json</code>, then <code>http://127.0.0.1:4317</code>. The CLI never requires auth for MVP.</li>
+      <li><strong>No-auth MVP:</strong> there is no authentication, reviewer token, share-token, or obfuscated review URL in the initial product. Anyone who can reach the service can view the index, open plans, create comments, and use queue endpoints. The service should print a startup warning when bound to non-loopback addresses so the operator understands the exposure.</li>
+      <li><strong>Plan index:</strong> <code>GET /</code> serves a browsable index of all registered plans grouped by repo and sorted by most recent registration/comment activity. The index supports text filtering, repo filtering, status counts, latest version metadata, links to open each plan, and comment-count badges.</li>
+      <li><strong>Repo identity:</strong> a repo is keyed by canonical git remote URL when available, otherwise absolute repo root path plus machine hostname. The API stores <code>repoKey</code>, <code>repoName</code>, <code>remoteUrl</code>, <code>rootPath</code>, <code>branch</code>, and <code>commitSha</code> on each registration so one SQLite file can safely hold many repos.</li>
+      <li><strong>Runtime/tooling:</strong> implementation targets Node 20+ ESM TypeScript at runtime. Bun is the package manager/script runner for this package to match the existing <code>tools/ltui</code> lockfile pattern.</li>
+      <li><strong>HTTP framework:</strong> use Fastify with TypeScript route schemas. Do not reopen Express/Hono during execution unless Fastify cannot satisfy an explicitly tested contract.</li>
+      <li><strong>Schema validation:</strong> use Zod as the single source for runtime validation and TypeScript request/response types.</li>
+      <li><strong>Storage:</strong> use <code>better-sqlite3</code> for local synchronous SQLite access behind a narrow repository interface so a future hosted deployment can move to Postgres without changing API contracts.</li>
+      <li><strong>HTML parsing/sanitization:</strong> use <code>parse5</code> for server-side HTML parsing/rewriting and <code>sanitize-html</code> for removing unsafe active content from the review artifact. Use Playwright for browser verification, not server-side DOM emulation.</li>
+      <li><strong>CLI:</strong> use <code>commander</code>, matching existing <code>tools/ltui</code>.</li>
+      <li><strong>Realtime default:</strong> use Server-Sent Events for plan/comment streams because browser and agent clients mostly need server-to-client updates. Keep REST writes for comments and acknowledgements. Do not introduce WebSockets unless bidirectional live collaboration becomes required.</li>
+      <li><strong>Plan render safety:</strong> serve uploaded HTML inside an iframe with <code>sandbox="allow-same-origin"</code> only and no <code>allow-scripts</code>. The review shell, annotation layer, zoom popovers, and event handlers run entirely in the parent document; parent code reads the same-origin sanitized iframe DOM via <code>contentDocument</code>/<code>elementFromPoint</code> and attaches parent-owned listeners to iframe scroll/resize. Do not inject scripts or postMessage hooks into the iframe. Set CSP to <code>default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'</code> for the review shell. Sanitized plan artifacts strip <code>&lt;script&gt;</code>, event-handler attributes, javascript/data navigation URLs except safe images, forms, object/embed, and external active resources. Blocked content is reported in registration/render metadata.</li>
+      <li><strong>Image support:</strong> registered plans must display safe local/relative images and safe data/blob images. The renderer copies relative image assets referenced by the HTML into content-addressed service storage when possible; unresolved images render as visible placeholders with actionable warnings.</li>
+      <li><strong>Image zoom and comments:</strong> clicking an image opens a parent-owned zoom popover/lightbox with fit-to-screen, zoom in/out, reset, pan, and close controls. Reviewers can comment on the whole image or on a point/rectangle inside the zoomed image; the comment stores image source hash/path, natural dimensions, displayed rect, and normalized coordinates.</li>
+      <li><strong>Anchoring model:</strong> store multiple selectors per DOM annotation: stable service-generated <code>data-plan-node-id</code>, CSS selector, DOM path, XPath-like path, text quote, nearest heading hierarchy, bounding rect, viewport size, and a trimmed outerHTML/context snapshot. Text-range annotations use <code>anchorType: "text_range"</code> and add start/end container selectors, character offsets, selected text, and client rects. Image annotations use the same surrounding DOM context plus normalized image coordinates.</li>
+      <li><strong>Anchor state mapping:</strong> comment anchor state values are <code>mapped</code>, <code>stale</code>, and <code>unmapped</code>. A comment is <code>mapped</code> when the current version resolves the same <code>data-plan-node-id</code> or generated selector and the text quote still matches. It is <code>stale</code> when only a weaker selector or heading/text context match succeeds. It is <code>unmapped</code> when no current node/image can be resolved; the UI must still show the original captured context and screenshot.</li>
+      <li><strong>Stable node ID algorithm:</strong> preserve an existing <code>id</code> as <code>data-plan-node-id</code>; otherwise derive <code>headingPathSlug + shortHash(textContent)</code> for headings/sections; otherwise derive <code>tagName + domSiblingPath + shortHash(trimmedTextOrOuterHtml)</code>. When two generated IDs collide within one version, append deterministic sibling-order suffixes <code>-2</code>, <code>-3</code>, etc. The renderer must produce deterministic IDs for identical plan content across registrations.</li>
+      <li><strong>Marker screenshots:</strong> the parent review shell captures a cropped marker screenshot with <code>html2canvas</code> after the selected-region highlight and marker are rendered. No screenshot code runs inside the sandboxed iframe. The screenshot is posted with the comment as safe PNG bytes, stored as a comment asset, and referenced by <code>screenshotAssetId</code>.</li>
+      <li><strong>Reviewer identity:</strong> the no-auth UI asks for an optional display name on first comment and stores it in localStorage. If omitted, comments use <code>{ "type": "reviewer", "displayName": "Anonymous reviewer" }</code>. The API accepts optional <code>createdBy.displayName</code> and normalizes missing/blank values to that anonymous default.</li>
+      <li><strong>Agent delivery:</strong> comments are delivered at least once. Agents must claim then ack comments; unacked claims expire after a 5-minute lease and re-enter the pending queue.</li>
+      <li><strong>Main conversation response:</strong> comment events include a <code>browser.comment.v1</code> conversation bridge payload so a host adapter can append the browser comment to the active chat thread, respond there, and ack/resolve the comment with a response summary, run ID, changed files, and optional commit SHA. The service/CLI owns the portable event and file/stdout handoff contract; host-specific injection into Codex, Claude, or Pi is a thin adapter that consumes that contract. The review service stores and displays response metadata but does not implement its own chat system.</li>
+      <li><strong>Queue state machine:</strong> comment status values are <code>pending</code>, <code>claimed</code>, <code>acknowledged</code>, and <code>resolved</code>. Allowed transitions are <code>pending → claimed → acknowledged → resolved</code>, <code>pending → resolved</code>, and <code>claimed → pending</code> on lease expiry or explicit release. Agent ack requires an active matching claim; direct ack from <code>pending</code> returns <code>409 claim_required</code>. Ack and resolve are idempotent for the life of the comment.</li>
+      <li><strong>Event sequencing:</strong> event sequence numbers are monotonic per plan. SSE uses <code>id: &lt;sequence&gt;</code>; reconnect with <code>Last-Event-ID</code> replays later events. Retain events until both thresholds are exceeded: older than 7 days and outside the latest 10,000 events per plan.</li>
+      <li><strong>Latency/reconnect defaults:</strong> local SSE delivery target is p95 under 1 second after transaction commit. Heartbeats are sent every 15 seconds. CLI reconnect backoff starts at 1 second and doubles to a 30-second max, with REST polling every 10 seconds if SSE is unavailable.</li>
+      <li><strong>Concurrent claims:</strong> claiming is atomic. Two agents cannot hold the same active claim; conflicts return <code>409 claim_conflict</code> with the current holder and lease expiry.</li>
+      <li><strong>Versioning:</strong> every registration creates or updates a plan version identified by file hash + repo + path + branch + commit. Comments attach to a plan version but can be shown on newer versions as “stale/mapped/unmapped.”</li>
+      <li><strong>Security posture:</strong> MVP intentionally optimizes for simple local-network access over access control. Authentication, reviewer tokens, private share links, SSO, and authorization are explicit future work, not part of initial execution.</li>
+    </ol>
+  </section>
+
+  <section id="architecture">
+    <h2>Architecture</h2>
+    <div class="card">
+      <pre><code>Agent repo                         Plan Review Service                       Reviewer browser
+---------                          -------------------                       ----------------
+thoughts/plans/*.html   register   REST API + storage             open /   Plan index
+plan-review CLI       ----------&gt;  HTML/image renderer + overlay  --------&gt;  sandboxed plan iframe
+plan-review watch     &lt;----------  SSE events + queue claims      &lt;--------  DOM/image comments
+agent action loop       claim/ack   durable comments + versions     stream    comment updates</code></pre>
+    </div>
+    <h3>Deployment and discovery</h3>
+    <p>The MVP runs as one shared Homebrew/launchctl-managed daemon, not one service per repo. It binds to <code>0.0.0.0:4317</code> by default so other devices on the reachable network can open the plan index. Agents in any repo use the same CLI, which discovers the daemon URL from flag, environment, project config, user config, then the local default. The daemon stores every plan under a repo-scoped key so <code>thoughts/plans/foo.html</code> in two repos cannot collide.</p>
+    <h3>Core components</h3>
+    <table>
+      <thead><tr><th>Component</th><th>Responsibility</th></tr></thead>
+      <tbody>
+        <tr><td>CLI</td><td>Register local plan files, infer git metadata, print review URL/index URL, watch event streams, claim/ack comments singly or in bulk.</td></tr>
+        <tr><td>API server</td><td>Plan index, plan registration, plan version lookup, comments, queue state, SSE streams, static review shell, and image assets without authentication.</td></tr>
+        <tr><td>Renderer</td><td>Stores uploaded HTML, copies safe image assets, sanitizes HTML, injects stable node IDs/metadata, serves a versioned render artifact inside a no-scripts sandboxed iframe.</td></tr>
+        <tr><td>Review UI</td><td>Shows plan index, plan iframe, parent-owned Washi annotation layer, image zoom lightbox, comment composer, comment sidebar, stale-anchor warnings, and resolution state.</td></tr>
+        <tr><td>Queue worker logic</td><td>Maintains pending/claimed/acknowledged/resolved comment lifecycle with claim leases and replayable sequence IDs.</td></tr>
+        <tr><td>Storage</td><td>SQLite tables for repos, plans, versions, plan assets, comments, comment events, claims, and agent consumers.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="review-ux-loop">
+    <h2>Review UX and agent response loop</h2>
+    <p>The core interaction should feel like collaborative plan review: the reviewer selects a concrete piece of the rendered plan, leaves a comment in the browser, and the active agent receives enough structured context to answer in the main conversation without asking the reviewer to restate the issue.</p>
+
+    <div class="mock-flow" aria-label="Visual mock showing plan selection, comment creation, and agent conversation response">
+      <div class="mock-browser">
+        <div class="mock-topbar"><span class="mock-dot"></span><span class="mock-dot"></span><span class="mock-dot"></span><span>/p/plan_123</span></div>
+        <div class="mock-plan">
+          <div class="mock-plan-section">
+            <h4>Phase 2 - Register plans</h4>
+            <p class="muted">Persist metadata, render the plan safely, and show it in the review shell.</p>
+          </div>
+          <div class="mock-plan-section mock-selected">
+            <h4>Phase 3 - Annotation UI</h4>
+            <p>The selected region is outlined in blue while the comment composer is open. Marker 1 stays attached to this section after submit.</p>
+          </div>
+          <div class="mock-pin">1</div>
+          <div class="mock-comment-box">
+            <h4>Comment on selection</h4>
+            <textarea readonly>Add a visual for how selection and comments work.</textarea>
+            <span class="mock-button">Submit comment</span>
+          </div>
+          <div class="mock-sidebar">
+            <div class="mock-comment-row"><strong>1 Pending</strong><br /><span class="muted">Phase 3 - Annotation UI</span></div>
+            <div class="mock-comment-row"><strong>Agent status</strong><br /><span class="muted">Waiting for claim</span></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mock-conversation">
+        <div class="mock-topbar"><span>Main agent conversation</span></div>
+        <div class="mock-message-list">
+          <div class="mock-message">
+            <div class="meta">Browser comment</div>
+            <strong>Comment 1 on section#phase-p3</strong>
+            <p>Add a visual for how selection and comments work.</p>
+          </div>
+          <div class="mock-message agent">
+            <div class="meta">Agent response</div>
+            <strong>Handled in plan update</strong>
+            <p>I added the selection/comment mockup and updated the response-loop requirements. The comment is acked with the changed file and summary.</p>
+          </div>
+          <div class="mock-message">
+            <div class="meta">Review UI update</div>
+            <strong>Comment 1 acknowledged</strong>
+            <p>The marker remains visible and the sidebar shows the agent response/resolution metadata.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="flow-steps">
+      <div class="flow-step"><strong>1. Select</strong><br /><span class="muted">Reviewer clicks or drags over a DOM node, text range, image point, or image rectangle. The review shell highlights the target and previews captured context.</span></div>
+      <div class="flow-step"><strong>2. Comment</strong><br /><span class="muted">Submitting creates a durable pending comment with selector, quote, rect, screenshot coordinates, and image metadata when applicable.</span></div>
+      <div class="flow-step"><strong>3. Wake agent</strong><br /><span class="muted">The daemon emits <code>comment.created</code>. Codex, Claude, Pi, or another watcher claims the comment and receives a conversation-ready payload.</span></div>
+      <div class="flow-step"><strong>4. Respond</strong><br /><span class="muted">The agent answers in the active chat, performs the requested edit when appropriate, then acks/resolves the comment with run metadata and a human-readable summary.</span></div>
+    </div>
+
+    <h3>Conversation bridge contract</h3>
+    <p>The MVP should expose the comment event in a shape that the host agent can surface as a normal user message in the active conversation. The service does not need to own chat UI. It must provide enough metadata for Codex-style clients to render “Browser comment: Comment 1” with the selected text, marker screenshot, URL, selector, and reviewer note, then let the agent reply in the main thread. The ack/resolve payload records the agent response summary so the review UI can show that the comment was handled even though the full discussion happened in chat.</p>
+    <pre><code>{
+  "type": "browser.comment.v1",
+  "commentId": "cmt_01...",
+  "conversationHint": {
+    "mode": "append-to-active-thread",
+    "title": "Comment 1 on Phase 3 - Annotation UI",
+    "summary": "Reviewer asked for visuals showing selection/comment UX and agent response behavior."
+  },
+  "evidence": {
+    "reviewUrl": "http://127.0.0.1:4317/p/plan_123",
+    "selector": "section#phase-p3",
+    "markerNumber": 1,
+    "textPreview": "Phase 3 - Annotation UI",
+    "screenshotAssetId": "asset_comment_marker_1"
+  },
+  "body": "Add a visual for how selection and comments work."
+}</code></pre>
+  </section>
+
+  <section id="contracts">
+    <h2>API and data contracts</h2>
+    <h3>SQLite schema contract</h3>
+    <table>
+      <thead><tr><th>Table</th><th>Required columns / relationships</th></tr></thead>
+      <tbody>
+        <tr><td><code>repos</code></td><td><code>id</code> PK, unique <code>repo_key</code>, <code>repo_name</code>, <code>remote_url</code>, <code>root_path</code>, <code>created_at</code>, <code>updated_at</code>.</td></tr>
+        <tr><td><code>plans</code></td><td><code>id</code> PK, <code>repo_id</code> FK, <code>slug</code>, <code>plan_path</code>, unique <code>(repo_id, plan_path, slug)</code>, <code>created_at</code>, <code>updated_at</code>.</td></tr>
+        <tr><td><code>plan_versions</code></td><td><code>id</code> PK, <code>plan_id</code> FK, <code>file_hash</code>, <code>branch</code>, <code>commit_sha</code>, <code>html_blob_path</code>, <code>rendered_blob_path</code>, <code>render_warnings_json</code>, unique <code>(plan_id, file_hash, branch, commit_sha)</code>.</td></tr>
+        <tr><td><code>plan_assets</code></td><td><code>id</code> PK, <code>version_id</code> FK, <code>source_url</code>, <code>asset_hash</code>, <code>content_type</code>, <code>width</code>, <code>height</code>, <code>blob_path</code>, <code>status</code>, <code>warning_json</code>, unique <code>(version_id, source_url)</code>.</td></tr>
+        <tr><td><code>comment_assets</code></td><td><code>id</code> PK, <code>comment_id</code> FK nullable until comment transaction completes, <code>asset_type</code> currently <code>marker_screenshot</code>, <code>content_hash</code>, <code>content_type</code>, <code>width</code>, <code>height</code>, <code>capture_rect_json</code>, <code>viewport_json</code>, <code>blob_path</code>, timestamps.</td></tr>
+        <tr><td><code>comments</code></td><td><code>id</code> PK, <code>plan_id</code> FK, <code>version_id</code> FK, per-plan <code>sequence</code>, <code>status</code>, <code>body</code>, <code>anchor_type</code> (<code>dom</code>, <code>text_range</code>, or <code>image</code>), <code>anchor_state</code> (<code>mapped</code>, <code>stale</code>, <code>unmapped</code>), <code>anchor_json</code>, <code>screenshot_asset_id</code> FK nullable, <code>conversation_payload_json</code>, <code>agent_response_json</code> nullable, <code>created_by_json</code>, <code>client_mutation_id</code> nullable, <code>claim_id</code> nullable, timestamps, unique <code>(plan_id, sequence)</code>, unique nullable <code>(plan_id, client_mutation_id)</code>.</td></tr>
+        <tr><td><code>comment_events</code></td><td><code>id</code> PK, <code>plan_id</code> FK, per-plan <code>sequence</code>, <code>event_type</code>, <code>comment_id</code> FK nullable, <code>client_mutation_id</code> nullable, <code>payload_json</code>, <code>created_at</code>, unique <code>(plan_id, sequence)</code>.</td></tr>
+        <tr><td><code>claims</code></td><td><code>id</code> PK, <code>comment_id</code> FK, <code>agent_id</code> text, <code>ack_client_mutation_id</code> nullable, <code>lease_expires_at</code>, <code>released_at</code>, <code>acknowledged_at</code>; partial unique active claim per comment.</td></tr>
+      </tbody>
+    </table>
+    <p>All JSON endpoints return <code>{ "ok": true, "data": ... }</code> on success. Errors return <code>{ "ok": false, "error": { "code", "message", "details", "nextAction" } }</code>. Common status codes are <code>400 validation_failed</code>, <code>404 not_found</code>, <code>409 claim_conflict</code>, and <code>422 unsafe_or_invalid_html</code>. There are no <code>401</code>/<code>403</code> paths in the MVP because access control is explicitly deferred.</p>
+
+    <h3>Endpoint contracts</h3>
+    <table>
+      <thead><tr><th>Endpoint</th><th>Request</th><th>Response</th></tr></thead>
+      <tbody>
+        <tr><td><code>GET /</code></td><td>Optional query filters <code>?q=&amp;repoKey=&amp;status=</code>.</td><td>HTML plan index grouped by repo with plan links, latest metadata, and comment-count badges.</td></tr>
+        <tr><td><code>GET /api/plans</code></td><td>Optional query filters <code>?q=&amp;repoKey=&amp;limit=&amp;cursor=</code>.</td><td><code>{ plans: [{ plan, latestVersion, counts, reviewUrl }], nextCursor? }</code>.</td></tr>
+        <tr><td><code>POST /api/plans/register</code></td><td><code>{ repoKey?, repoName, remoteUrl?, rootPath?, branch, commitSha?, planPath, slug?, html, fileHash, assets?: [{ sourceUrl, absolutePath?, bytesBase64? }], updateMode: "upsert"|"new-thread" }</code></td><td><code>{ planId, versionId, repoId, reviewUrl, indexUrl, watchCommand, renderedWithWarnings: [{ code, detail }] }</code>.</td></tr>
+        <tr><td><code>GET /p/:planId</code></td><td>No auth or token.</td><td>HTML review shell for the latest visible version.</td></tr>
+        <tr><td><code>GET /assets/:assetId</code></td><td>No body.</td><td>Safe copied image asset bytes with content type and cache headers.</td></tr>
+        <tr><td><code>GET /api/plans/:planId</code></td><td>No auth.</td><td><code>{ plan, latestVersion, assets, versions, counts: { pending, claimed, acknowledged, resolved }, reviewUrl }</code></td></tr>
+        <tr><td><code>POST /api/plans/:planId/comments</code></td><td><code>{ versionId, body, anchorType: "dom"|"text_range"|"image", anchor, markerScreenshot?: { contentType: "image/png", bytesBase64, width, height, captureRect, viewport }, createdBy?: { displayName? }, clientMutationId? }</code></td><td><code>{ comment, event }</code>; duplicate <code>clientMutationId</code> returns the original comment.</td></tr>
+        <tr><td><code>GET /api/plans/:planId/comments?status=&amp;versionId=&amp;anchorState=&amp;sinceSequence=</code></td><td>Filters only; no body.</td><td><code>{ comments, nextCursor? }</code> ordered by per-plan sequence.</td></tr>
+        <tr><td><code>POST /api/plans/:planId/comments/claim</code></td><td><code>{ mode: "one"|"selected"|"bulk", limit?, commentIds?, leaseSeconds?: 300 }</code></td><td><code>{ claimed: Comment[], leaseExpiresAt, skipped: [{ commentId, reason }] }</code>.</td></tr>
+        <tr><td><code>POST /api/comments/:commentId/ack</code></td><td><code>{ claimId, action?: { runId?, handoffPath?, commitSha?, note?, responseSummary?, changedFiles? }, clientMutationId? }</code></td><td><code>{ comment, alreadyAcknowledged: boolean }</code>; missing or inactive claims return <code>409 claim_required</code>.</td></tr>
+        <tr><td><code>POST /api/comments/:commentId/resolve</code></td><td><code>{ resolutionNote, action?: { runId?, commitSha?, responseSummary?, changedFiles? } }</code></td><td><code>{ comment, alreadyResolved: boolean }</code>.</td></tr>
+        <tr><td><code>POST /api/comments/:commentId/release</code></td><td><code>{ claimId, reason? }</code></td><td><code>{ comment }</code> with status returned to <code>pending</code>.</td></tr>
+        <tr><td><code>GET /comment-assets/:assetId</code></td><td>No body.</td><td>Safe comment asset bytes, currently marker screenshots, with content type and cache headers.</td></tr>
+        <tr><td><code>GET /api/plans/:planId/events</code></td><td>SSE request with optional <code>Last-Event-ID</code> header and query <code>?mode=all|queue</code>.</td><td><code>text/event-stream</code> with per-plan sequence replay, heartbeats, and queue/comment events.</td></tr>
+        <tr><td><code>GET /api/plans/:planId/events/poll?afterSequence=&amp;mode=&amp;limit=</code></td><td>REST polling fallback for environments where SSE cannot stay connected.</td><td><code>{ events, latestSequence, retryAfterMs }</code> using the same event payloads and sequence IDs as SSE.</td></tr>
+        <tr><td><code>GET /api/agent/queue?repoKey=&amp;planId=&amp;limit=</code></td><td>No auth.</td><td><code>{ items: Comment[], latestSequenceByPlan: Record&lt;string, number&gt; }</code>.</td></tr>
+      </tbody>
+    </table>
+
+    <h3>Agent watch contract</h3>
+    <p>Agents keep an open watch connection with Server-Sent Events. WebSockets are intentionally not part of the MVP because comment creation, ack, resolve, and claim writes are ordinary REST requests, while the watch side only needs server-to-agent notifications. Add WebSockets later only if bidirectional live collaboration becomes a product requirement.</p>
+    <pre><code>GET /api/plans/plan_123/events?mode=queue
+Accept: text/event-stream
+Last-Event-ID: 42</code></pre>
+    <ul>
+      <li><strong>Primary transport:</strong> <code>plan-review watch plan_123 --mode queue</code> opens <code>GET /api/plans/:planId/events?mode=queue</code> with <code>Accept: text/event-stream</code> and keeps the HTTP connection open until the process exits, the server closes it, or the network fails.</li>
+      <li><strong>Event shape:</strong> each SSE message uses <code>id: &lt;sequence&gt;</code>, <code>event: &lt;eventType&gt;</code>, and JSON <code>data</code>. Queue mode emits <code>comment.created</code>, <code>comment.claimed</code>, <code>comment.acknowledged</code>, <code>comment.resolved</code>, and <code>comment.released</code>. <code>mode=all</code> also emits plan-version events.</li>
+      <li><strong>Resume:</strong> the CLI stores the latest delivered sequence per plan. On reconnect it sends <code>Last-Event-ID</code>; the server replays events with a greater sequence before streaming live events.</li>
+      <li><strong>Heartbeat:</strong> the server sends <code>event: heartbeat</code> every 15 seconds with <code>{ latestSequence, serverTime }</code> so agents can detect dead connections.</li>
+      <li><strong>Fallback polling:</strong> if the SSE connection cannot be established or repeatedly drops, the CLI polls <code>GET /api/plans/:planId/events/poll?afterSequence=&amp;mode=queue</code> every 10 seconds. Poll responses use the same event objects and monotonic sequence IDs as SSE, with <code>retryAfterMs</code> available for backoff.</li>
+      <li><strong>Delivery semantics:</strong> watch delivery is at-least-once. Agents must dedupe by <code>{ planId, sequence }</code>, then claim/ack comments through the queue endpoints before acting.</li>
+      <li><strong>CLI output:</strong> <code>--json</code> prints each event as one NDJSON object with <code>source: "sse"</code> or <code>source: "poll"</code>. <code>--format browser-comment</code> prints only <code>browser.comment.v1</code> envelopes for host conversation adapters.</li>
+    </ul>
+
+    <h3>Claim request precedence</h3>
+    <ul>
+      <li><code>mode="one"</code> requires no <code>commentIds</code>; it claims the oldest pending comment by sequence, respecting optional <code>limit=1</code>.</li>
+      <li><code>mode="selected"</code> requires non-empty <code>commentIds</code>; <code>limit</code> is invalid and returns <code>400 validation_failed</code>.</li>
+      <li><code>mode="bulk"</code> rejects <code>commentIds</code>; it claims up to <code>limit</code> pending comments, default 50, max 200, ordered by sequence.</li>
+      <li>Expired claims are released transactionally before each claim query. Active claims held by another agent are skipped for bulk and returned as <code>409 claim_conflict</code> for selected mode.</li>
+    </ul>
+
+    <h3>Comment payload</h3>
+    <pre><code>{
+  "id": "cmt_01...",
+  "planId": "plan_01...",
+  "versionId": "ver_01...",
+  "sequence": 42,
+  "status": "pending",
+  "body": "Clarify how claim leases expire here.",
+  "anchorType": "dom",
+  "anchorState": "mapped",
+  "anchor": {
+    "planNodeId": "phase-p4-queue-streaming",
+    "cssSelector": "section#phase-p4 h2",
+    "domPath": "html/body/main/section[14]/h2[1]",
+    "xpath": "/html/body/main/section[14]/h2[1]",
+    "textQuote": { "exact": "Phase 4 - Implement comment queue", "prefix": "", "suffix": "" },
+    "headingPath": ["Phase-by-phase execution plan", "Phase 4 - Implement comment queue, streaming, and CLI watch"],
+    "rect": { "x": 84, "y": 1220, "width": 640, "height": 38 },
+    "viewport": { "width": 1440, "height": 1000 },
+    "textPreview": "Phase 4 - Implement comment queue, streaming, and CLI watch",
+    "outerHtmlPreview": "&lt;h2 id=\"phase-p4\" data-plan-node-id=\"phase-p4\"&gt;Phase 4...&lt;/h2&gt;"
+  },
+  "screenshotAssetId": "asset_01...",
+  "createdBy": { "type": "reviewer", "displayName": "Ann" },
+  "conversationPayload": {
+    "type": "browser.comment.v1",
+    "conversationHint": {
+      "mode": "append-to-active-thread",
+      "title": "Comment 42 on Phase 4 - Implement comment queue"
+    },
+    "evidence": {
+      "reviewUrl": "http://127.0.0.1:4317/p/plan_01...",
+      "markerNumber": 42,
+      "screenshotAssetId": "asset_01..."
+    }
+  },
+  "agentResponse": null,
+  "createdAt": "2026-05-30T00:00:00Z",
+  "claim": null
+}</code></pre>
+    <p>Text-range comments use <code>anchorType: "text_range"</code> and add <code>{ startContainerSelector, startOffset, endContainerSelector, endOffset, selectedText, clientRects: [{ x, y, width, height }] }</code> inside <code>anchor</code>, alongside the surrounding DOM selector/context fields. Image comments use <code>anchorType: "image"</code> and add <code>{ imageAssetId, sourceUrl, imageHash, naturalSize: { width, height }, normalizedPoint?: { x, y }, normalizedRect?: { x, y, width, height }, zoomState?: { scale, panX, panY } }</code> inside <code>anchor</code>.</p>
+
+    <h3>SSE event contract</h3>
+    <pre><code>id: 43
+event: comment.created
+data: {"sequence":43,"planId":"plan_01...","commentId":"cmt_01...","comment":{...}}</code></pre>
+    <ul>
+      <li><code>comment.created</code>: new pending comment available, including <code>conversationPayload.type = "browser.comment.v1"</code> so the host adapter can surface the browser comment in the active conversation.</li>
+      <li><code>comment.claimed</code>: agent claimed comment; review UI can show “agent reviewing.”</li>
+      <li><code>comment.acknowledged</code>: agent consumed comment and may include <code>agentResponse</code> metadata for the review UI sidebar.</li>
+      <li><code>comment.resolved</code>: comment closed, with resolution note and optional agent response summary.</li>
+      <li><code>comment.released</code>: claim released or lease expired.</li>
+      <li><code>plan.version.registered</code>: agent uploaded a new plan version.</li>
+      <li><code>heartbeat</code>: every 15 seconds with <code>{ latestSequence, serverTime }</code>.</li>
+    </ul>
+
+    <h3>Conversation bridge host contract</h3>
+    <p>The daemon and CLI expose a host-neutral bridge; they do not directly control proprietary chat UIs. <code>plan-review watch --format browser-comment</code> prints one <code>browser.comment.v1</code> envelope per pending comment. <code>plan-review watch --conversation-out ~/.plan-reviewer/host-bridge/inbox.ndjson</code> appends the same envelopes to a durable file for Codex/Claude/Pi host adapters. Host adapters are responsible for inserting that envelope into the active conversation. The MVP includes a serializer/parser and a fixture adapter test; if a host lacks an active-thread injection API, the adapter must fail with an actionable message and leave the comment pending.</p>
+
+    <h3>CLI output contracts</h3>
+    <ul>
+      <li><code>plan-review register path.html --json</code> prints the register response JSON and exits 0. Human mode prints <code>Plan ID</code>, <code>Index URL</code>, <code>Review URL</code>, and <code>Watch command</code>. Registration uploads or references relative image assets found in the plan.</li>
+      <li><code>plan-review index --json</code> prints the <code>GET /api/plans</code> response JSON. Human mode prints the index URL and a compact table of registered plans.</li>
+      <li><code>plan-review watch plan_123 --json</code> opens the SSE watch endpoint and prints one newline-delimited JSON event per line, reconnecting with saved sequence state. <code>--mode queue</code> prints only queue-relevant comment events, <code>--format browser-comment</code> prints the <code>conversationPayload</code> envelope, <code>--conversation-out &lt;path&gt;</code> appends those envelopes to a durable NDJSON host-bridge inbox, <code>--once</code> exits after the first matching event or timeout, and <code>--timeout &lt;ms&gt;</code> exits non-zero when no event arrives in time. If SSE is unavailable, 10-second REST polling against <code>/api/plans/:planId/events/poll</code> emits the same event objects with <code>"source":"poll"</code>; SSE events use <code>"source":"sse"</code>.</li>
+      <li><code>plan-review queue claim plan_123 --all --json</code> maps to <code>POST /api/plans/:planId/comments/claim</code> with <code>{ "mode": "bulk" }</code>, prints the claim response JSON, and exits 0 when zero or more comments are claimed. <code>--one</code> maps to <code>{ "mode": "one" }</code>; <code>--ids cmt_1,cmt_2</code> maps to <code>{ "mode": "selected", "commentIds": [...] }</code>.</li>
+      <li><code>plan-review ack cmt_123 --claim claim_123 --json</code> and <code>plan-review resolve cmt_123 --json</code> print their endpoint response JSON and are idempotent. Agent ack without <code>--claim</code> exits non-zero and prints the <code>claim_required</code> next action.</li>
+    </ul>
+  </section>
+
+  <section id="acceptance">
+    <h2>Acceptance criteria</h2>
+    <ol>
+      <li>Homebrew installs the daemon/CLI from this repo checkout as a local tap with <code>brew tap local/ai-configs &lt;repo-checkout-path&gt;</code> and <code>brew install local/ai-configs/plan-reviewer</code>, and <code>brew services start plan-reviewer</code> runs it persistently through launchctl on <code>0.0.0.0:4317</code> by default.</li>
+      <li>Agents can register an HTML plan from <code>thoughts/plans</code> via CLI and REST, receiving a stable plan ID, index URL, and review URL.</li>
+      <li>The index at <code>GET /</code> lists registered plans across repos with search/filtering, latest metadata, status counts, and links to open/comment on each plan.</li>
+      <li>The review URL renders the plan in a dark-compatible review shell without executing arbitrary plan-authored JavaScript.</li>
+      <li>Reviewers can select a DOM element/range or image/image region in the rendered plan, write a comment, and see an anchored marker, selected-region highlight, comment composer, and sidebar entry matching the UX in <a href="#review-ux-loop">Review UX and agent response loop</a>.</li>
+      <li>Each comment captures enough context for an agent to locate the affected plan content without looking at the browser: selectors, DOM path, heading path, quote, coordinates, marker screenshot, trimmed HTML/text context, and image coordinates/assets for image comments.</li>
+      <li>Images render from safe copied assets or safe data/blob URLs, support zoom/pan in a popover/lightbox, and support whole-image, point, and rectangle comments.</li>
+      <li>Agents can monitor comments near-real-time through a documented open SSE watch connection, receive a <code>browser.comment.v1</code> payload through stdout or a host-bridge NDJSON inbox for active chat insertion, and recover missed events through sequence replay or the documented REST polling fallback. WebSockets are not required for MVP.</li>
+      <li>Multiple comments queue durably. Agents can claim one comment, selected comments, or all pending comments for a single plan; repo-wide processing uses <code>GET /api/agent/queue?repoKey=...</code> followed by per-plan grouped claims.</li>
+      <li>Unacked claimed comments return to pending after a lease timeout; duplicate delivery is safe because ack is idempotent.</li>
+      <li>After claiming the comment and responding in the main conversation through a host adapter, an agent can ack or resolve the comment with response summary, changed files, run metadata, and optional commit SHA; the review UI shows that metadata on the anchored marker/sidebar entry.</li>
+      <li>CLI and REST expose equivalent registration, queue, claim, ack, resolve, and watch capabilities.</li>
+      <li>Errors for ambiguous repo inference, invalid HTML, missing image assets, unavailable service, and stale anchors include exact next steps.</li>
+      <li>Docs explain how agents should generate HTML plans with stable IDs and how to register/watch them.</li>
+    </ol>
+  </section>
+
+  <section id="bdd">
+    <h2>BDD scenarios</h2>
+    <h3>B1 - Golden-path registration</h3>
+    <p><strong>Given</strong> the Homebrew service is running through launchctl on <code>0.0.0.0:4317</code><br />
+    <strong>And</strong> an agent is in a git repo with <code>thoughts/plans/service-plan.html</code><br />
+    <strong>When</strong> it runs <code>plan-review register thoughts/plans/service-plan.html</code><br />
+    <strong>Then</strong> the CLI infers repo/branch/commit/path, uploads the plan and relative image assets, prints the index URL, prints a review URL, and prints the matching watch command.</p>
+
+    <h3>B2 - DOM-anchored comment creation</h3>
+    <p><strong>Given</strong> a reviewer opens the service index and chooses a plan<br />
+    <strong>When</strong> they select a phase card and submit a comment<br />
+    <strong>Then</strong> the service persists the comment with multiple selectors and displays the selected-region outline, marker, composer result, and sidebar entry anchored to the selected element.</p>
+
+    <h3>B3 - Agent wake-up stream and conversation payload</h3>
+    <p><strong>Given</strong> an agent is running <code>plan-review watch plan_123 --mode queue</code><br />
+    <strong>When</strong> a reviewer creates a comment<br />
+    <strong>Then</strong> the CLI receives a <code>comment.created</code> event within the p95 under-1-second local stream latency target and prints structured JSON with <code>conversationPayload.type = "browser.comment.v1"</code> suitable for a host adapter to append the browser comment to the active agent conversation.</p>
+
+    <h3>B4 - Bulk processing</h3>
+    <p><strong>Given</strong> five pending comments exist for a plan<br />
+    <strong>When</strong> the agent runs <code>plan-review queue claim plan_123 --all</code><br />
+    <strong>Then</strong> the service marks all five as claimed by that agent lease and returns them in deterministic sequence order.</p>
+
+    <h3>B5 - Disconnect recovery</h3>
+    <p><strong>Given</strong> an agent stream disconnects after event sequence 10<br />
+    <strong>When</strong> it reconnects with <code>Last-Event-ID: 10</code> or CLI state containing sequence 10<br />
+    <strong>Then</strong> the service replays later events and the agent does not lose comments.</p>
+
+    <h3>B6 - Lease expiry</h3>
+    <p><strong>Given</strong> an agent claims a comment but never acks it<br />
+    <strong>When</strong> the 5-minute claim lease expires<br />
+    <strong>Then</strong> the comment returns to pending and a future queue claim can receive it again.</p>
+
+    <h3>B7 - Stale anchor after plan update</h3>
+    <p><strong>Given</strong> a comment was anchored to an older plan version<br />
+    <strong>When</strong> the agent registers a newer version where the exact DOM node no longer exists<br />
+    <strong>Then</strong> the UI shows the comment as stale/unmapped and still exposes the original captured context to the agent.</p>
+
+    <h3>B8 - Fail-closed unsafe HTML</h3>
+    <p><strong>Given</strong> a plan contains inline scripts or external active content<br />
+    <strong>When</strong> the service prepares the review render<br />
+    <strong>Then</strong> it blocks arbitrary execution by default and reports which content was blocked or why rendering failed.</p>
+
+    <h3>B9 - Image zoom and image-region comment</h3>
+    <p><strong>Given</strong> a registered plan includes a relative image asset<br />
+    <strong>When</strong> a reviewer clicks the image, zooms in, selects a rectangle, and submits a comment<br />
+    <strong>Then</strong> the service stores an image comment with image asset identity, natural dimensions, normalized rectangle coordinates, zoom state, and surrounding DOM context.</p>
+
+    <h3>B10 - Browsable multi-repo index</h3>
+    <p><strong>Given</strong> plans from two repos have been registered<br />
+    <strong>When</strong> a reviewer opens <code>http://&lt;host&gt;:4317/</code><br />
+    <strong>Then</strong> the index groups plans by repo, shows latest version and comment counts, supports filtering, and links to each review page.</p>
+
+    <h3>B11 - Agent response reflected in review UI</h3>
+    <p><strong>Given</strong> a browser comment has been surfaced in the active agent conversation and claimed with <code>plan-review queue claim plan_123 --ids cmt_123 --json</code><br />
+    <strong>When</strong> the agent updates the plan and calls <code>plan-review ack cmt_123 --claim claim_123 --note "handled in plan update" --json</code> with response metadata<br />
+    <strong>Then</strong> the main conversation contains the agent response, and the review UI shows the marker/sidebar item as acknowledged with the response summary, changed files, run metadata, and optional commit SHA.</p>
+  </section>
+
+  <section id="phases">
+    <h2>Phase-by-phase execution plan</h2>
+
+    <section id="phase-p1">
+      <h3>Phase 1 - Bootstrap package, Homebrew, and launchctl service</h3>
+      <h4>End State</h4>
+      <p><code>tools/plan-reviewer</code> contains a buildable TypeScript CLI/API skeleton, and this repo contains Homebrew/launchctl install wiring for a persistent daemon that defaults to <code>0.0.0.0:4317</code>.</p>
+      <h4>Tests first</h4>
+      <ul>
+        <li>Schema tests for plan registration, plan index, DOM/image comment anchors, queue claim, ack, and SSE event payloads.</li>
+        <li>CLI argument parsing tests for <code>serve</code>, <code>register</code>, <code>index</code>, <code>watch</code>, <code>queue claim</code>, <code>ack</code>, and <code>resolve</code>.</li>
+        <li>Install tests or fixture checks for <code>Formula/plan-reviewer.rb</code>, asserting service label, <code>keep_alive true</code>, default host <code>0.0.0.0</code>, port <code>4317</code>, database path, and log paths.</li>
+        <li>Dependency smoke tests that import Fastify, Zod, better-sqlite3, parse5, sanitize-html, commander, <code>@washi-ui/core</code>, <code>@medv/finder</code>, <code>html2canvas</code>, and Playwright from the package.</li>
+      </ul>
+      <h4>Work</h4>
+      <ul>
+        <li>Create <code>tools/plan-reviewer/package.json</code>, <code>tsconfig.json</code>, source layout, Bun lockfile, and Node test wiring.</li>
+        <li>Install and wire the locked dependencies: Fastify, Zod, better-sqlite3, parse5, sanitize-html, commander, <code>@washi-ui/core</code>, <code>@medv/finder</code>, and Playwright.</li>
+        <li>Add package scripts for <code>test</code>, <code>test:e2e</code>, <code>test:fixtures</code>, <code>build</code>, and <code>dev</code>, runnable via <code>bun run</code>.</li>
+        <li>Define shared TypeScript schemas and OpenAPI-compatible route contracts for every endpoint in this plan.</li>
+        <li>Add a minimal health endpoint, config resolution, CLI <code>--help</code>, and <code>serve</code> defaults for <code>0.0.0.0:4317</code>.</li>
+        <li>Add <code>Formula/plan-reviewer.rb</code> with a Homebrew service block matching the locked persistent-install contract; include uninstall/caveat text for stopping the service and deleting <code>~/.plan-reviewer</code> data manually if desired.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <ul><li><code>tools/plan-reviewer/**</code></li><li><code>Formula/plan-reviewer.rb</code></li></ul>
+      <h4>Verify</h4>
+      <pre><code>cd tools/plan-reviewer
+bun install
+bun run test
+bun run build
+node dist/bin/plan-review.js --help
+cd ../..
+brew tap local/ai-configs &lt;repo-checkout-path&gt;
+brew install local/ai-configs/plan-reviewer
+brew services start plan-reviewer
+brew services list | grep plan-reviewer
+brew services stop plan-reviewer</code></pre>
+    </section>
+
+    <section id="phase-p2">
+      <h3>Phase 2 - Register plans and build browsable index</h3>
+      <h4>End State</h4>
+      <p>An agent can register a local HTML plan with image assets, the service persists versioned metadata/content, the index lists registered plans across repos, and the review shell renders selected plans safely.</p>
+      <h4>Tests first</h4>
+      <ul>
+        <li>Integration test for unauthenticated <code>POST /api/plans/register</code> idempotent update behavior.</li>
+        <li>Index tests for <code>GET /</code> and <code>GET /api/plans</code> grouping by repo, filtering, sorting, latest metadata, and comment-count badges.</li>
+        <li>Renderer tests for blocking active content, applying iframe/CSP metadata, copying safe relative image assets, reporting missing images, and preserving readable plan structure.</li>
+        <li>CLI test for service URL config resolution, git metadata inference, image asset discovery, and ambiguous repo failure.</li>
+      </ul>
+      <h4>Work</h4>
+      <ul>
+        <li>Implement SQLite migrations for repos, plans, versions, plan assets, comments, comment events, claims, and consumer state.</li>
+        <li>Implement CLI registration with service discovery, git metadata inference, relative image asset discovery, and explicit overrides.</li>
+        <li>Store uploaded plan content by hash, copy safe image assets by content hash, and create a sanitized render artifact with service-owned metadata and stable node IDs.</li>
+        <li>Serve <code>/</code> plan index, <code>/api/plans</code> JSON index, <code>/assets/:assetId</code> image assets, and <code>/p/:planId</code> review shell plus sandboxed plan iframe.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <ul><li><code>tools/plan-reviewer/src/server/**</code></li><li><code>tools/plan-reviewer/src/cli/**</code></li><li><code>tools/plan-reviewer/src/storage/**</code></li><li><code>tools/plan-reviewer/src/render/**</code></li></ul>
+      <h4>Verify</h4>
+      <pre><code>cd tools/plan-reviewer
+bun run test
+bun run build
+# Start this with the process tool, then run register/index checks in a separate shell; kill the process after verification:
+node dist/bin/plan-review.js serve --db /tmp/plan-reviewer.sqlite --host 0.0.0.0 --port 4317
+node dist/bin/plan-review.js register ../../thoughts/plans/html-plan-review-service.html --url http://127.0.0.1:4317 --json
+node dist/bin/plan-review.js index --url http://127.0.0.1:4317 --json
+curl -fsS http://127.0.0.1:4317/ >/tmp/plan-reviewer-index.html</code></pre>
+    </section>
+
+    <section id="phase-p3">
+      <h3>Phase 3 - Add DOM and image annotation UI</h3>
+      <h4>End State</h4>
+      <p>Reviewers can click/select plan DOM elements and images, zoom/pan images in a lightbox, create comments on DOM nodes or image regions, and see anchored markers/sidebar entries.</p>
+      <h4>Tests first</h4>
+      <ul>
+        <li>Browser/E2E test opens the index, navigates to a registered plan, selects an element, submits a comment, and verifies persisted DOM anchor fields.</li>
+        <li>Browser/E2E test selects a text range and verifies <code>anchorType: "text_range"</code>, start/end offsets, selected text, and client rects.</li>
+        <li>Browser/E2E test opens an image zoom lightbox, zooms/pans, selects a point and rectangle, submits comments, and verifies persisted image anchor fields.</li>
+        <li>Browser/E2E test verifies the selected-region outline, numbered marker, comment composer, sidebar entry, and marker screenshot asset match the UX contract in <a href="#review-ux-loop">Review UX and agent response loop</a>.</li>
+        <li>Browser/E2E test asserts parent-owned iframe selection under <code>sandbox="allow-same-origin"</code>: <code>elementFromPoint</code> coordinate translation, iframe scroll/resize marker reflow, and no iframe script execution.</li>
+        <li>Unit tests for selector generation, heading-path extraction, text quote capture, image-coordinate normalization, and context truncation.</li>
+      </ul>
+      <h4>Work</h4>
+      <ul>
+        <li>Implement review shell UI with <code>@washi-ui/core</code> mounted over the sandboxed iframe from the parent document; no script runs inside the iframe.</li>
+        <li>Generate stable <code>data-plan-node-id</code> values from existing IDs or heading/content hashes with deterministic collision suffixes.</li>
+        <li>Use parent-owned iframe DOM access plus finder to capture CSS selector, DOM path, XPath-like path, heading path, quote, rect, viewport, text, text-range offsets, and trimmed outerHTML.</li>
+        <li>Add image affordances: image hover/click target, zoom lightbox/popover, fit/zoom/pan controls, whole-image comment, point comment, and rectangle comment.</li>
+        <li>Use parent-owned <code>html2canvas</code> capture for marker screenshots; persist DOM/text-range/image comments, screenshot assets, selected-region highlights, numbered sidebar/marker entries, and status labels.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <ul><li><code>tools/plan-reviewer/src/client/**</code></li><li><code>tools/plan-reviewer/src/anchors/**</code></li></ul>
+      <h4>Verify</h4>
+      <pre><code>cd tools/plan-reviewer
+bun run test
+bun run test:e2e -- --grep "dom annotation|image annotation|plan index"</code></pre>
+    </section>
+
+    <section id="phase-p4">
+      <h3>Phase 4 - Implement comment queue, streaming, and CLI watch</h3>
+      <h4>End State</h4>
+      <p>Agents receive near-real-time comment notifications and can recover missed events.</p>
+      <h4>Tests first</h4>
+      <ul>
+        <li>Integration test for the SSE watch endpoint, monotonic event sequence creation, and <code>Last-Event-ID</code> replay.</li>
+        <li>CLI watch test using a test server that emits comment events over SSE.</li>
+        <li>Conversation payload contract test asserting comment events include title, summary, selected text, review URL, marker number, selector, and screenshot asset reference.</li>
+        <li>Host-bridge inbox test asserting <code>plan-review watch --conversation-out</code> appends valid <code>browser.comment.v1</code> NDJSON envelopes without losing sequence state.</li>
+        <li>Local latency measurement test that emits 50 committed comments through a fixture server and asserts p95 commit-to-watch delivery under 1000 ms on localhost.</li>
+        <li>Fallback polling test for <code>GET /api/plans/:planId/events/poll</code> when SSE fails.</li>
+      </ul>
+      <h4>Work</h4>
+      <ul>
+        <li>Add comment event log, SSE watch endpoint, heartbeat handling, <code>Last-Event-ID</code> replay, and REST polling fallback endpoint.</li>
+        <li>Implement CLI <code>watch</code> with reconnect, sequence persistence, JSON output, and human-readable output modes.</li>
+        <li>Build the <code>browser.comment.v1</code> conversation bridge payload and <code>--conversation-out</code> durable NDJSON handoff for each comment event so host clients can insert the browser comment into the active agent thread.</li>
+        <li>Add <code>GET /api/agent/queue</code> for pending queue snapshots across repos/plans.</li>
+        <li>Make reviewer UI subscribe to the same event stream for status changes.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <ul><li><code>tools/plan-reviewer/src/server/events*</code></li><li><code>tools/plan-reviewer/src/cli/watch*</code></li></ul>
+      <h4>Verify</h4>
+      <pre><code>cd tools/plan-reviewer
+bun run test
+bun run test:fixtures -- --scenario seeded-comment-stream
+bun run test:fixtures -- --scenario sse-latency --samples 50 --p95-ms 1000
+node dist/bin/plan-review.js watch &lt;plan-id&gt; --url http://127.0.0.1:4317 --json --once --timeout 5000</code></pre>
+    </section>
+
+    <section id="phase-p5">
+      <h3>Phase 5 - Add agent action lifecycle and bulk processing</h3>
+      <h4>End State</h4>
+      <p>Agents can claim, ack, resolve, and bulk-process comments with durable lease semantics.</p>
+      <h4>Tests first</h4>
+      <ul>
+        <li>Queue tests for single claim, selected claim, bulk claim, idempotent ack, resolve, and lease expiry.</li>
+        <li>Concurrency test proving two agents cannot hold the same active claim simultaneously.</li>
+        <li>Ack/resolve tests proving ack requires an active claim and agent response metadata is stored and returned to the review UI.</li>
+      </ul>
+      <h4>Work</h4>
+      <ul>
+        <li>Add claim lease fields and queue status transitions.</li>
+        <li>Implement REST endpoints and CLI commands for claim/ack/resolve/release.</li>
+        <li>Display queue/agent status in review UI.</li>
+        <li>Attach optional agent action metadata: run ID, handoff URL/path, commit SHA, changed files, response summary, or resolution note.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <ul><li><code>tools/plan-reviewer/src/queue/**</code></li><li><code>tools/plan-reviewer/src/cli/queue*</code></li></ul>
+      <h4>Verify</h4>
+      <pre><code>cd tools/plan-reviewer
+bun run test
+bun run test:fixtures -- --scenario queue-claim-ack
+node dist/bin/plan-review.js queue claim &lt;plan-id&gt; --url http://127.0.0.1:4317 --all --json
+node dist/bin/plan-review.js ack &lt;comment-id&gt; --url http://127.0.0.1:4317 --claim &lt;claim-id&gt; --note "handled in plan update" --json</code></pre>
+    </section>
+
+    <section id="phase-p6">
+      <h3>Phase 6 - Dogfood docs and future security seams</h3>
+      <h4>End State</h4>
+      <p>The no-auth MVP is easy to install with Homebrew, runs persistently via launchctl, is documented for agents that generate HTML/image-rich plans, and clearly marks security hardening as future work.</p>
+      <h4>Tests first</h4>
+      <ul>
+        <li>Install docs smoke test or scripted examples for Homebrew install, <code>brew services start</code>, register, index, review, image comment, and watch workflow.</li>
+        <li>Error-guidance tests for invalid HTML, missing image assets, unavailable service, stale anchors, and ambiguous repo metadata.</li>
+        <li>Startup-output test that warns when binding to <code>0.0.0.0</code> without authentication.</li>
+      </ul>
+      <h4>Work</h4>
+      <ul>
+        <li>Document Homebrew installation, launchctl persistence, default bind address, local-network exposure, and how to override host/port/db path.</li>
+        <li>Document recommended HTML plan conventions: stable IDs, semantic sections, dark mode, relative image assets, image dimensions/alt text, no required inline JS, and review-friendly components.</li>
+        <li>Add an agent prompt snippet showing how to register a plan, browse the index, and watch for comments.</li>
+        <li>Add explicit future-security seams in docs/code comments without implementing auth: where bearer tokens, private shares, or network restrictions would later plug in.</li>
+        <li>Dogfood the full flow with this plan and at least one image-rich fixture plan; record low-risk follow-ups separately instead of expanding MVP scope.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <ul><li><code>tools/plan-reviewer/README.md</code></li><li>Optional prompt/skill docs if the workflow is wired into Pi/Claude/Codex after MVP validation.</li></ul>
+      <h4>Verify</h4>
+      <pre><code>cd tools/plan-reviewer
+bun run test
+bun run build
+# plus manual dogfood: register this plan, open the index, create DOM/text/image comments, bridge one browser comment into the active agent conversation, claim/ack it from CLI</code></pre>
+    </section>
+  </section>
+
+  <section id="verification-strategy">
+    <h2>Verification strategy</h2>
+    <ul>
+      <li>Unit tests for schema validation, selector extraction, queue state transitions, and error text.</li>
+      <li>API integration tests against temporary SQLite databases.</li>
+      <li>CLI tests using local test servers and fixture repos, with parity assertions that compare CLI output JSON to direct REST responses for register, index, claim, ack, resolve, and queue list.</li>
+      <li>Browser/E2E tests for plan index, DOM/text-range selection visual states, image display, image zoom/pan, image-region comments, markers, composers, marker screenshots, sidebar entries, and no-scripts iframe selection behavior.</li>
+      <li>Homebrew/launchctl checks for default <code>0.0.0.0:4317</code> service configuration.</li>
+      <li>Manual dogfood: register this HTML plan plus an image-rich fixture, annotate at least one DOM section, one text range, and one image, watch the SSE stream, surface the browser comment through the host-bridge inbox into the active agent conversation, claim and ack the comments, and verify the review UI shows the agent response summary.</li>
+    </ul>
+
+    <h3>Test coverage matrix</h3>
+    <table>
+      <thead><tr><th>Acceptance / scenario</th><th>Planned evidence</th></tr></thead>
+      <tbody>
+        <tr><td>Install/service + B1</td><td>Homebrew formula/plist checks plus launchctl smoke verifying default <code>0.0.0.0:4317</code>.</td></tr>
+        <tr><td>Registration/index + B1/B10</td><td>CLI + API registration integration tests with git metadata inference and index rendering/filtering tests.</td></tr>
+        <tr><td>Safe render + B8</td><td>Renderer/sandbox tests plus browser smoke test.</td></tr>
+        <tr><td>DOM/text comments + B2</td><td>E2E DOM and text-range annotation tests, visual-state assertions for outline/marker/composer/sidebar/screenshot, and selector/context unit tests.</td></tr>
+        <tr><td>Image comments + B9</td><td>E2E image display, zoom, pan, point/rectangle comment tests and normalized-coordinate unit tests.</td></tr>
+        <tr><td>Realtime + B3/B5</td><td>SSE replay integration tests, CLI watch reconnect tests, localhost p95 latency fixture, host-bridge inbox tests, and conversation payload contract tests.</td></tr>
+        <tr><td>Queue + B4/B6/B11</td><td>Queue claim/ack/lease/concurrency tests plus ack/resolve response metadata tests.</td></tr>
+        <tr><td>CLI/REST parity</td><td>Parity tests that exercise equivalent CLI and REST paths.</td></tr>
+        <tr><td>Error guidance</td><td>Error-guidance assertions for representative failures.</td></tr>
+        <tr><td>Docs/dogfood</td><td>README plus dogfood registration of this plan and an image-rich fixture.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="delivery-order">
+    <h2>Delivery order</h2>
+    <ol>
+      <li>Package skeleton, Homebrew formula, and launchctl service.</li>
+      <li>Registration, storage, plan index, image asset handling, and safe rendering.</li>
+      <li>Reviewer UI with DOM and image anchoring, including selection visuals, composer, marker, and sidebar states.</li>
+      <li>SSE event stream, CLI watch, and conversation bridge payload for host agent clients.</li>
+      <li>Queue claim/ack/resolve lifecycle with agent response metadata shown in the review UI.</li>
+      <li>Docs, dogfood workflow, and future security seams.</li>
+    </ol>
+  </section>
+
+  <section id="non-goals">
+    <h2>Non-goals</h2>
+    <ul>
+      <li>General-purpose website QA or bug reporting outside registered HTML plan files.</li>
+      <li>Realtime collaborative editing of the plan document.</li>
+      <li>A standalone chat product inside the review service; agent replies happen in the host conversation and are summarized back into the review UI.</li>
+      <li>Replacing existing markdown inline plan review commands in Phase 1.</li>
+      <li>Internet-hosted public SaaS plan hosting; the MVP is a local-network daemon and intentionally has no auth.</li>
+      <li>Bearer tokens, private share links, SSO, OAuth, or enterprise administration in the initial release.</li>
+      <li>Guaranteeing exactly-once event delivery; the queue contract is at-least-once with idempotent ack.</li>
+      <li>Perfect automatic remapping of anchors across arbitrary plan rewrites.</li>
+    </ul>
+  </section>
+
+  <section id="risks">
+    <h2>Risks and mitigations</h2>
+    <table>
+      <thead><tr><th>Risk</th><th>Mitigation</th></tr></thead>
+      <tbody>
+        <tr><td>Unsafe plan HTML executes arbitrary code.</td><td>Sandbox iframe, CSP, block plan-authored scripts by default, inject only service overlay.</td></tr>
+        <tr><td>DOM anchors break after plan regeneration.</td><td>Capture multiple selectors and original context; show stale/unmapped status instead of pretending confidence.</td></tr>
+        <tr><td>Agents miss comments while offline.</td><td>Durable event log, sequence replay, REST queue snapshots, claim leases.</td></tr>
+        <tr><td>No-auth service is exposed on the network.</td><td>Keep this intentional for MVP, bind to <code>0.0.0.0</code> by default per product requirement, print a startup warning, and document host override for local-only use.</td></tr>
+        <tr><td>Reviewers accidentally comment on decorative markup.</td><td>Overlay should bubble to nearest semantic element and display selected context before submit.</td></tr>
+        <tr><td>Browser comments are disconnected from the active agent conversation.</td><td>Every comment event includes a conversation bridge payload; ack/resolve stores response metadata that the review UI can display even though the full reply lives in chat.</td></tr>
+        <tr><td>Image anchors drift after resize or reload.</td><td>Store natural dimensions plus normalized point/rectangle coordinates and recompute display positions from current rendered dimensions.</td></tr>
+        <tr><td>CLI and REST drift.</td><td>Generate CLI client behavior from shared schemas/contracts and test both surfaces against the same fixtures.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="dependencies">
+    <h2>Locked dependencies</h2>
+    <ul>
+      <li><strong>HTTP:</strong> Fastify.</li>
+      <li><strong>Schema validation:</strong> Zod.</li>
+      <li><strong>SQLite:</strong> better-sqlite3 behind a storage repository interface.</li>
+      <li><strong>HTML parsing/sanitization:</strong> parse5 plus sanitize-html.</li>
+      <li><strong>CLI:</strong> commander, matching existing <code>tools/ltui</code>.</li>
+      <li><strong>Browser testing:</strong> Playwright for UI selection flows.</li>
+      <li><strong>Overlay/annotation:</strong> use <code>@washi-ui/core</code> for iframe pin/comment overlay mechanics and <code>@medv/finder</code> for robust CSS selector generation. Use <code>html2canvas</code> from the parent review shell for marker screenshots. Implement only the service-specific adapter, anchor enrichment, and API wiring under <code>src/client</code>.</li>
+    </ul>
+    <h3>Overlay dependency evaluation</h3>
+    <table>
+      <thead><tr><th>Candidate</th><th>Decision</th><th>Reason</th></tr></thead>
+      <tbody>
+        <tr><td><code>@washi-ui/core</code></td><td>Use</td><td>Verified with <code>npm view @washi-ui/core</code> as a published framework-agnostic HTML commenting engine; pair with service anchor enrichment for agent context.</td></tr>
+        <tr><td><code>@medv/finder</code></td><td>Use</td><td>Verified with <code>npm view @medv/finder</code>; focused maintained CSS selector generator, avoiding custom selector-generation logic.</td></tr>
+        <tr><td><code>html2canvas</code></td><td>Use</td><td>Verified with <code>npm view html2canvas</code>; supports parent-owned screenshot capture without executing plan-authored iframe scripts.</td></tr>
+        <tr><td><code>agent-ui-annotation</code></td><td>Do not use for MVP</td><td>Verified published package, but it assumes a web-page annotation toolbar model rather than the no-scripts parent-owned iframe contract.</td></tr>
+        <tr><td><code>@vybe-adk/dom-element-selector</code></td><td>Do not use for MVP</td><td>Verified published package, but it targets same-tree React hook selection rather than a parent-controlled sandboxed iframe review shell.</td></tr>
+        <tr><td><code>@kendew-agency/react-feedback-layer</code></td><td>Do not use for MVP</td><td>Verified published package; comment lifecycle UI is useful, but it does not provide the iframe anchoring and multi-selector payload required for agent wake-up context.</td></tr>
+      </tbody>
+    </table>
+    <p>Execution may add small support libraries only when they do not change these architecture decisions and are documented in the implementation notes.</p>
+  </section>
+
+  <section id="decisions-log">
+    <h2>Decisions / Deviations log</h2>
+    <ul>
+      <li>2026-05-30: Chose HTML plan artifact for this plan to dogfood the requested plan format and comply with dark-mode HTML plan guidance.</li>
+      <li>2026-05-30: Chose SSE over WebSockets for MVP because comment notifications are primarily one-way server-to-agent/browser events, while writes remain simple REST calls.</li>
+      <li>2026-05-30: Chose SQLite for MVP storage to keep local/self-hosted dogfooding small while preserving a storage abstraction for a later hosted Postgres deployment.</li>
+      <li>2026-05-30: Locked at-least-once queue delivery with claim/ack/lease semantics instead of exactly-once delivery because it is simpler, recoverable, and agent-friendly.</li>
+      <li>2026-05-30: Integrated first Codex and Claude Code review blockers by locking dependencies, deployment/discovery, render safety policy, concrete API payloads, queue numerics, SSE replay semantics, claim precedence, CLI output shapes, and runnable verification gates.</li>
+      <li>2026-05-30: Integrated second Codex blockers by defining a no-scripts parent-owned iframe overlay contract, overlay dependency evaluation with <code>@washi-ui/core</code>/<code>@medv/finder</code> reuse, and Bun-based verification commands aligned with the existing tools package pattern.</li>
+      <li>2026-05-30: Superseded the reviewed auth-heavy MVP after user clarification: initial service is now no-auth, Homebrew-installed from this repo, launchctl-persistent, bound to <code>0.0.0.0</code> by default, index-first, and includes image display, zoom, and image-region comments.</li>
+      <li>2026-05-31: Added the review UX visual contract and main-conversation bridge so browser comments can wake the agent, be answered in the active chat through a host adapter, and reflect response metadata back in the review UI.</li>
+      <li>2026-05-31: Integrated Codex/Claude execution-readiness blockers by specifying Homebrew formula layout, claim-required ack semantics, text-range anchors, marker screenshot storage, reviewer identity defaulting, anchor-state mapping, host-bridge NDJSON handoff, CLI/API flag mappings, latency tests, and dependency verification evidence.</li>
+      <li>2026-05-31: Execution discovered Homebrew 5.1 rejects arbitrary local formula paths outside taps; the install contract was narrowed to a local tap install from this repo checkout while preserving the same formula and launchctl service behavior.</li>
+      <li>2026-05-31: Second-pass Codex and Claude reviews both returned <code>Execution-ready</code> with no blocking findings; only low-risk implementation notes remained.</li>
+      <li>2026-05-31: Third-pass Codex and Claude reviews after the agent watch contract update both returned <code>Execution-ready</code> with no blocking findings.</li>
+    </ul>
+  </section>
+</main>
+</body>
+</html>

--- a/tools/plan-reviewer/README.md
+++ b/tools/plan-reviewer/README.md
@@ -1,0 +1,90 @@
+# Plan Reviewer
+
+Local HTML plan review daemon and CLI for plans under `thoughts/plans`.
+
+## Install
+
+From this repo checkout:
+
+```bash
+brew tap local/ai-configs "$PWD"
+brew install local/ai-configs/plan-reviewer
+brew services start plan-reviewer
+```
+
+The service runs:
+
+```bash
+plan-review serve --host 0.0.0.0 --port 4317 --db ~/.plan-reviewer/plan-reviewer.sqlite
+```
+
+There is no authentication in the MVP. Anyone who can reach the service can view registered plans and create or process comments.
+
+## Register and Review
+
+```bash
+plan-review register thoughts/plans/my-plan.html --repo auto --branch auto --commit auto
+plan-review index
+```
+
+Open the printed review URL. The browser shell renders sanitized HTML in a no-script iframe and keeps the comment UI in the parent page. Selecting a DOM element opens the composer; image and text comments use the same comment API with `anchorType: "image"` or `anchorType: "text_range"`.
+
+## Agent Watch Contract
+
+Agents can keep an open SSE connection for queue events:
+
+```bash
+plan-review watch plan_123 --mode queue --json
+```
+
+Raw HTTP contract:
+
+```http
+GET /api/plans/:planId/events?mode=queue
+Accept: text/event-stream
+Last-Event-ID: <last-seen-sequence>
+```
+
+SSE frames use `id: <sequence>`, `event: comment.created|comment.claimed|comment.acknowledged|comment.resolved|comment.released`, and JSON `data`. On reconnect, `Last-Event-ID` replays later events. Heartbeats are sent every 15 seconds. If SSE is unavailable, agents poll:
+
+```http
+GET /api/plans/:planId/events/poll?afterSequence=<last-seen-sequence>&mode=queue
+```
+
+Poll responses include `{ events, latestSequence, retryAfterMs }`. The CLI falls back to 10-second REST polling when the stream is unavailable.
+
+## Queue Lifecycle
+
+Comments are delivered at least once. An agent should claim, process, ack, then optionally resolve:
+
+```bash
+plan-review queue claim plan_123 --one --json
+plan-review ack cmt_123 --claim claim_123 --note "Updated the plan" --json
+plan-review resolve cmt_123 --note "Done" --json
+```
+
+Direct ack without an active matching claim returns `409 claim_required`. Claims have a default 5-minute lease and expired claims return to `pending`.
+
+## Browser Comment Bridge
+
+Every comment event carries `conversationPayload.type = "browser.comment.v1"`. Host adapters for Codex, Claude, or Pi can append that payload into the active conversation, let the agent answer there, and call `ack` or `resolve` with a response summary, changed files, run ID, and optional commit SHA. The service stores the response metadata but does not implement a separate chat product.
+
+## Authoring HTML Plans
+
+Use stable `id` attributes on major sections, phase cards, acceptance criteria, diagrams, and mockups. The renderer preserves those IDs as `data-plan-node-id`; otherwise it derives deterministic IDs from headings, sibling paths, and short content hashes. Prefer semantic `section`, `article`, `figure`, `figcaption`, headings, lists, and tables so comments capture useful heading paths.
+
+Keep images relative to the plan file when they are repo assets. Include `alt`, `width`, and `height` where possible. Plan-authored scripts, event handlers, forms, and active embeds are stripped from the review render; put interactive review behavior in the plan-reviewer shell, not in the plan artifact.
+
+## Security Seams
+
+The MVP is intentionally unauthenticated. Future bearer tokens, private share links, or network restrictions should plug in at Fastify request hooks before the route handlers and at CLI service-discovery/config boundaries. Until then, use `--host 127.0.0.1` for local-only use or the Homebrew default `0.0.0.0` only on a trusted network.
+
+## Development
+
+```bash
+cd tools/plan-reviewer
+bun install
+bun run test
+bun run test:e2e -- --grep "dom annotation|image annotation|plan index"
+bun run test:fixtures -- --scenario seeded-comment-stream
+```

--- a/tools/plan-reviewer/bin/plan-review
+++ b/tools/plan-reviewer/bin/plan-review
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import('../dist/cli.js')
+  .then(mod => {
+    if (typeof mod.main !== 'function') {
+      console.error('ERROR: cli_load_failed Missing main export');
+      process.exit(1);
+    }
+    const result = mod.main(process.argv.slice(2));
+    if (result && typeof result.then === 'function') {
+      result.catch(err => {
+        console.error('ERROR: cli_runtime_failed', err?.message ?? String(err));
+        process.exit(1);
+      });
+    }
+  })
+  .catch(err => {
+    console.error('ERROR: cli_load_failed', err?.message ?? String(err));
+    process.exit(1);
+  });

--- a/tools/plan-reviewer/bun.lock
+++ b/tools/plan-reviewer/bun.lock
@@ -1,0 +1,334 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "plan-reviewer",
+      "dependencies": {
+        "@medv/finder": "^4.0.2",
+        "@washi-ui/core": "^1.0.2",
+        "better-sqlite3": "^12.4.6",
+        "commander": "^12.1.0",
+        "fastify": "^5.6.2",
+        "html2canvas": "^1.4.1",
+        "nanoid": "^5.1.6",
+        "parse5": "^8.0.0",
+        "sanitize-html": "^2.17.0",
+        "zod": "^4.1.13",
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "@types/node": "^20.19.25",
+        "@types/sanitize-html": "^2.16.0",
+        "playwright": "^1.57.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
+
+    "@fastify/ajv-compiler": ["@fastify/ajv-compiler@4.0.5", "", { "dependencies": { "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0" } }, "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A=="],
+
+    "@fastify/error": ["@fastify/error@4.2.0", "", {}, "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ=="],
+
+    "@fastify/fast-json-stringify-compiler": ["@fastify/fast-json-stringify-compiler@5.0.3", "", { "dependencies": { "fast-json-stringify": "^6.0.0" } }, "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ=="],
+
+    "@fastify/forwarded": ["@fastify/forwarded@3.0.1", "", {}, "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw=="],
+
+    "@fastify/merge-json-schemas": ["@fastify/merge-json-schemas@0.2.1", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A=="],
+
+    "@fastify/proxy-addr": ["@fastify/proxy-addr@5.1.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw=="],
+
+    "@medv/finder": ["@medv/finder@4.0.2", "", {}, "sha512-RraNY9SCcx4KZV0Dh6BEW6XEW2swkqYca74pkFFRw6hHItSHiy+O/xMnpbofjYbzXj0tSpBGthUF1hHTsr3vIQ=="],
+
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
+
+    "@types/node": ["@types/node@20.19.41", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ=="],
+
+    "@types/sanitize-html": ["@types/sanitize-html@2.16.1", "", { "dependencies": { "htmlparser2": "^10.1" } }, "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA=="],
+
+    "@washi-ui/core": ["@washi-ui/core@1.0.2", "", {}, "sha512-sQQcgmbib2QHNKWjWvesjStdRKT8rOSVtIpYqmQpSxFSOW4o4QRGfiKdhNyhgHpDNKNrCoSyKZKZZo2yHQSqaA=="],
+
+    "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "avvio": ["avvio@9.2.0", "", { "dependencies": { "@fastify/error": "^4.0.0", "fastq": "^1.17.1" } }, "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ=="],
+
+    "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "better-sqlite3": ["better-sqlite3@12.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+
+    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "css-line-break": ["css-line-break@2.1.0", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
+
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stringify": ["fast-json-stringify@6.4.0", "", { "dependencies": { "@fastify/merge-json-schemas": "^0.2.0", "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0", "json-schema-ref-resolver": "^3.0.0", "rfdc": "^1.2.0" } }, "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ=="],
+
+    "fast-querystring": ["fast-querystring@1.1.2", "", { "dependencies": { "fast-decode-uri-component": "^1.0.1" } }, "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "fastify": ["fastify@5.8.5", "", { "dependencies": { "@fastify/ajv-compiler": "^4.0.5", "@fastify/error": "^4.0.0", "@fastify/fast-json-stringify-compiler": "^5.0.0", "@fastify/proxy-addr": "^5.0.0", "abstract-logging": "^2.0.1", "avvio": "^9.0.0", "fast-json-stringify": "^6.0.0", "find-my-way": "^9.0.0", "light-my-request": "^6.0.0", "pino": "^9.14.0 || ^10.1.0", "process-warning": "^5.0.0", "rfdc": "^1.3.1", "secure-json-parse": "^4.0.0", "semver": "^7.6.0", "toad-cache": "^3.7.0" } }, "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
+    "find-my-way": ["find-my-way@9.6.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-querystring": "^1.0.0", "safe-regex2": "^5.0.0" } }, "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
+
+    "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "ipaddr.js": ["ipaddr.js@2.4.0", "", {}, "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ=="],
+
+    "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
+
+    "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "launder": ["launder@1.7.1", "", { "dependencies": { "dayjs": "^1.11.7" } }, "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw=="],
+
+    "light-my-request": ["light-my-request@6.6.0", "", { "dependencies": { "cookie": "^1.0.1", "process-warning": "^4.0.0", "set-cookie-parser": "^2.6.0" } }, "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A=="],
+
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
+
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
+    "node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parse-srcset": ["parse-srcset@1.0.2", "", {}, "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="],
+
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "ret": ["ret@0.5.0", "", {}, "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-regex2": ["safe-regex2@5.1.1", "", { "dependencies": { "ret": "~0.5.0" }, "bin": { "safe-regex2": "bin/safe-regex2.js" } }, "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "sanitize-html": ["sanitize-html@2.17.4", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^10.1.0", "is-plain-object": "^5.0.0", "launder": "^1.7.1", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
+
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
+    "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
+
+    "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
+
+    "toad-cache": ["toad-cache@3.7.1", "", {}, "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ=="],
+
+    "tsx": ["tsx@4.22.3", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "utrie": ["utrie@1.0.2", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
+
+    "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
+
+    "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+  }
+}

--- a/tools/plan-reviewer/package-lock.json
+++ b/tools/plan-reviewer/package-lock.json
@@ -1,0 +1,1799 @@
+{
+  "name": "plan-reviewer",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plan-reviewer",
+      "version": "0.1.0",
+      "dependencies": {
+        "@medv/finder": "^4.0.2",
+        "@washi-ui/core": "^1.0.2",
+        "better-sqlite3": "^12.4.6",
+        "commander": "^12.1.0",
+        "fastify": "^5.6.2",
+        "html2canvas": "^1.4.1",
+        "nanoid": "^5.1.6",
+        "parse5": "^8.0.0",
+        "sanitize-html": "^2.17.0",
+        "zod": "^4.1.13"
+      },
+      "bin": {
+        "plan-review": "bin/plan-review"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "@types/node": "^20.19.25",
+        "@types/sanitize-html": "^2.16.0",
+        "playwright": "^1.57.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.0.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@medv/finder": {
+      "version": "4.0.2",
+      "license": "MIT"
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "license": "MIT"
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
+      }
+    },
+    "node_modules/@washi-ui/core": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "license": "ISC"
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "license": "MIT"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "6.4.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.8.5",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.0.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/find-my-way": {
+      "version": "9.6.0",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.11",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "license": "ISC"
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.12",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.4",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "license": "MIT"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/tools/plan-reviewer/package.json
+++ b/tools/plan-reviewer/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "plan-reviewer",
+  "version": "0.1.0",
+  "description": "Local HTML plan review daemon and CLI for agent comment workflows",
+  "bin": {
+    "plan-review": "bin/plan-review"
+  },
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "test": "bun run build && node --test dist/**/*.test.js",
+    "test:e2e": "bun run build && node dist/test-fixtures/e2e-run.js",
+    "test:fixtures": "bun run build && node dist/test-fixtures/run.js",
+    "dev": "tsx src/cli.ts"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "dependencies": {
+    "@medv/finder": "^4.0.2",
+    "@washi-ui/core": "^1.0.2",
+    "better-sqlite3": "^12.4.6",
+    "commander": "^12.1.0",
+    "fastify": "^5.6.2",
+    "html2canvas": "^1.4.1",
+    "nanoid": "^5.1.6",
+    "parse5": "^8.0.0",
+    "sanitize-html": "^2.17.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^20.19.25",
+    "@types/sanitize-html": "^2.16.0",
+    "playwright": "^1.57.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/tools/plan-reviewer/src/__tests__/contracts.test.ts
+++ b/tools/plan-reviewer/src/__tests__/contracts.test.ts
@@ -53,11 +53,27 @@ test('renderer strips active content, rewrites images, and adds deterministic no
   }));
   assert.equal(unquotedImage.renderedHtml.includes('src="/assets/'), true);
   assert.equal(unquotedImage.renderedHtml.includes('data-plan-image-source="diagram.png"'), true);
-  assert.deepEqual(findImageSources('<img src=diagram.png><img src="./two.png"><img alt=x src=\'three.png\'>'), [
+  assert.deepEqual(findImageSources('<img src=diagram.png><img src="./two.png"><img alt=x src=\'three.png\'><img data-src="placeholder.png" alt="preview src=placeholder.png" src="actual.png">'), [
     'diagram.png',
     './two.png',
-    'three.png'
+    'three.png',
+    'actual.png'
   ]);
+
+  const lazyImage = renderPlan(sampleRegisterPayload({
+    html: '<!doctype html><html><body><img data-src="placeholder.png" alt="lazy preview src=placeholder.png" src="diagram.png"></body></html>',
+    fileHash: 'lazy-image'
+  }));
+  assert.equal(lazyImage.renderedHtml.includes('data-src="placeholder.png"'), true);
+  assert.equal(lazyImage.renderedHtml.includes('alt="lazy preview src=placeholder.png"'), true);
+  assert.equal(lazyImage.renderedHtml.includes('data-plan-image-source="diagram.png"'), true);
+
+  const quotedAttributeImage = renderPlan(sampleRegisterPayload({
+    html: '<!doctype html><html><body><img alt=\'preview src="diagram.png"\' src="diagram.png"></body></html>',
+    fileHash: 'quoted-attribute-image'
+  }));
+  assert.equal(quotedAttributeImage.renderedHtml.includes('data-plan-image-source="diagram.png"'), true);
+  assert.equal(quotedAttributeImage.renderedHtml.includes('alt="preview src=&quot;/assets/'), false);
 
   const unsafeLink = renderPlan(sampleRegisterPayload({
     html: '<!doctype html><html><body><a href="data:text/html,bad">bad link</a><img src="data:image/png;base64,abc" alt="inline"></body></html>'
@@ -269,6 +285,33 @@ test('HTTP API registers plans, creates comments, claims, acks, resolves, and po
     });
     assert.equal(resolveResponse.statusCode, 200);
     assert.equal(resolveResponse.json().data.comment.status, 'resolved');
+
+    const eventsBeforeRetry = await app.inject({ method: 'GET', url: `/api/plans/${planId}/events/poll?afterSequence=0&mode=queue` });
+    const lastQueueSequence = eventsBeforeRetry.json().data.events.at(-1).sequence;
+
+    const duplicateCreate = await app.inject({
+      method: 'POST',
+      url: `/api/plans/${planId}/comments`,
+      payload: {
+        versionId,
+        body: 'Retry after resolution.',
+        anchorType: 'dom',
+        anchor: domAnchor(),
+        clientMutationId: 'comment-1'
+      }
+    });
+    assert.equal(duplicateCreate.statusCode, 200);
+    assert.equal(duplicateCreate.json().data.created, false);
+    assert.equal(duplicateCreate.json().data.comment.id, comment.id);
+    assert.equal(duplicateCreate.json().data.event.eventType, 'comment.created');
+    assert.equal(duplicateCreate.json().data.event.commentId, comment.id);
+
+    const retryEvents = await app.inject({
+      method: 'GET',
+      url: `/api/plans/${planId}/events/poll?afterSequence=${lastQueueSequence}&mode=queue`
+    });
+    assert.equal(retryEvents.statusCode, 200);
+    assert.deepEqual(retryEvents.json().data.events, []);
 
     const events = await app.inject({ method: 'GET', url: `/api/plans/${planId}/events/poll?afterSequence=0&mode=queue` });
     assert.equal(events.statusCode, 200);

--- a/tools/plan-reviewer/src/__tests__/contracts.test.ts
+++ b/tools/plan-reviewer/src/__tests__/contracts.test.ts
@@ -1,0 +1,566 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import { spawn, spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { claimCommentsSchema, createCommentSchema, registerPlanSchema } from '../schemas.js';
+import { renderPlan } from '../render/render.js';
+import { PlanReviewStore } from '../storage/database.js';
+import { createApp } from '../server/app.js';
+import { findImageSources } from '../htmlImages.js';
+import { domAnchor, registeredApp, sampleHtml, sampleRegisterPayload, tempDbPath } from './helpers.js';
+
+test('schemas validate locked registration, comment, and claim contracts', () => {
+  const register = registerPlanSchema.parse(sampleRegisterPayload());
+  assert.equal(register.updateMode, 'upsert');
+
+  const comment = createCommentSchema.parse({
+    versionId: 'ver_1',
+    body: 'This section needs more acceptance detail.',
+    anchorType: 'dom',
+    anchor: domAnchor(),
+    createdBy: { displayName: '' }
+  });
+  assert.equal(comment.anchorType, 'dom');
+
+  assert.equal(claimCommentsSchema.parse({ mode: 'one' }).leaseSeconds, 300);
+  assert.throws(() => claimCommentsSchema.parse({ mode: 'bulk', limit: 0 }));
+});
+
+test('renderer strips active content, rewrites images, and adds deterministic node ids', () => {
+  const output = renderPlan(sampleRegisterPayload());
+
+  assert.equal(output.warnings.some(item => item.code === 'blocked_script'), true);
+  assert.equal(output.renderedHtml.includes('<script>'), false);
+  assert.equal(output.renderedHtml.includes('src="/assets/'), true);
+  assert.equal(output.renderedHtml.includes('data-plan-image-hash='), true);
+  assert.equal(output.renderedHtml.includes('data-plan-node-id="phase-p1"'), true);
+
+  const repeated = renderPlan(sampleRegisterPayload({ html: sampleHtml() }));
+  assert.equal(output.renderedHtml, repeated.renderedHtml);
+
+  const external = renderPlan(sampleRegisterPayload({
+    html: '<!doctype html><html><body><img src="https://example.com/track.png" alt="external"></body></html>'
+  }));
+  assert.equal(external.warnings.some(item => item.code === 'blocked_external_image'), true);
+  assert.equal(external.renderedHtml.includes('src="https://example.com/track.png"'), false);
+
+  const unquotedImage = renderPlan(sampleRegisterPayload({
+    html: '<!doctype html><html><body><img src=diagram.png alt=Diagram></body></html>',
+    fileHash: 'unquoted-image'
+  }));
+  assert.equal(unquotedImage.renderedHtml.includes('src="/assets/'), true);
+  assert.equal(unquotedImage.renderedHtml.includes('data-plan-image-source="diagram.png"'), true);
+  assert.deepEqual(findImageSources('<img src=diagram.png><img src="./two.png"><img alt=x src=\'three.png\'>'), [
+    'diagram.png',
+    './two.png',
+    'three.png'
+  ]);
+
+  const unsafeLink = renderPlan(sampleRegisterPayload({
+    html: '<!doctype html><html><body><a href="data:text/html,bad">bad link</a><img src="data:image/png;base64,abc" alt="inline"></body></html>'
+  }));
+  assert.equal(unsafeLink.renderedHtml.includes('href="data:text/html,bad"'), false);
+  assert.equal(unsafeLink.renderedHtml.includes('src="data:image/png;base64,abc"'), true);
+
+  assert.throws(
+    () => renderPlan(sampleRegisterPayload({ html: '<!doctype html><html><body><div id="x" id="y"></div></body></html>', fileHash: 'invalid-html' })),
+    /Plan HTML could not be parsed safely/
+  );
+});
+
+test('registration upserts by default and creates a distinct plan for new-thread', async () => {
+  const { app } = await registeredApp('new-thread');
+  try {
+    const upsert = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload()
+    });
+    assert.equal(upsert.statusCode, 200);
+
+    const newThread = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({ updateMode: 'new-thread' })
+    });
+    assert.equal(newThread.statusCode, 200);
+
+    const plans = await app.inject({ method: 'GET', url: '/api/plans' });
+    assert.equal(plans.statusCode, 200);
+    assert.equal(plans.json().data.plans.length, 2);
+    assert.notEqual(newThread.json().data.planId, upsert.json().data.planId);
+  } finally {
+    await app.close();
+  }
+});
+
+test('HTTP API reports schema errors as validation_failed and renders canonical escaped plan ids', async () => {
+  const app = createApp({ dbPath: tempDbPath('validation-shell') });
+  try {
+    const invalid = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: { html: '<html></html>' }
+    });
+    assert.equal(invalid.statusCode, 400);
+    assert.equal(invalid.json().error.code, 'validation_failed');
+    assert.match(invalid.json().error.nextAction, /documented endpoint contract/);
+
+    const unsafeSlug = 'bad" onmouseover="alert(1)';
+    const registered = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({ slug: unsafeSlug, fileHash: 'unsafe-slug' })
+    });
+    assert.equal(registered.statusCode, 200);
+    const planId = registered.json().data.planId;
+
+    const shell = await app.inject({
+      method: 'GET',
+      url: `/p/${encodeURIComponent(unsafeSlug)}`
+    });
+    assert.equal(shell.statusCode, 200);
+    assert.match(shell.body, new RegExp(`data-plan-id="${planId}"`));
+    assert.match(shell.body, new RegExp(`src="/render/${planId}"`));
+    assert.doesNotMatch(shell.body, /onmouseover/);
+  } finally {
+    await app.close();
+  }
+});
+
+test('plan versions are distinct for the same content on a different branch or commit', () => {
+  const store = new PlanReviewStore(tempDbPath('version-key'));
+  try {
+    const payload = sampleRegisterPayload();
+    const rendered = renderPlan(payload);
+    const first = store.registerPlan(payload, rendered.renderedHtml, rendered.warnings);
+    const second = store.registerPlan(
+      { ...payload, branch: 'feature/review', commitSha: 'def456' },
+      rendered.renderedHtml,
+      rendered.warnings
+    );
+    assert.equal(first.planId, second.planId);
+    assert.notEqual(first.versionId, second.versionId);
+  } finally {
+    store.close();
+  }
+});
+
+test('HTTP API registers plans, creates comments, claims, acks, resolves, and polls events', async () => {
+  const { app, planId, versionId } = await registeredApp('contracts');
+  try {
+    const index = await app.inject({ method: 'GET', url: '/api/plans' });
+    assert.equal(index.statusCode, 200);
+    assert.equal(index.json().data.plans.length, 1);
+
+    const planMeta = await app.inject({ method: 'GET', url: `/api/plans/${planId}` });
+    assert.equal(planMeta.statusCode, 200);
+    assert.equal(planMeta.json().data.assets.length, 1);
+    assert.equal(planMeta.json().data.assets[0].sourceUrl, './diagram.png');
+    assert.equal(planMeta.json().data.assets[0].contentType, 'image/png');
+    const planAsset = await app.inject({ method: 'GET', url: `/assets/${planMeta.json().data.assets[0].id}` });
+    assert.equal(planAsset.statusCode, 200);
+    assert.equal(planAsset.headers['cache-control'], 'public, max-age=31536000, immutable');
+
+    const html2canvas = await app.inject({ method: 'GET', url: '/vendor/html2canvas.js' });
+    assert.equal(html2canvas.statusCode, 200);
+    assert.match(html2canvas.body, /html2canvas/);
+    const finder = await app.inject({ method: 'GET', url: '/vendor/finder.js' });
+    assert.equal(finder.statusCode, 200);
+    assert.match(finder.body, /export function finder/);
+    const washi = await app.inject({ method: 'GET', url: '/vendor/washi.js' });
+    assert.equal(washi.statusCode, 200);
+    assert.match(washi.body, /export \{\s*Washi\s*\}/);
+
+    const commentResponse = await app.inject({
+      method: 'POST',
+      url: `/api/plans/${planId}/comments`,
+      payload: {
+        versionId,
+        body: 'Add the agent watch contract here.',
+        anchorType: 'dom',
+        anchor: domAnchor(),
+        markerScreenshot: {
+          contentType: 'image/png',
+          bytesBase64: Buffer.from('screen').toString('base64'),
+          width: 20,
+          height: 10,
+          captureRect: { x: 0, y: 0, width: 20, height: 10 },
+          viewport: { width: 1280, height: 800 }
+        },
+        createdBy: { displayName: 'Reviewer' },
+        clientMutationId: 'comment-1'
+      }
+    });
+    assert.equal(commentResponse.statusCode, 200);
+    const comment = commentResponse.json().data.comment;
+    assert.equal(comment.status, 'pending');
+    assert.equal(comment.sequence, 1);
+    assert.equal(comment.conversationPayload.type, 'browser.comment.v1');
+    const commentAsset = await app.inject({ method: 'GET', url: `/comment-assets/${comment.screenshotAssetId}` });
+    assert.equal(commentAsset.statusCode, 200);
+    assert.equal(commentAsset.headers['cache-control'], 'public, max-age=31536000, immutable');
+
+    const wrongVersion = await app.inject({
+      method: 'POST',
+      url: `/api/plans/${planId}/comments`,
+      payload: {
+        versionId: 'ver_missing',
+        body: 'wrong version',
+        anchorType: 'dom',
+        anchor: domAnchor()
+      }
+    });
+    assert.equal(wrongVersion.statusCode, 400);
+    assert.equal(wrongVersion.json().error.code, 'validation_failed');
+
+    const ackWithoutClaim = await app.inject({
+      method: 'POST',
+      url: `/api/comments/${comment.id}/ack`,
+      payload: { claimId: 'missing', action: { responseSummary: 'no claim' } }
+    });
+    assert.equal(ackWithoutClaim.statusCode, 409);
+    assert.equal(ackWithoutClaim.json().error.code, 'claim_required');
+
+    const claimResponse = await app.inject({
+      method: 'POST',
+      url: `/api/plans/${planId}/comments/claim`,
+      headers: { 'x-agent-id': 'agent-a' },
+      payload: { mode: 'one' }
+    });
+    assert.equal(claimResponse.statusCode, 200);
+    const claimed = claimResponse.json().data.claimed[0];
+    assert.equal(claimed.status, 'claimed');
+
+    const resolveClaimed = await app.inject({
+      method: 'POST',
+      url: `/api/comments/${comment.id}/resolve`,
+      payload: { resolutionNote: 'skip ack' }
+    });
+    assert.equal(resolveClaimed.statusCode, 409);
+    assert.equal(resolveClaimed.json().error.code, 'invalid_state');
+
+    const ackResponse = await app.inject({
+      method: 'POST',
+      url: `/api/comments/${comment.id}/ack`,
+      payload: {
+        claimId: claimed.claim.id,
+        action: { responseSummary: 'Updated the plan.', changedFiles: ['thoughts/plans/sample-plan.html'] }
+      }
+    });
+    assert.equal(ackResponse.statusCode, 200);
+    assert.equal(ackResponse.json().data.comment.status, 'acknowledged');
+
+    const releaseAcknowledged = await app.inject({
+      method: 'POST',
+      url: `/api/comments/${comment.id}/release`,
+      payload: { claimId: claimed.claim.id }
+    });
+    assert.equal(releaseAcknowledged.statusCode, 409);
+    assert.equal(releaseAcknowledged.json().error.code, 'invalid_state');
+
+    const resolveResponse = await app.inject({
+      method: 'POST',
+      url: `/api/comments/${comment.id}/resolve`,
+      payload: { resolutionNote: 'done' }
+    });
+    assert.equal(resolveResponse.statusCode, 200);
+    assert.equal(resolveResponse.json().data.comment.status, 'resolved');
+
+    const events = await app.inject({ method: 'GET', url: `/api/plans/${planId}/events/poll?afterSequence=0&mode=queue` });
+    assert.equal(events.statusCode, 200);
+    assert.deepEqual(
+      events.json().data.events.map((event: { eventType: string }) => event.eventType),
+      ['comment.created', 'comment.claimed', 'comment.acknowledged', 'comment.resolved']
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('lease expiry emits a queue release event during polling', async () => {
+  const { app, planId, versionId } = await registeredApp('lease-expiry');
+  try {
+    const commentResponse = await app.inject({
+      method: 'POST',
+      url: `/api/plans/${planId}/comments`,
+      payload: {
+        versionId,
+        body: 'Claim should expire.',
+        anchorType: 'dom',
+        anchor: domAnchor()
+      }
+    });
+    assert.equal(commentResponse.statusCode, 200);
+
+    const claimResponse = await app.inject({
+      method: 'POST',
+      url: `/api/plans/${planId}/comments/claim`,
+      payload: { mode: 'one', leaseSeconds: 1 }
+    });
+    assert.equal(claimResponse.statusCode, 200);
+    const claim = claimResponse.json().data.claimed[0];
+
+    await new Promise(resolve => setTimeout(resolve, 1100));
+    const events = await app.inject({ method: 'GET', url: `/api/plans/${planId}/events/poll?afterSequence=0&mode=queue` });
+    assert.equal(events.statusCode, 200);
+    assert.deepEqual(
+      events.json().data.events.map((event: { eventType: string }) => event.eventType),
+      ['comment.created', 'comment.claimed', 'comment.released']
+    );
+
+    const comments = await app.inject({ method: 'GET', url: `/api/plans/${planId}/comments` });
+    assert.equal(comments.json().data.comments[0].status, 'pending');
+
+    const expiredAck = await app.inject({
+      method: 'POST',
+      url: `/api/comments/${claim.id}/ack`,
+      payload: { claimId: claim.claim.id, action: { responseSummary: 'too late' } }
+    });
+    assert.equal(expiredAck.statusCode, 409);
+    assert.equal(expiredAck.json().error.code, 'claim_required');
+  } finally {
+    await app.close();
+  }
+});
+
+test('CLI watch polling fallback keeps waiting for once until timeout or event', async () => {
+  let polls = 0;
+  const server = http.createServer((request, response) => {
+    if (request.url?.startsWith('/api/plans/plan_1/events/poll')) {
+      polls += 1;
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({
+        ok: true,
+        data: {
+              events: polls >= 2 ? [{ sequence: 1, eventType: 'comment.created', payload: { eventType: 'comment.created', sequence: 1, comment: { conversationPayload: { type: 'browser.comment.v1', commentId: 'cmt_1', evidence: { reviewUrl: '/p/plan_1' } } } } }] : [],
+          latestSequence: polls >= 2 ? 1 : 0,
+          retryAfterMs: 25
+        }
+      }));
+      return;
+    }
+    if (request.url?.startsWith('/api/plans/plan_1/events')) {
+      response.statusCode = 503;
+      response.end('sse unavailable');
+      return;
+    }
+    response.statusCode = 404;
+    response.end('not found');
+  });
+
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const conversationOut = path.join('/tmp', `plan-reviewer-conversation-${process.pid}.ndjson`);
+  fs.rmSync(conversationOut, { force: true });
+  try {
+    const address = server.address();
+    assert(address && typeof address !== 'string');
+    const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+    const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>(resolve => {
+      const child = spawn(process.execPath, ['dist/cli.js', 'watch', 'plan_1', '--url', `http://127.0.0.1:${address.port}`, '--once', '--timeout', '1000', '--json', '--conversation-out', conversationOut], {
+        cwd: root,
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', chunk => { stdout += chunk; });
+      child.stderr.on('data', chunk => { stderr += chunk; });
+      child.on('close', code => resolve({ code, stdout, stderr }));
+    });
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stdout, /comment\.created/);
+    const conversation = JSON.parse(fs.readFileSync(conversationOut, 'utf8').trim());
+    assert.equal(conversation.type, 'browser.comment.v1');
+    assert.equal(conversation.evidence.reviewUrl, `http://127.0.0.1:${address.port}/p/plan_1`);
+    assert.equal(polls >= 2, true);
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+});
+
+test('CLI release maps to the REST release endpoint', async () => {
+  let captured: { method?: string; url?: string; body?: string } = {};
+  const server = http.createServer((request, response) => {
+    if (request.url === '/api/comments/cmt_1/release') {
+      captured = { method: request.method, url: request.url, body: '' };
+      request.on('data', chunk => { captured.body += chunk; });
+      request.on('end', () => {
+        response.setHeader('content-type', 'application/json');
+        response.end(JSON.stringify({ ok: true, data: { comment: { id: 'cmt_1', status: 'pending' } } }));
+      });
+      return;
+    }
+    response.statusCode = 404;
+    response.end('not found');
+  });
+
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const address = server.address();
+    assert(address && typeof address !== 'string');
+    const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+    const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>(resolve => {
+      const child = spawn(process.execPath, [
+        'dist/cli.js',
+        'release',
+        'cmt_1',
+        '--url',
+        `http://127.0.0.1:${address.port}`,
+        '--claim',
+        'claim_1',
+        '--reason',
+        'needs-retry',
+        '--json'
+      ], { cwd: root, stdio: ['ignore', 'pipe', 'pipe'] });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', chunk => { stdout += chunk; });
+      child.stderr.on('data', chunk => { stderr += chunk; });
+      child.on('close', code => resolve({ code, stdout, stderr }));
+    });
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(captured.method, 'POST');
+    assert.equal(JSON.parse(captured.body ?? '{}').claimId, 'claim_1');
+    assert.equal(JSON.parse(captured.body ?? '{}').reason, 'needs-retry');
+    assert.equal(JSON.parse(result.stdout).comment.status, 'pending');
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+});
+
+test('new plan versions remap changed anchors to stale or unmapped', async () => {
+  const { app, planId, versionId } = await registeredApp('anchor-remap');
+  try {
+    const commentResponse = await app.inject({
+      method: 'POST',
+      url: `/api/plans/${planId}/comments`,
+      payload: {
+        versionId,
+        body: 'Old phase disappeared.',
+        anchorType: 'dom',
+        anchor: domAnchor()
+      }
+    });
+    assert.equal(commentResponse.statusCode, 200);
+
+    const changedTextHtml = '<!doctype html><html><body><main><section id="phase-p1"><h2>Phase 1</h2><p>Different copy remains.</p></section></main></body></html>';
+    const staleRegister = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({ html: changedTextHtml, fileHash: 'changed-anchor-text' })
+    });
+    assert.equal(staleRegister.statusCode, 200);
+
+    const staleComments = await app.inject({ method: 'GET', url: `/api/plans/${planId}/comments` });
+    assert.equal(staleComments.json().data.comments[0].anchorState, 'stale');
+
+    const missingHtml = '<!doctype html><html><body><main><section id="different"><h2>Different</h2><p>Nothing remains.</p></section></main></body></html>';
+    const missingRegister = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({ html: missingHtml, fileHash: 'changed-anchor-missing' })
+    });
+    assert.equal(missingRegister.statusCode, 200);
+
+    const unmappedComments = await app.inject({ method: 'GET', url: `/api/plans/${planId}/comments` });
+    assert.equal(unmappedComments.json().data.comments[0].anchorState, 'unmapped');
+  } finally {
+    await app.close();
+  }
+});
+
+test('index groups plans by repo and sorts API plans by comment activity', async () => {
+  const { app, planId, versionId } = await registeredApp('index-activity');
+  try {
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        repoKey: 'git@example.com:demo/other.git',
+        repoName: 'other',
+        remoteUrl: 'git@example.com:demo/other.git',
+        rootPath: '/tmp/other',
+        planPath: 'thoughts/plans/other.html',
+        slug: 'other-plan',
+        fileHash: 'other-plan-hash'
+      })
+    });
+    assert.equal(second.statusCode, 200);
+    await new Promise(resolve => setTimeout(resolve, 5));
+
+    const commentResponse = await app.inject({
+      method: 'POST',
+      url: `/api/plans/${planId}/comments`,
+      payload: {
+        versionId,
+        body: 'Activity bump.',
+        anchorType: 'dom',
+        anchor: domAnchor()
+      }
+    });
+    assert.equal(commentResponse.statusCode, 200);
+
+    const apiIndex = await app.inject({ method: 'GET', url: '/api/plans' });
+    assert.equal(apiIndex.json().data.plans[0].plan.id, planId);
+
+    const repoFiltered = await app.inject({ method: 'GET', url: '/api/plans?repoKey=git%40example.com%3Ademo%2Fother.git' });
+    assert.equal(repoFiltered.json().data.plans.length, 1);
+    assert.equal(repoFiltered.json().data.plans[0].plan.repoName, 'other');
+
+    const queryFiltered = await app.inject({ method: 'GET', url: '/api/plans?q=other&limit=1' });
+    assert.equal(queryFiltered.json().data.plans.length, 1);
+    assert.equal(queryFiltered.json().data.nextCursor, undefined);
+
+    const paged = await app.inject({ method: 'GET', url: '/api/plans?limit=1' });
+    assert.equal(paged.json().data.plans.length, 1);
+    assert.equal(paged.json().data.nextCursor, '1');
+
+    const htmlIndex = await app.inject({ method: 'GET', url: '/' });
+    assert.match(htmlIndex.body, /class="repo-group"/);
+    assert.match(htmlIndex.body, />sample</);
+    assert.match(htmlIndex.body, />other</);
+  } finally {
+    await app.close();
+  }
+});
+
+test('CLI help is wired through the installed bin entrypoint', () => {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+  const result = spawnSync(process.execPath, ['dist/cli.js', '--help'], {
+    cwd: root,
+    encoding: 'utf8'
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /plan-review/);
+  assert.match(result.stdout, /watch/);
+  assert.match(result.stdout, /ack/);
+  assert.match(result.stdout, /resolve/);
+  assert.match(result.stdout, /release/);
+  assert.match(spawnSync(process.execPath, ['dist/cli.js', 'register', '--help'], { cwd: root, encoding: 'utf8' }).stdout, /--new-thread/);
+  assert.match(spawnSync(process.execPath, ['dist/cli.js', 'index', '--help'], { cwd: root, encoding: 'utf8' }).stdout, /--repo-key/);
+  assert.match(spawnSync(process.execPath, ['dist/cli.js', 'queue', '--help'], { cwd: root, encoding: 'utf8' }).stdout, /list/);
+  assert.match(spawnSync(process.execPath, ['dist/cli.js', 'ack', '--help'], { cwd: root, encoding: 'utf8' }).stdout, /--changed-files/);
+  assert.match(spawnSync(process.execPath, ['dist/cli.js', 'resolve', '--help'], { cwd: root, encoding: 'utf8' }).stdout, /--commit/);
+  assert.match(spawnSync(process.execPath, ['dist/cli.js', 'release', '--help'], { cwd: root, encoding: 'utf8' }).stdout, /--claim/);
+});
+
+test('Homebrew formula locks the daemon service contract', () => {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+  const formula = fs.readFileSync(path.join(root, 'Formula/plan-reviewer.rb'), 'utf8');
+
+  assert.match(formula, /class PlanReviewer < Formula/);
+  assert.match(formula, /bin\.install_symlink/);
+  assert.match(formula, /"serve", "--host", "0\.0\.0\.0", "--port", "4317"/);
+  assert.match(formula, /"\#\{Dir\.home\}\/\.plan-reviewer\/plan-reviewer\.sqlite"/);
+  assert.match(formula, /keep_alive true/);
+  assert.match(formula, /log_path var\/"log\/plan-reviewer\.log"/);
+  assert.match(formula, /error_log_path var\/"log\/plan-reviewer\.err\.log"/);
+  assert.match(formula, /brew services stop plan-reviewer/);
+  assert.match(formula, /rm -rf ~\/\.plan-reviewer/);
+});

--- a/tools/plan-reviewer/src/__tests__/contracts.test.ts
+++ b/tools/plan-reviewer/src/__tests__/contracts.test.ts
@@ -11,6 +11,8 @@ import { PlanReviewStore } from '../storage/database.js';
 import { createApp } from '../server/app.js';
 import { findImageSources } from '../htmlImages.js';
 import { resolveServiceUrl } from '../config.js';
+import { discoverImageAssets } from '../cli.js';
+import { sha256 } from '../util.js';
 import { domAnchor, registeredApp, sampleHtml, sampleRegisterPayload, tempDbPath } from './helpers.js';
 
 test('schemas validate locked registration, comment, and claim contracts', () => {
@@ -164,6 +166,87 @@ test('plan versions are distinct for the same content on a different branch or c
   } finally {
     store.close();
   }
+});
+
+test('rendered blobs stay isolated when identical HTML uses different local assets', async () => {
+  const app = createApp({ dbPath: tempDbPath('rendered-blob-isolation') });
+  const html = '<!doctype html><html><body><main><img src="./diagram.png" alt="Diagram"></main></body></html>';
+  const fileHash = sha256(html);
+  const firstAssetHash = sha256(Buffer.from('first-image'));
+  const secondAssetHash = sha256(Buffer.from('second-image'));
+  try {
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        repoKey: 'git@example.com:demo/first.git',
+        repoName: 'first',
+        rootPath: '/tmp/first',
+        planPath: 'thoughts/plans/shared.html',
+        slug: 'shared',
+        html,
+        fileHash,
+        assets: [{ sourceUrl: './diagram.png', absolutePath: '/tmp/first/thoughts/plans/diagram.png', bytesBase64: Buffer.from('first-image').toString('base64') }]
+      })
+    });
+    assert.equal(first.statusCode, 200);
+    const firstPlanId = first.json().data.planId;
+    const firstRendered = await app.inject({ method: 'GET', url: `/render/${firstPlanId}` });
+    assert.equal(firstRendered.statusCode, 200);
+    assert.match(firstRendered.body, new RegExp(`/assets/${firstAssetHash}`));
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        repoKey: 'git@example.com:demo/second.git',
+        repoName: 'second',
+        rootPath: '/tmp/second',
+        planPath: 'thoughts/plans/shared.html',
+        slug: 'shared',
+        html,
+        fileHash,
+        assets: [{ sourceUrl: './diagram.png', absolutePath: '/tmp/second/thoughts/plans/diagram.png', bytesBase64: Buffer.from('second-image').toString('base64') }]
+      })
+    });
+    assert.equal(second.statusCode, 200);
+
+    const firstRenderedAfterSecondRegister = await app.inject({ method: 'GET', url: `/render/${firstPlanId}` });
+    assert.equal(firstRenderedAfterSecondRegister.statusCode, 200);
+    assert.match(firstRenderedAfterSecondRegister.body, new RegExp(`/assets/${firstAssetHash}`));
+    assert.doesNotMatch(firstRenderedAfterSecondRegister.body, new RegExp(`/assets/${secondAssetHash}`));
+
+    const secondRendered = await app.inject({ method: 'GET', url: `/render/${second.json().data.planId}` });
+    assert.equal(secondRendered.statusCode, 200);
+    assert.match(secondRendered.body, new RegExp(`/assets/${secondAssetHash}`));
+  } finally {
+    await app.close();
+  }
+});
+
+test('CLI local image discovery only reads supported images inside the plan directory', () => {
+  const root = fs.mkdtempSync(path.join('/tmp', `plan-reviewer-assets-${process.pid}-`));
+  const planDir = path.join(root, 'plans');
+  fs.mkdirSync(planDir);
+  fs.writeFileSync(path.join(planDir, 'diagram.png'), 'png-data');
+  fs.writeFileSync(path.join(planDir, 'notes.txt'), 'not an image');
+  fs.writeFileSync(path.join(root, 'secret.png'), 'outside');
+  fs.writeFileSync(path.join(root, 'secret.txt'), 'outside');
+
+  const assets = discoverImageAssets(
+    '<img src="./diagram.png"><img src="./notes.txt"><img src="../secret.png"><img src="../secret.txt"><img src="../missing.png"><img src="./missing.png"><img src="https://example.com/remote.png">',
+    path.join(planDir, 'plan.html')
+  );
+  const bySource = new Map(assets.map(asset => [asset.sourceUrl, asset]));
+
+  assert.equal(bySource.get('./diagram.png')?.bytesBase64, Buffer.from('png-data').toString('base64'));
+  assert.equal(bySource.get('./notes.txt')?.bytesBase64, undefined);
+  assert.equal(bySource.get('../secret.png')?.bytesBase64, undefined);
+  assert.equal(bySource.get('../secret.png')?.absolutePath, undefined);
+  assert.equal(bySource.get('../secret.txt')?.absolutePath, undefined);
+  assert.equal(bySource.get('../missing.png')?.absolutePath, undefined);
+  assert.equal(bySource.get('./missing.png')?.bytesBase64, undefined);
+  assert.equal(bySource.has('https://example.com/remote.png'), false);
 });
 
 test('HTTP API registers plans, creates comments, claims, acks, resolves, and polls events', async () => {

--- a/tools/plan-reviewer/src/__tests__/contracts.test.ts
+++ b/tools/plan-reviewer/src/__tests__/contracts.test.ts
@@ -234,12 +234,13 @@ test('CLI local image discovery only reads supported images inside the plan dire
   fs.writeFileSync(path.join(root, 'secret.txt'), 'outside');
 
   const assets = discoverImageAssets(
-    '<img src="./diagram.png"><img src="./notes.txt"><img src="../secret.png"><img src="../secret.txt"><img src="../missing.png"><img src="./missing.png"><img src="https://example.com/remote.png">',
+    '<img src="./diagram.png"><img src="./diagram.png?v=2"><img src="./notes.txt"><img src="../secret.png"><img src="../secret.txt"><img src="../missing.png"><img src="./missing.png"><img src="https://example.com/remote.png">',
     path.join(planDir, 'plan.html')
   );
   const bySource = new Map(assets.map(asset => [asset.sourceUrl, asset]));
 
   assert.equal(bySource.get('./diagram.png')?.bytesBase64, Buffer.from('png-data').toString('base64'));
+  assert.equal(bySource.get('./diagram.png?v=2')?.bytesBase64, Buffer.from('png-data').toString('base64'));
   assert.equal(bySource.get('./notes.txt')?.bytesBase64, undefined);
   assert.equal(bySource.get('../secret.png')?.bytesBase64, undefined);
   assert.equal(bySource.get('../secret.png')?.absolutePath, undefined);

--- a/tools/plan-reviewer/src/__tests__/contracts.test.ts
+++ b/tools/plan-reviewer/src/__tests__/contracts.test.ts
@@ -10,6 +10,7 @@ import { renderPlan } from '../render/render.js';
 import { PlanReviewStore } from '../storage/database.js';
 import { createApp } from '../server/app.js';
 import { findImageSources } from '../htmlImages.js';
+import { resolveServiceUrl } from '../config.js';
 import { domAnchor, registeredApp, sampleHtml, sampleRegisterPayload, tempDbPath } from './helpers.js';
 
 test('schemas validate locked registration, comment, and claim contracts', () => {
@@ -53,7 +54,7 @@ test('renderer strips active content, rewrites images, and adds deterministic no
   }));
   assert.equal(unquotedImage.renderedHtml.includes('src="/assets/'), true);
   assert.equal(unquotedImage.renderedHtml.includes('data-plan-image-source="diagram.png"'), true);
-  assert.deepEqual(findImageSources('<img src=diagram.png><img src="./two.png"><img alt=x src=\'three.png\'><img data-src="placeholder.png" alt="preview src=placeholder.png" src="actual.png">'), [
+  assert.deepEqual(findImageSources('<img src=diagram.png><img src="./two.png"><img alt=x src=\'three.png\'><img data-src="placeholder.png" alt="preview src=placeholder.png > ok" src="actual.png">'), [
     'diagram.png',
     './two.png',
     'three.png',
@@ -69,7 +70,7 @@ test('renderer strips active content, rewrites images, and adds deterministic no
   assert.equal(lazyImage.renderedHtml.includes('data-plan-image-source="diagram.png"'), true);
 
   const quotedAttributeImage = renderPlan(sampleRegisterPayload({
-    html: '<!doctype html><html><body><img alt=\'preview src="diagram.png"\' src="diagram.png"></body></html>',
+    html: '<!doctype html><html><body><img alt=\'preview src="diagram.png" > still attribute\' src="diagram.png"></body></html>',
     fileHash: 'quoted-attribute-image'
   }));
   assert.equal(quotedAttributeImage.renderedHtml.includes('data-plan-image-source="diagram.png"'), true);
@@ -250,6 +251,9 @@ test('HTTP API registers plans, creates comments, claims, acks, resolves, and po
     assert.equal(claimResponse.statusCode, 200);
     const claimed = claimResponse.json().data.claimed[0];
     assert.equal(claimed.status, 'claimed');
+    const claimedComments = await app.inject({ method: 'GET', url: `/api/plans/${planId}/comments` });
+    assert.equal(claimedComments.json().data.comments[0].claim.id, claimed.claim.id);
+    assert.equal(claimedComments.json().data.comments[0].claim.agentId, 'agent-a');
 
     const resolveClaimed = await app.inject({
       method: 'POST',
@@ -563,6 +567,10 @@ test('index groups plans by repo and sorts API plans by comment activity', async
     assert.equal(paged.json().data.plans.length, 1);
     assert.equal(paged.json().data.nextCursor, '1');
 
+    const invalidCursor = await app.inject({ method: 'GET', url: '/api/plans?cursor=abc' });
+    assert.equal(invalidCursor.statusCode, 400);
+    assert.equal(invalidCursor.json().error.code, 'validation_failed');
+
     const htmlIndex = await app.inject({ method: 'GET', url: '/' });
     assert.match(htmlIndex.body, /class="repo-group"/);
     assert.match(htmlIndex.body, />sample</);
@@ -570,6 +578,41 @@ test('index groups plans by repo and sorts API plans by comment activity', async
   } finally {
     await app.close();
   }
+});
+
+test('bare plan slugs fail clearly when multiple repos register the same slug', async () => {
+  const { app } = await registeredApp('ambiguous-slug');
+  try {
+    const duplicateSlug = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        repoKey: 'git@example.com:demo/other-slug.git',
+        repoName: 'other-slug',
+        remoteUrl: 'git@example.com:demo/other-slug.git',
+        rootPath: '/tmp/other-slug',
+        planPath: 'thoughts/plans/sample-plan.html',
+        fileHash: 'other-slug-hash'
+      })
+    });
+    assert.equal(duplicateSlug.statusCode, 200);
+
+    const slugLookup = await app.inject({ method: 'GET', url: '/api/plans/sample-plan' });
+    assert.equal(slugLookup.statusCode, 409);
+    assert.equal(slugLookup.json().error.code, 'ambiguous_plan_slug');
+  } finally {
+    await app.close();
+  }
+});
+
+test('service URL config ignores invalid url values and trims valid URLs', () => {
+  const dir = path.join('/tmp', `plan-reviewer-config-${process.pid}-${Date.now()}`);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '.plan-reviewer.json'), '{"url":{}}');
+  assert.equal(resolveServiceUrl(undefined, dir), 'http://127.0.0.1:4317');
+
+  fs.writeFileSync(path.join(dir, '.plan-reviewer.json'), '{"url":"http://127.0.0.1:9999/"}');
+  assert.equal(resolveServiceUrl(undefined, dir), 'http://127.0.0.1:9999');
 });
 
 test('CLI help is wired through the installed bin entrypoint', () => {

--- a/tools/plan-reviewer/src/__tests__/dependency-smoke.test.ts
+++ b/tools/plan-reviewer/src/__tests__/dependency-smoke.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('locked third-party primitives import successfully', async () => {
+  const [fastify, commander, sqlite, finder, html2canvas, playwright] = await Promise.all([
+    import('fastify'),
+    import('commander'),
+    import('better-sqlite3'),
+    import('@medv/finder'),
+    import('html2canvas'),
+    import('playwright')
+  ]);
+
+  assert.equal(typeof fastify.default, 'function');
+  assert.equal(typeof commander.Command, 'function');
+  assert.equal(typeof sqlite.default, 'function');
+  assert.equal(typeof finder.finder, 'function');
+  assert.equal(typeof html2canvas.default, 'function');
+  assert.equal(typeof playwright.request.newContext, 'function');
+});

--- a/tools/plan-reviewer/src/__tests__/helpers.ts
+++ b/tools/plan-reviewer/src/__tests__/helpers.ts
@@ -1,0 +1,74 @@
+import os from 'node:os';
+import path from 'node:path';
+import { createApp } from '../server/app.js';
+import { sha256 } from '../util.js';
+
+export function tempDbPath(name: string): string {
+  return path.join(os.tmpdir(), `plan-reviewer-${process.pid}-${name}-${Date.now()}.sqlite`);
+}
+
+export function sampleHtml(): string {
+  return `<!doctype html>
+  <html>
+    <head><title>Sample Plan</title><script>window.bad = true</script></head>
+    <body>
+      <main id="sample-plan">
+        <section id="phase-p1"><h2>Phase 1</h2><p>Register the plan.</p></section>
+        <section><h2>Phase 2</h2><p>Reviewers can select this section.</p><img src="./diagram.png" alt="Diagram"></section>
+      </main>
+    </body>
+  </html>`;
+}
+
+export function sampleRegisterPayload(overrides: Record<string, unknown> = {}) {
+  const html = sampleHtml();
+  return {
+    repoKey: 'git@example.com:demo/sample.git',
+    repoName: 'sample',
+    remoteUrl: 'git@example.com:demo/sample.git',
+    rootPath: '/tmp/sample',
+    branch: 'main',
+    commitSha: 'abc123',
+    planPath: 'thoughts/plans/sample-plan.html',
+    slug: 'sample-plan',
+    html,
+    fileHash: sha256(html),
+    assets: [
+      {
+        sourceUrl: './diagram.png',
+        absolutePath: '/tmp/sample/thoughts/plans/diagram.png',
+        bytesBase64: Buffer.from('png-data').toString('base64')
+      }
+    ],
+    updateMode: 'upsert' as const,
+    ...overrides
+  };
+}
+
+export async function registeredApp(name = 'default') {
+  const app = createApp({ dbPath: tempDbPath(name) });
+  const register = await app.inject({
+    method: 'POST',
+    url: '/api/plans/register',
+    payload: sampleRegisterPayload()
+  });
+  if (register.statusCode !== 200) {
+    throw new Error(`registration failed: ${register.statusCode} ${register.body}`);
+  }
+  const data = register.json().data as { planId: string; versionId: string };
+  return { app, planId: data.planId, versionId: data.versionId };
+}
+
+export function domAnchor() {
+  return {
+    planNodeId: 'phase-p1',
+    cssSelector: '#phase-p1',
+    domPath: 'html/body/main/section[1]',
+    textQuote: { exact: 'Register the plan.', prefix: 'Phase 1', suffix: '' },
+    headingPath: ['Phase 1'],
+    rect: { x: 10, y: 20, width: 300, height: 80 },
+    viewport: { width: 1280, height: 800 },
+    textPreview: 'Phase 1 Register the plan.',
+    outerHtmlPreview: '<section id="phase-p1"><h2>Phase 1</h2></section>'
+  };
+}

--- a/tools/plan-reviewer/src/bin/plan-review.ts
+++ b/tools/plan-reviewer/src/bin/plan-review.ts
@@ -1,0 +1,3 @@
+import { main } from '../cli.js';
+
+await main();

--- a/tools/plan-reviewer/src/cli.ts
+++ b/tools/plan-reviewer/src/cli.ts
@@ -1,0 +1,460 @@
+import { Command } from 'commander';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { serve } from './server/serve.js';
+import { defaultDbPath, PlanReviewError, sha256, slugify } from './util.js';
+import { resolveServiceUrl } from './config.js';
+import { appendNdjson, requestJson } from './client/api.js';
+import { findImageSources } from './htmlImages.js';
+
+interface RegisterResponse {
+  planId: string;
+  versionId: string;
+  repoId: string;
+  reviewUrl: string;
+  indexUrl: string;
+  watchCommand: string;
+  renderedWithWarnings: Array<{ code: string; detail: string }>;
+}
+
+function git(args: string[], cwd = process.cwd()): string | undefined {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (result.status !== 0) return undefined;
+  return result.stdout.trim() || undefined;
+}
+
+function repoMetadata(cwd = process.cwd()) {
+  const rootPath = git(['rev-parse', '--show-toplevel'], cwd) ?? cwd;
+  const remoteUrl = git(['config', '--get', 'remote.origin.url'], rootPath);
+  const branch = git(['branch', '--show-current'], rootPath) ?? 'detached';
+  const commitSha = git(['rev-parse', 'HEAD'], rootPath);
+  const repoName = remoteUrl
+    ? path.basename(remoteUrl.replace(/\.git$/, ''))
+    : path.basename(rootPath);
+  return {
+    repoName,
+    remoteUrl,
+    rootPath,
+    branch,
+    commitSha,
+    repoKey: remoteUrl || `${rootPath}@${os.hostname()}`
+  };
+}
+
+function discoverImageAssets(html: string, planFile: string) {
+  const planDir = path.dirname(planFile);
+  const assets: Array<{ sourceUrl: string; absolutePath?: string; bytesBase64?: string }> = [];
+  for (const sourceUrl of findImageSources(html)) {
+    if (/^(data:|blob:|https?:\/\/|\/)/i.test(sourceUrl)) continue;
+    const absolutePath = path.resolve(planDir, sourceUrl);
+    if (!fs.existsSync(absolutePath)) {
+      assets.push({ sourceUrl, absolutePath });
+      continue;
+    }
+    assets.push({
+      sourceUrl,
+      absolutePath,
+      bytesBase64: fs.readFileSync(absolutePath).toString('base64')
+    });
+  }
+  return assets;
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function fullUrl(base: string, maybePath: string): string {
+  return maybePath.startsWith('http') ? maybePath : `${base.replace(/\/$/, '')}${maybePath}`;
+}
+
+function enrichConversationPayload(value: any, serviceUrl: string) {
+  const reviewUrl = value?.evidence?.reviewUrl;
+  if (!reviewUrl || typeof reviewUrl !== 'string' || !reviewUrl.startsWith('/')) return value;
+  return {
+    ...value,
+    evidence: {
+      ...value.evidence,
+      reviewUrl: fullUrl(serviceUrl, reviewUrl)
+    }
+  };
+}
+
+function defaultWatchStatePath(): string {
+  return path.join(os.homedir(), '.plan-reviewer', 'watch-state.json');
+}
+
+function readWatchState(filePath: string): Record<string, number> {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, number>;
+  } catch {
+    return {};
+  }
+}
+
+function writeWatchState(filePath: string, key: string, sequence: number): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const state = readWatchState(filePath);
+  state[key] = sequence;
+  fs.writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+async function registerPlan(filePath: string, options: { url?: string; json?: boolean; repo?: string; branch?: string; commit?: string; newThread?: boolean }) {
+  const serviceUrl = resolveServiceUrl(options.url);
+  const absolute = path.resolve(filePath);
+  const html = fs.readFileSync(absolute, 'utf8');
+  const meta = repoMetadata(path.dirname(absolute));
+  const branch = options.branch && options.branch !== 'auto' ? options.branch : meta.branch;
+  const commitSha = options.commit && options.commit !== 'auto' ? options.commit : meta.commitSha;
+  const repoName = options.repo && options.repo !== 'auto' ? options.repo : meta.repoName;
+  const payload = {
+    repoKey: meta.repoKey,
+    repoName,
+    remoteUrl: meta.remoteUrl,
+    rootPath: meta.rootPath,
+    branch,
+    commitSha,
+    planPath: path.relative(meta.rootPath, absolute) || filePath,
+    slug: slugify(path.basename(filePath, path.extname(filePath))),
+    html,
+    fileHash: sha256(html),
+    assets: discoverImageAssets(html, absolute),
+    updateMode: options.newThread ? 'new-thread' as const : 'upsert' as const
+  };
+  const data = await requestJson<RegisterResponse>(`${serviceUrl}/api/plans/register`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (options.json) {
+    printJson(data);
+    return;
+  }
+  process.stdout.write(`Plan ID: ${data.planId}\nIndex URL: ${fullUrl(serviceUrl, data.indexUrl)}\nReview URL: ${fullUrl(serviceUrl, data.reviewUrl)}\nWatch command: ${data.watchCommand} --url ${serviceUrl}\n`);
+}
+
+async function printIndex(options: { url?: string; json?: boolean; q?: string; repoKey?: string; limit?: string; cursor?: string }) {
+  const serviceUrl = resolveServiceUrl(options.url);
+  const params = new URLSearchParams();
+  if (options.q) params.set('q', options.q);
+  if (options.repoKey) params.set('repoKey', options.repoKey);
+  if (options.limit) params.set('limit', options.limit);
+  if (options.cursor) params.set('cursor', options.cursor);
+  const query = params.toString();
+  const data = await requestJson<{ plans?: Array<{ plan: { repoName: string; slug: string }; counts: { pending: number; claimed: number; acknowledged: number; resolved: number }; reviewUrl: string }>; nextCursor?: string }>(`${serviceUrl}/api/plans${query ? `?${query}` : ''}`);
+  if (options.json) printJson(data);
+  else {
+    const rows = data.plans ?? [];
+    const table = rows.map(item =>
+      `${item.plan.repoName}\t${item.plan.slug}\tpending:${item.counts.pending} claimed:${item.counts.claimed} ack:${item.counts.acknowledged} resolved:${item.counts.resolved}\t${fullUrl(serviceUrl, item.reviewUrl)}`
+    );
+    process.stdout.write(`Index URL: ${serviceUrl}/\nRepo\tPlan\tStatus\tReview URL\n${table.join('\n')}${data.nextCursor ? `\nNext cursor: ${data.nextCursor}` : ''}\n`);
+  }
+}
+
+function parseSse(buffer: string): { events: Array<{ id?: string; event?: string; data?: string }>; rest: string } {
+  const events: Array<{ id?: string; event?: string; data?: string }> = [];
+  let index: number;
+  while ((index = buffer.indexOf('\n\n')) >= 0) {
+    const raw = buffer.slice(0, index);
+    buffer = buffer.slice(index + 2);
+    const event: { id?: string; event?: string; data?: string } = {};
+    for (const line of raw.split('\n')) {
+      if (line.startsWith('id:')) event.id = line.slice(3).trim();
+      if (line.startsWith('event:')) event.event = line.slice(6).trim();
+      if (line.startsWith('data:')) event.data = `${event.data ?? ''}${line.slice(5).trim()}`;
+    }
+    if (event.event || event.data) events.push(event);
+  }
+  return { events, rest: buffer };
+}
+
+async function pollEvents(serviceUrl: string, planId: string, afterSequence: number, mode: string) {
+  return requestJson<{ events: any[]; latestSequence: number; retryAfterMs: number }>(
+    `${serviceUrl}/api/plans/${planId}/events/poll?afterSequence=${afterSequence}&mode=${encodeURIComponent(mode)}`
+  );
+}
+
+async function watchPlan(planId: string, options: {
+  url?: string;
+  json?: boolean;
+  mode?: 'all' | 'queue';
+  once?: boolean;
+  timeout?: string;
+  format?: string;
+  conversationOut?: string;
+  state?: string;
+}) {
+  const serviceUrl = resolveServiceUrl(options.url);
+  const mode = options.mode ?? 'queue';
+  const statePath = options.state ?? defaultWatchStatePath();
+  const stateKey = `${serviceUrl}|${planId}|${mode}`;
+  let latestSequence = readWatchState(statePath)[stateKey] ?? 0;
+  const timeoutMs = options.timeout ? Number(options.timeout) : undefined;
+  const started = Date.now();
+  const emit = (event: any, source: 'sse' | 'poll') => {
+    latestSequence = Number(event.sequence ?? latestSequence);
+    if (latestSequence > 0) writeWatchState(statePath, stateKey, latestSequence);
+    const conversation = (event.eventType ?? event.event) === 'comment.created'
+      ? enrichConversationPayload(event.comment?.conversationPayload ?? event.conversationPayload, serviceUrl)
+      : undefined;
+    const output = options.format === 'browser-comment' ? conversation : { source, ...event };
+    if (options.conversationOut && conversation) appendNdjson(options.conversationOut, conversation);
+    if (options.format === 'browser-comment' && !conversation) return;
+    if (options.json || options.format === 'browser-comment') process.stdout.write(`${JSON.stringify(output)}\n`);
+    else process.stdout.write(`${event.eventType ?? event.event ?? 'event'} #${latestSequence}\n`);
+  };
+  const remainingTimeout = () => timeoutMs ? Math.max(0, timeoutMs - (Date.now() - started)) : undefined;
+
+  let backoffMs = 1000;
+  while (true) {
+    try {
+      const abort = new AbortController();
+      const remaining = remainingTimeout();
+      const timeout = remaining !== undefined ? setTimeout(() => abort.abort(), remaining) : undefined;
+      try {
+        const response = await fetch(`${serviceUrl}/api/plans/${planId}/events?mode=${mode}`, {
+          headers: latestSequence ? { 'Last-Event-ID': String(latestSequence), accept: 'text/event-stream' } : { accept: 'text/event-stream' },
+          signal: abort.signal
+        });
+        if (!response.ok || !response.body) throw new Error(`SSE unavailable (${response.status})`);
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let rest = '';
+        while (true) {
+          const remainingRead = remainingTimeout();
+          if (remainingRead !== undefined && remainingRead <= 0) {
+            throw new PlanReviewError('watch_timeout', 'No event arrived before timeout', 1);
+          }
+          const read = timeoutMs
+            ? await Promise.race([
+                reader.read(),
+                new Promise<ReadableStreamReadResult<Uint8Array>>((_resolve, reject) =>
+                  setTimeout(() => reject(new PlanReviewError('watch_timeout', 'No event arrived before timeout', 1)), remainingRead)
+                )
+              ])
+            : await reader.read();
+          if (read.done) break;
+          const parsed = parseSse(rest + decoder.decode(read.value));
+          rest = parsed.rest;
+          for (const raw of parsed.events) {
+            if (raw.event === 'heartbeat' || raw.event === 'connected') continue;
+            const data = raw.data ? JSON.parse(raw.data) : {};
+            emit(data, 'sse');
+            if (options.once) {
+              await reader.cancel();
+              return;
+            }
+          }
+        }
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
+    } catch (error) {
+      if (error instanceof PlanReviewError && error.code === 'watch_timeout') throw error;
+      const data = await pollEvents(serviceUrl, planId, latestSequence, mode);
+      for (const event of data.events) {
+        emit(event.payload ?? event, 'poll');
+        if (options.once) return;
+      }
+      const remaining = remainingTimeout();
+      if (remaining !== undefined && remaining <= 0) {
+        throw new PlanReviewError('watch_timeout', 'No event arrived before timeout', 1);
+      }
+      await new Promise(resolve => setTimeout(resolve, Math.min(remaining ?? 10000, data.retryAfterMs ?? backoffMs)));
+      backoffMs = Math.min(30000, backoffMs * 2);
+    }
+  }
+}
+
+async function claim(planId: string, options: { url?: string; all?: boolean; one?: boolean; ids?: string; limit?: string; leaseSeconds?: string; json?: boolean }) {
+  const serviceUrl = resolveServiceUrl(options.url);
+  const body = options.ids
+    ? { mode: 'selected', commentIds: options.ids.split(',').filter(Boolean), leaseSeconds: options.leaseSeconds ? Number(options.leaseSeconds) : undefined }
+    : options.one
+      ? { mode: 'one', leaseSeconds: options.leaseSeconds ? Number(options.leaseSeconds) : undefined }
+      : { mode: 'bulk', limit: options.limit ? Number(options.limit) : undefined, leaseSeconds: options.leaseSeconds ? Number(options.leaseSeconds) : undefined };
+  const data = await requestJson<unknown>(`${serviceUrl}/api/plans/${planId}/comments/claim`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  if (options.json) printJson(data);
+  else process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+}
+
+async function queueSnapshot(options: { url?: string; repoKey?: string; planId?: string; limit?: string; json?: boolean }) {
+  const serviceUrl = resolveServiceUrl(options.url);
+  const params = new URLSearchParams();
+  if (options.repoKey) params.set('repoKey', options.repoKey);
+  if (options.planId) params.set('planId', options.planId);
+  if (options.limit) params.set('limit', options.limit);
+  const query = params.toString();
+  const data = await requestJson<unknown>(`${serviceUrl}/api/agent/queue${query ? `?${query}` : ''}`);
+  if (options.json) printJson(data);
+  else process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+}
+
+function csv(value?: string): string[] | undefined {
+  return value?.split(',').map(item => item.trim()).filter(Boolean);
+}
+
+function actionFromOptions(options: {
+  note?: string;
+  summary?: string;
+  changedFiles?: string;
+  commit?: string;
+  runId?: string;
+  handoff?: string;
+}) {
+  return {
+    note: options.note,
+    responseSummary: options.summary ?? options.note,
+    changedFiles: csv(options.changedFiles),
+    commitSha: options.commit,
+    runId: options.runId,
+    handoffPath: options.handoff
+  };
+}
+
+async function ack(commentId: string, options: { url?: string; claim?: string; note?: string; summary?: string; changedFiles?: string; commit?: string; runId?: string; handoff?: string; json?: boolean }) {
+  if (!options.claim) throw new PlanReviewError('claim_required', 'ack requires --claim <claim-id>', 1, { commentId }, 'Claim the comment first, then pass --claim <claim-id>.');
+  const serviceUrl = resolveServiceUrl(options.url);
+  const data = await requestJson<unknown>(`${serviceUrl}/api/comments/${commentId}/ack`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ claimId: options.claim, action: actionFromOptions(options) })
+  });
+  if (options.json) printJson(data);
+  else process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+}
+
+async function resolveComment(commentId: string, options: { url?: string; note?: string; summary?: string; changedFiles?: string; commit?: string; runId?: string; json?: boolean }) {
+  const serviceUrl = resolveServiceUrl(options.url);
+  const data = await requestJson<unknown>(`${serviceUrl}/api/comments/${commentId}/resolve`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ resolutionNote: options.note ?? 'resolved', action: actionFromOptions(options) })
+  });
+  if (options.json) printJson(data);
+  else process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+}
+
+async function releaseComment(commentId: string, options: { url?: string; claim?: string; reason?: string; json?: boolean }) {
+  if (!options.claim) throw new PlanReviewError('claim_required', 'release requires --claim <claim-id>', 1, { commentId }, 'Pass the active claim id with --claim <claim-id>.');
+  const serviceUrl = resolveServiceUrl(options.url);
+  const data = await requestJson<unknown>(`${serviceUrl}/api/comments/${commentId}/release`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ claimId: options.claim, reason: options.reason })
+  });
+  if (options.json) printJson(data);
+  else process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)) {
+  const program = new Command();
+  program.name('plan-review').description('Local HTML plan review daemon and CLI');
+
+  program.command('serve')
+    .option('--host <host>', 'host to bind', '0.0.0.0')
+    .option('--port <port>', 'port to bind', value => Number(value), 4317)
+    .option('--db <path>', 'SQLite database path', defaultDbPath())
+    .action(async options => {
+      await serve({ host: options.host, port: options.port, dbPath: options.db });
+    });
+
+  program.command('register <path>')
+    .option('--url <url>')
+    .option('--repo <repo>')
+    .option('--branch <branch>')
+    .option('--commit <commit>')
+    .option('--new-thread')
+    .option('--json')
+    .action(registerPlan);
+
+  program.command('index')
+    .option('--url <url>')
+    .option('--q <query>')
+    .option('--repo-key <repoKey>')
+    .option('--limit <limit>')
+    .option('--cursor <cursor>')
+    .option('--json')
+    .action(printIndex);
+
+  program.command('watch <planId>')
+    .option('--url <url>')
+    .option('--json')
+    .option('--mode <mode>', 'all|queue', 'queue')
+    .option('--once')
+    .option('--timeout <ms>')
+    .option('--format <format>')
+    .option('--conversation-out <path>')
+    .option('--state <path>')
+    .action(watchPlan);
+
+  const queue = program.command('queue');
+  queue.command('list')
+    .option('--url <url>')
+    .option('--repo-key <repoKey>')
+    .option('--plan-id <planId>')
+    .option('--limit <limit>')
+    .option('--json')
+    .action(queueSnapshot);
+
+  queue.command('claim <planId>')
+    .option('--url <url>')
+    .option('--all')
+    .option('--one')
+    .option('--ids <ids>')
+    .option('--limit <limit>')
+    .option('--lease-seconds <seconds>')
+    .option('--json')
+    .action(claim);
+
+  program.command('ack <commentId>')
+    .option('--url <url>')
+    .option('--claim <claimId>')
+    .option('--note <note>')
+    .option('--summary <summary>')
+    .option('--changed-files <paths>')
+    .option('--commit <sha>')
+    .option('--run-id <id>')
+    .option('--handoff <path>')
+    .option('--json')
+    .action(ack);
+
+  program.command('resolve <commentId>')
+    .option('--url <url>')
+    .option('--note <note>')
+    .option('--summary <summary>')
+    .option('--changed-files <paths>')
+    .option('--commit <sha>')
+    .option('--run-id <id>')
+    .option('--json')
+    .action(resolveComment);
+
+  program.command('release <commentId>')
+    .option('--url <url>')
+    .option('--claim <claimId>')
+    .option('--reason <reason>')
+    .option('--json')
+    .action(releaseComment);
+
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+  } catch (error) {
+    if (error instanceof PlanReviewError) {
+      console.error(`ERROR: ${error.code} ${error.message}${error.nextAction ? `\nNEXT: ${error.nextAction}` : ''}`);
+      process.exitCode = error.statusCode === 1 ? 1 : 2;
+      return;
+    }
+    throw error;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/tools/plan-reviewer/src/cli.ts
+++ b/tools/plan-reviewer/src/cli.ts
@@ -242,7 +242,12 @@ async function watchPlan(planId: string, options: {
           for (const raw of parsed.events) {
             if (raw.event === 'heartbeat' || raw.event === 'connected') continue;
             const data = raw.data ? JSON.parse(raw.data) : {};
-            emit(data, 'sse');
+            emit({
+              ...data,
+              sequence: raw.id ? Number(raw.id) : data.sequence,
+              eventType: raw.event ?? data.eventType,
+              event: raw.event ?? data.event
+            }, 'sse');
             if (options.once) {
               await reader.cancel();
               return;
@@ -256,7 +261,12 @@ async function watchPlan(planId: string, options: {
       if (error instanceof PlanReviewError && error.code === 'watch_timeout') throw error;
       const data = await pollEvents(serviceUrl, planId, latestSequence, mode);
       for (const event of data.events) {
-        emit(event.payload ?? event, 'poll');
+        emit({
+          ...(event.payload ?? {}),
+          sequence: event.sequence,
+          eventType: event.eventType,
+          event: event.eventType
+        }, 'poll');
         if (options.once) return;
       }
       const remaining = remainingTimeout();

--- a/tools/plan-reviewer/src/cli.ts
+++ b/tools/plan-reviewer/src/cli.ts
@@ -43,20 +43,42 @@ function repoMetadata(cwd = process.cwd()) {
   };
 }
 
-function discoverImageAssets(html: string, planFile: string) {
+function isLocalImagePath(sourceUrl: string): boolean {
+  return ['.gif', '.jpg', '.jpeg', '.png', '.svg', '.webp'].includes(
+    path.extname(sourceUrl.split(/[?#]/, 1)[0] || '').toLowerCase()
+  );
+}
+
+function isInsideDirectory(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+export function discoverImageAssets(html: string, planFile: string) {
   const planDir = path.dirname(planFile);
+  const absolutePlanDir = path.resolve(planDir);
+  const realPlanDir = fs.realpathSync(planDir);
   const assets: Array<{ sourceUrl: string; absolutePath?: string; bytesBase64?: string }> = [];
   for (const sourceUrl of findImageSources(html)) {
     if (/^(data:|blob:|https?:\/\/|\/)/i.test(sourceUrl)) continue;
     const absolutePath = path.resolve(planDir, sourceUrl);
-    if (!fs.existsSync(absolutePath)) {
+    if (!isInsideDirectory(absolutePlanDir, absolutePath)) {
+      assets.push({ sourceUrl });
+      continue;
+    }
+    if (!fs.existsSync(absolutePath) || !isLocalImagePath(sourceUrl)) {
       assets.push({ sourceUrl, absolutePath });
+      continue;
+    }
+    const realAssetPath = fs.realpathSync(absolutePath);
+    if (!isInsideDirectory(realPlanDir, realAssetPath) || !fs.statSync(realAssetPath).isFile()) {
+      assets.push({ sourceUrl });
       continue;
     }
     assets.push({
       sourceUrl,
-      absolutePath,
-      bytesBase64: fs.readFileSync(absolutePath).toString('base64')
+      absolutePath: realAssetPath,
+      bytesBase64: fs.readFileSync(realAssetPath).toString('base64')
     });
   }
   return assets;

--- a/tools/plan-reviewer/src/cli.ts
+++ b/tools/plan-reviewer/src/cli.ts
@@ -61,7 +61,8 @@ export function discoverImageAssets(html: string, planFile: string) {
   const assets: Array<{ sourceUrl: string; absolutePath?: string; bytesBase64?: string }> = [];
   for (const sourceUrl of findImageSources(html)) {
     if (/^(data:|blob:|https?:\/\/|\/)/i.test(sourceUrl)) continue;
-    const absolutePath = path.resolve(planDir, sourceUrl);
+    const filesystemSource = sourceUrl.split(/[?#]/, 1)[0] || sourceUrl;
+    const absolutePath = path.resolve(planDir, filesystemSource);
     if (!isInsideDirectory(absolutePlanDir, absolutePath)) {
       assets.push({ sourceUrl });
       continue;

--- a/tools/plan-reviewer/src/client/annotationAdapter.ts
+++ b/tools/plan-reviewer/src/client/annotationAdapter.ts
@@ -1,0 +1,8 @@
+export async function loadAnnotationDependencies() {
+  const [washi, finder, html2canvas] = await Promise.all([
+    import('@washi-ui/core'),
+    import('@medv/finder'),
+    import('html2canvas')
+  ]);
+  return { washi, finder, html2canvas };
+}

--- a/tools/plan-reviewer/src/client/api.ts
+++ b/tools/plan-reviewer/src/client/api.ts
@@ -3,13 +3,27 @@ import path from 'node:path';
 import { PlanReviewError } from '../util.js';
 
 export async function requestJson<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(url, options);
-  const text = await response.text();
+  let response: Response;
+  try {
+    response = await fetch(url, options);
+  } catch (error) {
+    throw new PlanReviewError('network_error', `Unable to reach ${url}`, 503, {
+      cause: error instanceof Error ? error.message : String(error)
+    }, 'Start plan-reviewer or pass --url / PLAN_REVIEW_URL for the running service.');
+  }
+  let text: string;
+  try {
+    text = await response.text();
+  } catch (error) {
+    throw new PlanReviewError('network_error', `Failed reading response from ${url}`, response.status, {
+      cause: error instanceof Error ? error.message : String(error)
+    });
+  }
   let json: any;
   try {
     json = text ? JSON.parse(text) : {};
   } catch {
-    throw new PlanReviewError('invalid_json', `Expected JSON from ${url}`, response.status);
+    throw new PlanReviewError('invalid_json', `Expected JSON from ${url}`, response.status, { bodyPreview: text.slice(0, 240) });
   }
   if (!response.ok || json.ok === false) {
     const error = json.error ?? {};

--- a/tools/plan-reviewer/src/client/api.ts
+++ b/tools/plan-reviewer/src/client/api.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { PlanReviewError } from '../util.js';
+
+export async function requestJson<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  let json: any;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    throw new PlanReviewError('invalid_json', `Expected JSON from ${url}`, response.status);
+  }
+  if (!response.ok || json.ok === false) {
+    const error = json.error ?? {};
+    throw new PlanReviewError(error.code ?? 'api_error', error.message ?? `Request failed: ${response.status}`, response.status, error.details, error.nextAction);
+  }
+  return (json.data ?? json) as T;
+}
+
+export function appendNdjson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.appendFileSync(filePath, `${JSON.stringify(value)}\n`);
+}

--- a/tools/plan-reviewer/src/config.ts
+++ b/tools/plan-reviewer/src/config.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export interface ServiceConfig {
+  url: string;
+}
+
+function readJson(filePath: string): Partial<ServiceConfig> {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as Partial<ServiceConfig>;
+  } catch {
+    return {};
+  }
+}
+
+export function resolveServiceUrl(explicitUrl?: string, cwd = process.cwd()): string {
+  if (explicitUrl) return explicitUrl.replace(/\/$/, '');
+  if (process.env.PLAN_REVIEW_URL) return process.env.PLAN_REVIEW_URL.replace(/\/$/, '');
+
+  const project = readJson(path.join(cwd, '.plan-reviewer.json'));
+  if (project.url) return project.url.replace(/\/$/, '');
+
+  const user = readJson(path.join(os.homedir(), '.config', 'plan-reviewer', 'config.json'));
+  if (user.url) return user.url.replace(/\/$/, '');
+
+  return 'http://127.0.0.1:4317';
+}

--- a/tools/plan-reviewer/src/config.ts
+++ b/tools/plan-reviewer/src/config.ts
@@ -14,15 +14,23 @@ function readJson(filePath: string): Partial<ServiceConfig> {
   }
 }
 
+function normalizeUrl(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.replace(/\/$/, '') : undefined;
+}
+
 export function resolveServiceUrl(explicitUrl?: string, cwd = process.cwd()): string {
-  if (explicitUrl) return explicitUrl.replace(/\/$/, '');
-  if (process.env.PLAN_REVIEW_URL) return process.env.PLAN_REVIEW_URL.replace(/\/$/, '');
+  const explicit = normalizeUrl(explicitUrl);
+  if (explicit) return explicit;
+  const env = normalizeUrl(process.env.PLAN_REVIEW_URL);
+  if (env) return env;
 
   const project = readJson(path.join(cwd, '.plan-reviewer.json'));
-  if (project.url) return project.url.replace(/\/$/, '');
+  const projectUrl = normalizeUrl(project.url);
+  if (projectUrl) return projectUrl;
 
   const user = readJson(path.join(os.homedir(), '.config', 'plan-reviewer', 'config.json'));
-  if (user.url) return user.url.replace(/\/$/, '');
+  const userUrl = normalizeUrl(user.url);
+  if (userUrl) return userUrl;
 
   return 'http://127.0.0.1:4317';
 }

--- a/tools/plan-reviewer/src/htmlImages.ts
+++ b/tools/plan-reviewer/src/htmlImages.ts
@@ -1,0 +1,29 @@
+const imageTagPattern = /<img\b[^>]*>/gi;
+const srcAttributePattern = /\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/i;
+
+export interface ImageTagMatch {
+  tag: string;
+  src: string;
+  srcAttribute: string;
+}
+
+export function findImageSources(html: string): string[] {
+  const sources: string[] = [];
+  for (const tag of html.match(imageTagPattern) ?? []) {
+    const match = srcAttributePattern.exec(tag);
+    if (match) sources.push(match[1] ?? match[2] ?? match[3] ?? '');
+  }
+  return sources;
+}
+
+export function replaceImageTags(html: string, visitor: (match: ImageTagMatch) => string): string {
+  return html.replace(imageTagPattern, tag => {
+    const match = srcAttributePattern.exec(tag);
+    if (!match) return tag;
+    return visitor({
+      tag,
+      src: match[1] ?? match[2] ?? match[3] ?? '',
+      srcAttribute: match[0]
+    });
+  });
+}

--- a/tools/plan-reviewer/src/htmlImages.ts
+++ b/tools/plan-reviewer/src/htmlImages.ts
@@ -1,29 +1,71 @@
 const imageTagPattern = /<img\b[^>]*>/gi;
-const srcAttributePattern = /\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/i;
 
 export interface ImageTagMatch {
   tag: string;
   src: string;
   srcAttribute: string;
+  srcAttributeStart: number;
+  srcAttributeEnd: number;
+}
+
+function findSrcAttribute(tag: string): Omit<ImageTagMatch, 'tag'> | undefined {
+  let index = /^<img\b/i.test(tag) ? 4 : 0;
+  while (index < tag.length) {
+    while (/\s|\/|>/.test(tag[index] ?? '')) index += 1;
+    const nameStart = index;
+    while (index < tag.length && !/[\s=/>]/.test(tag[index])) index += 1;
+    if (index === nameStart) break;
+    const name = tag.slice(nameStart, index).toLowerCase();
+    while (/\s/.test(tag[index] ?? '')) index += 1;
+    if (tag[index] !== '=') continue;
+    index += 1;
+    while (/\s/.test(tag[index] ?? '')) index += 1;
+
+    let src = '';
+    if (tag[index] === '"' || tag[index] === "'") {
+      const quote = tag[index];
+      index += 1;
+      const valueStart = index;
+      while (index < tag.length && tag[index] !== quote) index += 1;
+      src = tag.slice(valueStart, index);
+      if (tag[index] === quote) index += 1;
+    } else {
+      const valueStart = index;
+      while (index < tag.length && !/[\s/>]/.test(tag[index])) index += 1;
+      src = tag.slice(valueStart, index);
+    }
+
+    if (name === 'src') {
+      return {
+        src,
+        srcAttribute: tag.slice(nameStart, index),
+        srcAttributeStart: nameStart,
+        srcAttributeEnd: index
+      };
+    }
+  }
+  return undefined;
 }
 
 export function findImageSources(html: string): string[] {
   const sources: string[] = [];
   for (const tag of html.match(imageTagPattern) ?? []) {
-    const match = srcAttributePattern.exec(tag);
-    if (match) sources.push(match[1] ?? match[2] ?? match[3] ?? '');
+    const match = findSrcAttribute(tag);
+    if (match) sources.push(match.src);
   }
   return sources;
 }
 
 export function replaceImageTags(html: string, visitor: (match: ImageTagMatch) => string): string {
   return html.replace(imageTagPattern, tag => {
-    const match = srcAttributePattern.exec(tag);
+    const match = findSrcAttribute(tag);
     if (!match) return tag;
     return visitor({
       tag,
-      src: match[1] ?? match[2] ?? match[3] ?? '',
-      srcAttribute: match[0]
+      src: match.src,
+      srcAttribute: match.srcAttribute,
+      srcAttributeStart: match.srcAttributeStart,
+      srcAttributeEnd: match.srcAttributeEnd
     });
   });
 }

--- a/tools/plan-reviewer/src/htmlImages.ts
+++ b/tools/plan-reviewer/src/htmlImages.ts
@@ -1,4 +1,5 @@
-const imageTagPattern = /<img\b[^>]*>/gi;
+import { parseFragment } from 'parse5';
+import type { DefaultTreeAdapterMap } from 'parse5';
 
 export interface ImageTagMatch {
   tag: string;
@@ -8,64 +9,53 @@ export interface ImageTagMatch {
   srcAttributeEnd: number;
 }
 
-function findSrcAttribute(tag: string): Omit<ImageTagMatch, 'tag'> | undefined {
-  let index = /^<img\b/i.test(tag) ? 4 : 0;
-  while (index < tag.length) {
-    while (/\s|\/|>/.test(tag[index] ?? '')) index += 1;
-    const nameStart = index;
-    while (index < tag.length && !/[\s=/>]/.test(tag[index])) index += 1;
-    if (index === nameStart) break;
-    const name = tag.slice(nameStart, index).toLowerCase();
-    while (/\s/.test(tag[index] ?? '')) index += 1;
-    if (tag[index] !== '=') continue;
-    index += 1;
-    while (/\s/.test(tag[index] ?? '')) index += 1;
+type Node = DefaultTreeAdapterMap['node'];
+type ElementNode = DefaultTreeAdapterMap['element'];
+type ImageTagLocation = ImageTagMatch & { tagStart: number; tagEnd: number };
 
-    let src = '';
-    if (tag[index] === '"' || tag[index] === "'") {
-      const quote = tag[index];
-      index += 1;
-      const valueStart = index;
-      while (index < tag.length && tag[index] !== quote) index += 1;
-      src = tag.slice(valueStart, index);
-      if (tag[index] === quote) index += 1;
-    } else {
-      const valueStart = index;
-      while (index < tag.length && !/[\s/>]/.test(tag[index])) index += 1;
-      src = tag.slice(valueStart, index);
-    }
+function isElement(node: Node): node is ElementNode {
+  return 'tagName' in node && typeof node.tagName === 'string';
+}
 
-    if (name === 'src') {
-      return {
-        src,
-        srcAttribute: tag.slice(nameStart, index),
-        srcAttributeStart: nameStart,
-        srcAttributeEnd: index
-      };
+function imageMatches(html: string): ImageTagLocation[] {
+  const fragment = parseFragment(html, { sourceCodeLocationInfo: true }) as DefaultTreeAdapterMap['documentFragment'];
+  const matches: ImageTagLocation[] = [];
+  const walk = (node: Node): void => {
+    if (isElement(node) && node.tagName.toLowerCase() === 'img') {
+      const src = node.attrs.find(attr => attr.name.toLowerCase() === 'src')?.value;
+      const location = node.sourceCodeLocation;
+      const srcLocation = location?.attrs?.src;
+      const startTag = location?.startTag;
+      if (src !== undefined && srcLocation && startTag) {
+        const tagStart = startTag.startOffset;
+        const tagEnd = startTag.endOffset;
+        matches.push({
+          tag: html.slice(tagStart, tagEnd),
+          tagStart,
+          tagEnd,
+          src,
+          srcAttribute: html.slice(srcLocation.startOffset, srcLocation.endOffset),
+          srcAttributeStart: srcLocation.startOffset - tagStart,
+          srcAttributeEnd: srcLocation.endOffset - tagStart
+        });
+      }
     }
-  }
-  return undefined;
+    if ('childNodes' in node && Array.isArray(node.childNodes)) {
+      for (const child of node.childNodes) walk(child as Node);
+    }
+  };
+  for (const child of fragment.childNodes) walk(child as Node);
+  return matches;
 }
 
 export function findImageSources(html: string): string[] {
-  const sources: string[] = [];
-  for (const tag of html.match(imageTagPattern) ?? []) {
-    const match = findSrcAttribute(tag);
-    if (match) sources.push(match.src);
-  }
-  return sources;
+  return imageMatches(html).map(match => match.src);
 }
 
 export function replaceImageTags(html: string, visitor: (match: ImageTagMatch) => string): string {
-  return html.replace(imageTagPattern, tag => {
-    const match = findSrcAttribute(tag);
-    if (!match) return tag;
-    return visitor({
-      tag,
-      src: match.src,
-      srcAttribute: match.srcAttribute,
-      srcAttributeStart: match.srcAttributeStart,
-      srcAttributeEnd: match.srcAttributeEnd
-    });
-  });
+  let output = html;
+  for (const match of imageMatches(html).reverse()) {
+    output = `${output.slice(0, match.tagStart)}${visitor(match)}${output.slice(match.tagEnd)}`;
+  }
+  return output;
 }

--- a/tools/plan-reviewer/src/render/render.ts
+++ b/tools/plan-reviewer/src/render/render.ts
@@ -1,0 +1,158 @@
+import sanitizeHtml from 'sanitize-html';
+import { parse, serialize } from 'parse5';
+import type { DefaultTreeAdapterMap } from 'parse5';
+import type { RegisterPlanInput } from '../schemas.js';
+import { PlanReviewError, sha256, shortHash, slugify } from '../util.js';
+import { replaceImageTags } from '../htmlImages.js';
+
+export interface RenderResult {
+  renderedHtml: string;
+  warnings: Array<{ code: string; detail: string }>;
+}
+
+type ElementNode = DefaultTreeAdapterMap['element'];
+type Node = DefaultTreeAdapterMap['node'];
+
+const allowedTags = sanitizeHtml.defaults.allowedTags.concat([
+  'html',
+  'head',
+  'body',
+  'main',
+  'section',
+  'article',
+  'aside',
+  'figure',
+  'figcaption',
+  'img',
+  'table',
+  'thead',
+  'tbody',
+  'tr',
+  'th',
+  'td',
+  'input',
+  'label'
+]);
+
+const allowedAttributes: Record<string, sanitizeHtml.AllowedAttribute[]> = {
+  ...sanitizeHtml.defaults.allowedAttributes,
+  '*': ['id', 'class', 'style', 'title', 'aria-label', 'role', 'data-*'],
+  img: ['src', 'alt', 'width', 'height', 'title', 'data-*'],
+  input: ['type', 'checked', 'disabled', 'readonly', 'aria-label', 'data-*'],
+  a: ['href', 'name', 'target', 'rel', 'data-*']
+};
+
+function isElement(node: Node): node is ElementNode {
+  return 'tagName' in node && typeof node.tagName === 'string';
+}
+
+function getAttr(node: ElementNode, name: string): string | undefined {
+  return node.attrs.find(attr => attr.name === name)?.value;
+}
+
+function setAttr(node: ElementNode, name: string, value: string): void {
+  const attr = node.attrs.find(item => item.name === name);
+  if (attr) attr.value = value;
+  else node.attrs.push({ name, value });
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/[&<>"]/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[char]!));
+}
+
+function textContent(node: Node): string {
+  if ('value' in node && typeof node.value === 'string') return node.value;
+  if ('childNodes' in node && Array.isArray(node.childNodes)) {
+    return node.childNodes.map(textContent).join('');
+  }
+  return '';
+}
+
+function walk(node: Node, visitor: (node: ElementNode, path: number[]) => void, path: number[] = []): void {
+  if (isElement(node)) visitor(node, path);
+  if ('childNodes' in node && Array.isArray(node.childNodes)) {
+    node.childNodes.forEach((child, index) => walk(child, visitor, [...path, index + 1]));
+  }
+}
+
+function rewriteImages(html: string, input: RegisterPlanInput, warnings: RenderResult['warnings']): string {
+  return replaceImageTags(html, ({ tag, src, srcAttribute }) => {
+    if (/^(https?:)?\/\//i.test(src)) {
+      warnings.push({ code: 'blocked_external_image', detail: `External image '${src}' was blocked; upload a relative image asset instead.` });
+      return `<span data-missing-image="${escapeAttr(src)}" style="display:inline-block;border:1px solid #fbbf24;padding:8px;color:#fbbf24">Blocked external image: ${escapeAttr(src)}</span>`;
+    }
+    if (/^(data:image\/|blob:|\/assets\/)/i.test(src)) {
+      return tag;
+    }
+    const asset = input.assets?.find(item =>
+      item.sourceUrl === src ||
+      item.sourceUrl === src.replace(/^\.\//, '') ||
+      item.sourceUrl.replace(/^\.\//, '') === src
+    );
+    if (!asset?.bytesBase64) {
+      warnings.push({ code: 'missing_image_asset', detail: `Image asset '${src}' was not uploaded; leaving visible placeholder.` });
+      return `<span data-missing-image="${escapeAttr(src)}" style="display:inline-block;border:1px solid #fbbf24;padding:8px;color:#fbbf24">Missing image: ${escapeAttr(src)}</span>`;
+    }
+    const assetHash = sha256(Buffer.from(asset.bytesBase64, 'base64'));
+    return tag.replace(srcAttribute, `src="/assets/${assetHash}" data-plan-image-source="${escapeAttr(src)}" data-plan-image-hash="${assetHash}"`);
+  });
+}
+
+export function renderPlan(input: RegisterPlanInput): RenderResult {
+  const parseErrors: Array<{ code?: string; startLine?: number; startCol?: number }> = [];
+  parse(input.html, {
+    onParseError(error) {
+      parseErrors.push({ code: error.code, startLine: error.startLine, startCol: error.startCol });
+    }
+  });
+  if (parseErrors.length > 0) {
+    throw new PlanReviewError(
+      'unsafe_or_invalid_html',
+      'Plan HTML could not be parsed safely',
+      422,
+      { parseErrors },
+      'Fix the HTML parse errors and register the plan again.'
+    );
+  }
+
+  const warnings: RenderResult['warnings'] = [];
+  let rewritten = rewriteImages(input.html, input, warnings);
+  const blockedScriptCount = (rewritten.match(/<script\b/gi) ?? []).length;
+  if (blockedScriptCount > 0) {
+    warnings.push({ code: 'blocked_script', detail: `${blockedScriptCount} script tag(s) removed from review render.` });
+  }
+  const sanitized = sanitizeHtml(rewritten, {
+    allowedTags,
+    allowedAttributes,
+    allowedSchemes: ['http', 'https', 'mailto'],
+    allowProtocolRelative: false,
+    allowedSchemesByTag: { img: ['data', 'blob'] },
+    disallowedTagsMode: 'discard',
+    transformTags: {
+      a: (_tagName, attribs) => ({
+        tagName: 'a',
+        attribs: { ...attribs, rel: 'noopener noreferrer' }
+      })
+    }
+  });
+
+  const document = parse(sanitized) as DefaultTreeAdapterMap['document'];
+  const used = new Map<string, number>();
+  walk(document as unknown as Node, (node, domPath) => {
+    const text = textContent(node).trim().replace(/\s+/g, ' ').slice(0, 160);
+    const existingId = getAttr(node, 'id');
+    const base =
+      existingId ||
+      (['h1', 'h2', 'h3', 'h4', 'section', 'article'].includes(node.tagName)
+        ? slugify(text || node.tagName)
+        : `${node.tagName}-${domPath.join('-')}-${shortHash(text || serialize(node).slice(0, 160))}`);
+    const count = used.get(base) ?? 0;
+    used.set(base, count + 1);
+    setAttr(node, 'data-plan-node-id', count === 0 ? base : `${base}-${count + 1}`);
+  });
+
+  return {
+    renderedHtml: serialize(document),
+    warnings
+  };
+}

--- a/tools/plan-reviewer/src/render/render.ts
+++ b/tools/plan-reviewer/src/render/render.ts
@@ -76,7 +76,7 @@ function walk(node: Node, visitor: (node: ElementNode, path: number[]) => void, 
 }
 
 function rewriteImages(html: string, input: RegisterPlanInput, warnings: RenderResult['warnings']): string {
-  return replaceImageTags(html, ({ tag, src, srcAttribute }) => {
+  return replaceImageTags(html, ({ tag, src, srcAttributeStart, srcAttributeEnd }) => {
     if (/^(https?:)?\/\//i.test(src)) {
       warnings.push({ code: 'blocked_external_image', detail: `External image '${src}' was blocked; upload a relative image asset instead.` });
       return `<span data-missing-image="${escapeAttr(src)}" style="display:inline-block;border:1px solid #fbbf24;padding:8px;color:#fbbf24">Blocked external image: ${escapeAttr(src)}</span>`;
@@ -94,7 +94,8 @@ function rewriteImages(html: string, input: RegisterPlanInput, warnings: RenderR
       return `<span data-missing-image="${escapeAttr(src)}" style="display:inline-block;border:1px solid #fbbf24;padding:8px;color:#fbbf24">Missing image: ${escapeAttr(src)}</span>`;
     }
     const assetHash = sha256(Buffer.from(asset.bytesBase64, 'base64'));
-    return tag.replace(srcAttribute, `src="/assets/${assetHash}" data-plan-image-source="${escapeAttr(src)}" data-plan-image-hash="${assetHash}"`);
+    const rewrittenSrc = `src="/assets/${assetHash}" data-plan-image-source="${escapeAttr(src)}" data-plan-image-hash="${assetHash}"`;
+    return `${tag.slice(0, srcAttributeStart)}${rewrittenSrc}${tag.slice(srcAttributeEnd)}`;
   });
 }
 

--- a/tools/plan-reviewer/src/schemas.ts
+++ b/tools/plan-reviewer/src/schemas.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+
+export const commentStatusSchema = z.enum(['pending', 'claimed', 'acknowledged', 'resolved']);
+export const anchorTypeSchema = z.enum(['dom', 'text_range', 'image']);
+export const anchorStateSchema = z.enum(['mapped', 'stale', 'unmapped']);
+export const claimModeSchema = z.enum(['one', 'selected', 'bulk']);
+export const eventTypeSchema = z.enum([
+  'comment.created',
+  'comment.claimed',
+  'comment.acknowledged',
+  'comment.resolved',
+  'comment.released',
+  'plan.version.registered',
+  'heartbeat'
+]);
+
+export const markerScreenshotSchema = z.object({
+  contentType: z.literal('image/png'),
+  bytesBase64: z.string().min(1),
+  width: z.number().int().positive(),
+  height: z.number().int().positive(),
+  captureRect: z.record(z.string(), z.unknown()),
+  viewport: z.record(z.string(), z.unknown())
+});
+
+export const registerPlanSchema = z.object({
+  repoKey: z.string().optional(),
+  repoName: z.string().min(1),
+  remoteUrl: z.string().optional(),
+  rootPath: z.string().optional(),
+  branch: z.string().min(1),
+  commitSha: z.string().optional(),
+  planPath: z.string().min(1),
+  slug: z.string().optional(),
+  html: z.string().min(1),
+  fileHash: z.string().min(1),
+  assets: z.array(z.object({
+    sourceUrl: z.string().min(1),
+    absolutePath: z.string().optional(),
+    bytesBase64: z.string().optional()
+  })).optional(),
+  updateMode: z.enum(['upsert', 'new-thread']).default('upsert')
+});
+
+export const createCommentSchema = z.object({
+  versionId: z.string().min(1),
+  body: z.string().min(1),
+  anchorType: anchorTypeSchema,
+  anchor: z.record(z.string(), z.unknown()),
+  markerScreenshot: markerScreenshotSchema.optional(),
+  createdBy: z.object({ displayName: z.string().optional() }).optional(),
+  clientMutationId: z.string().optional()
+});
+
+export const claimCommentsSchema = z.object({
+  mode: claimModeSchema,
+  limit: z.number().int().positive().max(200).optional(),
+  commentIds: z.array(z.string()).optional(),
+  leaseSeconds: z.number().int().positive().max(3600).default(300)
+});
+
+export const ackCommentSchema = z.object({
+  claimId: z.string().min(1),
+  action: z.object({
+    runId: z.string().optional(),
+    handoffPath: z.string().optional(),
+    commitSha: z.string().optional(),
+    note: z.string().optional(),
+    responseSummary: z.string().optional(),
+    changedFiles: z.array(z.string()).optional()
+  }).optional(),
+  clientMutationId: z.string().optional()
+});
+
+export const resolveCommentSchema = z.object({
+  resolutionNote: z.string().min(1),
+  action: z.object({
+    runId: z.string().optional(),
+    commitSha: z.string().optional(),
+    responseSummary: z.string().optional(),
+    changedFiles: z.array(z.string()).optional()
+  }).optional()
+});
+
+export const releaseCommentSchema = z.object({
+  claimId: z.string().min(1),
+  reason: z.string().optional()
+});
+
+export type RegisterPlanInput = z.infer<typeof registerPlanSchema>;
+export type CreateCommentInput = z.infer<typeof createCommentSchema>;
+export type ClaimCommentsInput = z.infer<typeof claimCommentsSchema>;
+export type AckCommentInput = z.infer<typeof ackCommentSchema>;
+export type ResolveCommentInput = z.infer<typeof resolveCommentSchema>;

--- a/tools/plan-reviewer/src/server/app.ts
+++ b/tools/plan-reviewer/src/server/app.ts
@@ -69,6 +69,17 @@ function indexHtml(plans: ReturnType<PlanReviewStore['listPlans']>): string {
 }
 
 function filterPlans(plans: ReturnType<PlanReviewStore['listPlans']>, query: { q?: string; repoKey?: string; status?: string; limit?: string; cursor?: string }) {
+  const parseInteger = (value: string | undefined, name: string, min: number, max?: number): number | undefined => {
+    if (value === undefined) return undefined;
+    if (!/^\d+$/.test(value)) {
+      throw new PlanReviewError('validation_failed', `${name} must be a non-negative integer`, 400, { [name]: value });
+    }
+    const parsed = Number(value);
+    if (!Number.isSafeInteger(parsed) || parsed < min || (max !== undefined && parsed > max)) {
+      throw new PlanReviewError('validation_failed', `${name} must be between ${min} and ${max ?? Number.MAX_SAFE_INTEGER}`, 400, { [name]: value });
+    }
+    return parsed;
+  };
   const text = query.q?.toLowerCase();
   const filtered = plans.filter(item => {
     const matchesRepo = !query.repoKey || item.plan.repoKey === query.repoKey;
@@ -77,8 +88,8 @@ function filterPlans(plans: ReturnType<PlanReviewStore['listPlans']>, query: { q
     const matchesText = !text || haystack.includes(text);
     return matchesRepo && matchesStatus && matchesText;
   });
-  const offset = query.cursor ? Math.max(0, Number(query.cursor)) : 0;
-  const limit = query.limit ? Math.max(1, Math.min(200, Number(query.limit))) : undefined;
+  const offset = parseInteger(query.cursor, 'cursor', 0) ?? 0;
+  const limit = parseInteger(query.limit, 'limit', 1, 200);
   const page = limit ? filtered.slice(offset, offset + limit) : filtered.slice(offset);
   return {
     plans: page,
@@ -556,10 +567,14 @@ export function createApp(options: AppOptions): FastifyInstance {
     reply.type('text/html').send(indexHtml(filterPlans(store.listPlans(), query).plans));
   });
 
-  app.get('/api/plans', async (request) => {
-    const query = request.query as { q?: string; repoKey?: string; status?: string; limit?: string; cursor?: string };
-    const { plans, nextCursor } = filterPlans(store.listPlans(), query);
-    return ok({ plans, nextCursor });
+  app.get('/api/plans', async (request, reply) => {
+    try {
+      const query = request.query as { q?: string; repoKey?: string; status?: string; limit?: string; cursor?: string };
+      const { plans, nextCursor } = filterPlans(store.listPlans(), query);
+      return ok({ plans, nextCursor });
+    } catch (error) {
+      sendError(reply, error);
+    }
   });
 
   app.post('/api/plans/register', async (request, reply) => {

--- a/tools/plan-reviewer/src/server/app.ts
+++ b/tools/plan-reviewer/src/server/app.ts
@@ -1,0 +1,786 @@
+import fs from 'node:fs';
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Fastify, { type FastifyInstance, type FastifyReply } from 'fastify';
+import { ZodError } from 'zod';
+import {
+  ackCommentSchema,
+  claimCommentsSchema,
+  createCommentSchema,
+  registerPlanSchema,
+  releaseCommentSchema,
+  resolveCommentSchema
+} from '../schemas.js';
+import { renderPlan } from '../render/render.js';
+import { PlanReviewStore, type StoredEvent } from '../storage/database.js';
+import { fail, ok, PlanReviewError } from '../util.js';
+
+export interface AppOptions {
+  dbPath: string;
+}
+
+interface EventBus {
+  emitEvent(event: StoredEvent): void;
+  onEvent(planId: string, handler: (event: StoredEvent) => void): () => void;
+}
+
+function createEventBus(): EventBus {
+  const emitter = new EventEmitter();
+  emitter.setMaxListeners(200);
+  return {
+    emitEvent(event) {
+      emitter.emit(event.planId, event);
+    },
+    onEvent(planId, handler) {
+      emitter.on(planId, handler);
+      return () => emitter.off(planId, handler);
+    }
+  };
+}
+
+function eventForSse(event: StoredEvent): string {
+  return `id: ${event.sequence}\nevent: ${event.eventType}\ndata: ${JSON.stringify(event.payload)}\n\n`;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '').replace(/[&<>"]/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[char]!));
+}
+
+function indexHtml(plans: ReturnType<PlanReviewStore['listPlans']>): string {
+  const repos = [...new Set(plans.map(item => item.plan.repoName))].sort();
+  const rows = repos
+    .map(repoName => {
+      const repoPlans = plans.filter(item => item.plan.repoName === repoName);
+      return `<section class="repo-group" data-repo-group="${escapeHtml(repoName)}"><h2>${escapeHtml(repoName)}</h2>${repoPlans.map(item => `<article class="plan-card" data-repo="${escapeHtml(item.plan.repoName)}" data-search="${escapeHtml(`${item.plan.repoName} ${item.plan.slug} ${item.plan.planPath}`.toLowerCase())}">
+      <h2><a href="/p/${escapeHtml(item.plan.id)}">${escapeHtml(item.plan.repoName)} / ${escapeHtml(item.plan.slug)}</a></h2>
+      <p><code>${escapeHtml(item.plan.planPath)}</code></p>
+      <p>Branch <code>${escapeHtml(item.latestVersion.branch)}</code> · pending ${item.counts.pending} · claimed ${item.counts.claimed} · acknowledged ${item.counts.acknowledged} · resolved ${item.counts.resolved} · activity ${escapeHtml(item.activityAt)}</p>
+    </article>`).join('\n')}</section>`;
+    })
+    .join('\n');
+  return `<!doctype html><html><head><meta charset="utf-8"><title>Plan Review Index</title>
+    <style>body{margin:0;background:#0b1020;color:#e5e7eb;font-family:system-ui,sans-serif}main{max-width:980px;margin:0 auto;padding:32px}a{color:#7dd3fc}.toolbar{display:grid;grid-template-columns:minmax(0,1fr) 220px;gap:10px;margin:18px 0}.toolbar input,.toolbar select{background:#0f172a;color:#e5e7eb;border:1px solid #2b364d;border-radius:6px;padding:10px}.plan-card{border:1px solid #2b364d;background:#111827;border-radius:8px;padding:16px;margin:12px 0}code{background:#0f172a;color:#dbeafe;padding:.1rem .25rem;border-radius:4px}@media(max-width:680px){.toolbar{grid-template-columns:1fr}}</style>
+  </head><body><main><h1>Plan Review Index</h1><div class="toolbar"><input id="q" placeholder="Filter plans" aria-label="Filter plans"><select id="repo" aria-label="Filter by repo"><option value="">All repos</option>${repos.map(repo => `<option value="${escapeHtml(repo)}">${escapeHtml(repo)}</option>`).join('')}</select></div><div id="plans">${rows || '<p>No plans registered.</p>'}</div><script>
+  const q=document.getElementById('q'), repo=document.getElementById('repo'), cards=[...document.querySelectorAll('.plan-card')];
+  function apply(){const text=q.value.toLowerCase(), r=repo.value; cards.forEach(card=>{card.hidden=!!((r&&card.dataset.repo!==r)||(text&&!card.dataset.search.includes(text)));}); document.querySelectorAll('.repo-group').forEach(group=>{group.hidden=!group.querySelector('.plan-card:not([hidden])');});}
+  q.addEventListener('input',apply); repo.addEventListener('change',apply);
+  </script></main></body></html>`;
+}
+
+function filterPlans(plans: ReturnType<PlanReviewStore['listPlans']>, query: { q?: string; repoKey?: string; status?: string; limit?: string; cursor?: string }) {
+  const text = query.q?.toLowerCase();
+  const filtered = plans.filter(item => {
+    const matchesRepo = !query.repoKey || item.plan.repoKey === query.repoKey;
+    const matchesStatus = !query.status || Number(item.counts[query.status as keyof typeof item.counts] ?? 0) > 0;
+    const haystack = `${item.plan.repoName} ${item.plan.repoKey} ${item.plan.slug} ${item.plan.planPath}`.toLowerCase();
+    const matchesText = !text || haystack.includes(text);
+    return matchesRepo && matchesStatus && matchesText;
+  });
+  const offset = query.cursor ? Math.max(0, Number(query.cursor)) : 0;
+  const limit = query.limit ? Math.max(1, Math.min(200, Number(query.limit))) : undefined;
+  const page = limit ? filtered.slice(offset, offset + limit) : filtered.slice(offset);
+  return {
+    plans: page,
+    nextCursor: limit && offset + limit < filtered.length ? String(offset + limit) : undefined
+  };
+}
+
+function reviewShell(planId: string): string {
+  const escapedPlanId = escapeHtml(planId);
+  return `<!doctype html><html><head><meta charset="utf-8"><title>Plan ${escapedPlanId}</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'">
+    <link rel="stylesheet" href="/client.css">
+  </head><body data-plan-id="${escapedPlanId}">
+    <div id="app">
+      <aside id="sidebar"><h1>Comments</h1><div id="comments"></div></aside>
+      <main id="review"><iframe id="plan-frame" sandbox="allow-same-origin" src="/render/${escapedPlanId}"></iframe></main>
+    </div>
+    <div id="lightbox" class="lightbox" hidden><header><button id="zoom-out">-</button><button id="zoom-reset">Reset</button><button id="zoom-in">+</button><button id="pan-toggle">Pan</button><button id="close-lightbox">Close</button></header><div id="lightbox-stage" class="lightbox-stage"><img id="lightbox-image" alt=""><div id="image-selection-box" hidden></div></div></div>
+    <div id="composer" hidden><textarea id="comment-body" placeholder="Comment on selection"></textarea><button id="submit-comment">Submit</button><button id="cancel-comment">Cancel</button></div>
+    <script src="/vendor/html2canvas.js"></script>
+    <script type="module" src="/client.js"></script>
+  </body></html>`;
+}
+
+function resolvedModuleFile(specifier: string): string {
+  return fileURLToPath(import.meta.resolve(specifier));
+}
+
+const clientCss = `
+body{margin:0;background:#0b1020;color:#e5e7eb;font-family:system-ui,sans-serif}
+#app{display:grid;grid-template-columns:minmax(0,1fr) 320px;min-height:100vh}
+#review{grid-column:1;position:relative}#sidebar{grid-column:2;grid-row:1;border-left:1px solid #2b364d;padding:16px;background:#111827}
+#plan-frame{width:100%;height:100vh;border:0;background:white}.comment-row{border:1px solid #2b364d;padding:10px;margin:8px 0;border-radius:8px;background:#0f172a}.comment-row small{color:#a7b0c0}.marker{position:absolute;z-index:9;width:24px;height:24px;border-radius:50%;display:grid;place-items:center;background:#0ea5e9;color:white;border:2px solid #dbeafe;font-weight:700;box-shadow:0 8px 18px rgba(0,0,0,.35);pointer-events:none}
+#composer{position:fixed;right:340px;top:80px;background:#0f172a;border:1px solid #38bdf8;padding:12px;border-radius:8px;z-index:20;box-shadow:0 12px 32px rgba(0,0,0,.4)}
+#composer textarea{width:260px;height:90px;background:#020617;color:#e5e7eb;border:1px solid #2b364d;border-radius:6px;padding:8px;display:block}
+	#composer button{margin-top:8px;margin-right:8px}.plan-review-selected{outline:3px solid #38bdf8!important;box-shadow:0 0 0 4px rgba(56,189,248,.2)!important}.lightbox{position:fixed;inset:36px 360px 36px 36px;background:#020617;border:1px solid #38bdf8;z-index:12;display:grid;grid-template-rows:auto 1fr}.lightbox[hidden]{display:none}.lightbox header{display:flex;gap:8px;padding:10px;border-bottom:1px solid #2b364d}.lightbox img{max-width:100%;max-height:100%;place-self:center;transform-origin:center}.lightbox-stage{display:grid;overflow:hidden;position:relative}#image-selection-box{position:absolute;border:2px solid #38bdf8;background:rgba(56,189,248,.2);pointer-events:none}
+`;
+
+const clientJs = `
+import { finder } from '/vendor/finder.js';
+import { Washi } from '/vendor/washi.js';
+
+const planId = document.body.dataset.planId;
+const frame = document.getElementById('plan-frame');
+const composer = document.getElementById('composer');
+const body = document.getElementById('comment-body');
+const comments = document.getElementById('comments');
+const lightbox = document.getElementById('lightbox');
+const lightboxImage = document.getElementById('lightbox-image');
+const lightboxStage = document.getElementById('lightbox-stage');
+const imageSelectionBox = document.getElementById('image-selection-box');
+let selected = null;
+let selectedForScreenshot = null;
+let pendingAnchor = null;
+let markerCount = 0;
+let markerComments = [];
+let markerReflowQueued = false;
+let zoom = 1;
+let panX = 0;
+let panY = 0;
+let panMode = false;
+let versionId = null;
+let lightboxDragStart = null;
+let lightboxPanStart = null;
+let washi = null;
+async function loadMeta(){
+  const res = await fetch('/api/plans/'+planId);
+  const json = await res.json();
+  versionId = json.data.latestVersion.id;
+  renderComments(json.data.comments || []);
+}
+function renderComments(items){
+  renderMarkers(items);
+  comments.innerHTML = items.map(c => {
+    const response = c.agentResponse || {};
+    const changed = Array.isArray(response.changedFiles) ? response.changedFiles.join(', ') : '';
+    const metadata = [response.responseSummary || response.resolutionNote || response.note, changed, response.runId, response.handoffPath, response.commitSha].filter(Boolean).map(escapeHtml).join(' · ');
+    const context = [c.anchor?.textPreview, c.anchor?.selectedText, c.anchor?.textQuote?.exact, c.anchor?.cssSelector].filter(Boolean).map(escapeHtml).join(' · ');
+    const screenshot = c.screenshotAssetId ? '<a href="/comment-assets/'+encodeURIComponent(c.screenshotAssetId)+'">screenshot</a>' : '';
+    return '<div class="comment-row"><strong>#'+c.sequence+' '+escapeHtml(c.status)+'</strong><p>'+escapeHtml(c.body)+'</p><small>'+escapeHtml(c.anchorType)+' · '+escapeHtml(c.anchorState)+(metadata ? ' · '+metadata : '')+'</small>'+(context ? '<p><small>Context: '+context+'</small></p>' : '')+(screenshot ? '<p><small>'+screenshot+'</small></p>' : '')+'</div>';
+  }).join('');
+}
+function escapeHtml(value){ return String(value).replace(/[&<>"]/g, ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[ch])); }
+function renderMarkers(items){
+  markerComments = items.filter(comment => comment.anchor?.rect);
+  redrawMarkers();
+}
+function selectorForPlanNodeId(planNodeId){
+  return '[data-plan-node-id=' + JSON.stringify(String(planNodeId)) + ']';
+}
+function currentRectForComment(comment){
+  const anchor = comment.anchor || {};
+  try {
+    const doc = frame.contentDocument;
+    if (doc) {
+      let target = anchor.planNodeId ? doc.querySelector(selectorForPlanNodeId(anchor.planNodeId)) : null;
+      if (!target && anchor.cssSelector) target = doc.querySelector(anchor.cssSelector);
+      if (target) {
+        const rect = target.getBoundingClientRect();
+        return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+      }
+    }
+  } catch {}
+  return anchor.rect;
+}
+function redrawMarkers(){
+  document.querySelectorAll('.marker').forEach(marker => marker.remove());
+  markerCount = 0;
+  for (const comment of markerComments) {
+    const rect = currentRectForComment(comment);
+    if (!rect) continue;
+    markerCount = Math.max(markerCount, Number(comment.sequence) || 0);
+    addMarker(rect, comment.sequence);
+  }
+}
+function scheduleMarkerReflow(){
+  if (markerReflowQueued) return;
+  markerReflowQueued = true;
+  requestAnimationFrame(() => {
+    markerReflowQueued = false;
+    redrawMarkers();
+  });
+}
+async function markerScreenshot(anchor){
+  if (typeof html2canvas !== 'function' || !frame.contentDocument || !frame.contentWindow) {
+    throw new Error('html2canvas unavailable');
+  }
+    const rect = anchor.rect || { x:0, y:0, width:1, height:1 };
+    const target = selectedForScreenshot || frame.contentDocument.body;
+    const targetRect = target.getBoundingClientRect();
+    const cropWidth = Math.min(960, Math.max(320, targetRect.width || rect.width || 1));
+    const cropHeight = Math.min(640, Math.max(220, targetRect.height || rect.height || 1));
+    const captureRoot = document.createElement('div');
+    captureRoot.style.position = 'fixed';
+    captureRoot.style.left = '-10000px';
+    captureRoot.style.top = '0';
+    captureRoot.style.width = cropWidth + 'px';
+    captureRoot.style.minHeight = cropHeight + 'px';
+    captureRoot.style.padding = '16px';
+    captureRoot.style.background = '#ffffff';
+    captureRoot.style.color = '#0f172a';
+    captureRoot.style.font = getComputedStyle(document.body).font;
+    captureRoot.innerHTML = target.outerHTML || target.textContent || '';
+    document.body.appendChild(captureRoot);
+    let canvas;
+    try {
+      canvas = await Promise.race([
+        html2canvas(captureRoot, { backgroundColor: '#ffffff', width: cropWidth, height: cropHeight, useCORS: false, allowTaint: false }),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('html2canvas_timeout')), 1500))
+      ]);
+    } finally {
+      captureRoot.remove();
+    }
+    const ctx = canvas.getContext('2d');
+    const markerX = Math.min(canvas.width - 16, Math.max(16, rect.width ? rect.width - 10 : 16));
+    const markerY = 16;
+    ctx.fillStyle = '#0ea5e9'; ctx.strokeStyle = '#dbeafe'; ctx.lineWidth = 3;
+    ctx.beginPath(); ctx.arc(markerX, markerY, 13, 0, Math.PI * 2); ctx.fill(); ctx.stroke();
+    ctx.fillStyle = '#ffffff'; ctx.font = '700 13px system-ui'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    ctx.fillText(String(markerCount), markerX, markerY + 1);
+  return { contentType:'image/png', bytesBase64: canvas.toDataURL('image/png').split(',')[1], width: canvas.width, height: canvas.height, captureRect: { x: targetRect.x, y: targetRect.y, width: cropWidth, height: cropHeight }, viewport:{ width:innerWidth, height:innerHeight } };
+}
+function domPathFor(element){
+  const parts=[]; let node=element;
+  while(node && node.nodeType===1 && parts.length<8){ const parent=node.parentElement; const index=parent ? [...parent.children].filter(child=>child.tagName===node.tagName).indexOf(node)+1 : 1; parts.unshift(node.tagName.toLowerCase()+'['+index+']'); node=parent; }
+  return parts.join('/');
+}
+function xpathFor(element){ return '/' + domPathFor(element); }
+function headingPathFor(element){
+  const headings=[]; let node=element;
+  while(node){ const heading=node.querySelector && node.querySelector('h1,h2,h3,h4,h5,h6'); if(heading) headings.unshift(heading.textContent.trim().slice(0,80)); node=node.parentElement; }
+  return [...new Set(headings)].slice(-5);
+}
+function cssFor(element){
+  try { return finder(element, { root: frame.contentDocument.body }); } catch {}
+  if(element.id) return '#'+CSS.escape(element.id);
+  const nodeId=element.getAttribute('data-plan-node-id');
+  if(nodeId) return element.tagName.toLowerCase()+'[data-plan-node-id="'+nodeId.replace(/"/g,'')+'"]';
+  return element.tagName.toLowerCase();
+}
+async function mountWashiOverlay(){
+  try {
+    if (washi) washi.unmount();
+    washi = new Washi({ load: async () => [], save: async () => {}, update: async () => {}, delete: async () => {} });
+    await washi.mount(frame, { readOnly: true, disableBuiltinDialog: true });
+    washi.setMode('view');
+  } catch (error) {
+    console.warn('washi overlay unavailable', error);
+  }
+}
+function addMarker(rect, label){
+  if (!label) markerCount += 1;
+  const frameRect = frame.getBoundingClientRect();
+  const marker = document.createElement('div');
+  marker.className = 'marker';
+  marker.textContent = String(label || markerCount);
+  const x = Number(rect.x ?? rect.left ?? 0);
+  const y = Number(rect.y ?? rect.top ?? 0);
+  marker.style.left = Math.max(8, frameRect.left + x + Number(rect.width ?? 0) - 10) + 'px';
+  marker.style.top = Math.max(8, frameRect.top + y - 10) + 'px';
+  document.getElementById('review').appendChild(marker);
+  return marker;
+}
+function assetIdFor(element){
+  const value = element.getAttribute('data-plan-image-hash') || element.currentSrc || element.src || '';
+  const match = value.match(/\\/assets\\/([^?#]+)/);
+  return match ? match[1] : value || undefined;
+}
+function hashString(value){
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+function imagePointFor(element, event){
+  const rect = element.getBoundingClientRect();
+  const x = event ? Math.min(1, Math.max(0, (event.clientX - rect.left) / Math.max(1, rect.width))) : 0.5;
+  const y = event ? Math.min(1, Math.max(0, (event.clientY - rect.top) / Math.max(1, rect.height))) : 0.5;
+  return { x, y };
+}
+function displayedRectFor(element){
+  const rect = element.getBoundingClientRect();
+  return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+}
+function applyImageTransform(){
+  lightboxImage.style.transform = 'translate('+panX+'px, '+panY+'px) scale('+zoom+')';
+  if (pendingAnchor?.type === 'image') pendingAnchor.anchor.zoomState = { scale: zoom, panX, panY };
+}
+function anchorForElement(element, event){
+  const rect = element.getBoundingClientRect();
+  const isImage = element.tagName.toLowerCase() === 'img';
+  const point = isImage ? imagePointFor(element, event) : undefined;
+  return {
+    type: isImage ? 'image' : 'dom',
+    anchor: {
+      planNodeId: element.getAttribute('data-plan-node-id'),
+      cssSelector: cssFor(element),
+      domPath: domPathFor(element),
+      xpath: xpathFor(element),
+      textQuote: { exact: element.textContent.trim().slice(0, 160), prefix: '', suffix: '' },
+      headingPath: headingPathFor(element),
+      rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+      viewport: { width: innerWidth, height: innerHeight },
+      textPreview: element.textContent.trim().slice(0, 120),
+      outerHtmlPreview: element.outerHTML.slice(0, 500),
+      sourceUrl: element.getAttribute('data-plan-image-source') || element.currentSrc || element.src || undefined,
+      imageAssetId: isImage ? assetIdFor(element) : undefined,
+      imageHash: isImage ? (element.getAttribute('data-plan-image-hash') || hashString(element.currentSrc || element.src || element.outerHTML)) : undefined,
+      naturalSize: isImage ? { width: element.naturalWidth, height: element.naturalHeight } : undefined,
+      displayedRect: isImage ? displayedRectFor(element) : undefined,
+      zoomState: isImage ? { scale: zoom, panX, panY } : undefined,
+      normalizedPoint: point
+    },
+    rect
+  };
+}
+function showLightbox(element){
+  lightboxImage.src = element.currentSrc || element.src;
+  lightboxImage.alt = element.alt || 'Plan image';
+  zoom = 1;
+  panX = 0;
+  panY = 0;
+  panMode = false;
+  applyImageTransform();
+  imageSelectionBox.hidden = true;
+  lightbox.hidden = false;
+}
+function lightboxImagePoint(event){
+  const rect = lightboxImage.getBoundingClientRect();
+  return {
+    x: Math.min(1, Math.max(0, (event.clientX - rect.left) / Math.max(1, rect.width))),
+    y: Math.min(1, Math.max(0, (event.clientY - rect.top) / Math.max(1, rect.height)))
+  };
+}
+function updateImageRectangle(start, end){
+  const x = Math.min(start.x, end.x);
+  const y = Math.min(start.y, end.y);
+  const width = Math.abs(end.x - start.x);
+  const height = Math.abs(end.y - start.y);
+  if (pendingAnchor?.type === 'image') {
+    pendingAnchor.anchor.normalizedRect = { x, y, width, height };
+    pendingAnchor.anchor.zoomState = { scale: zoom, panX, panY };
+    pendingAnchor.anchor.displayedRect = displayedRectFor(selected);
+  }
+  const imageRect = lightboxImage.getBoundingClientRect();
+  const stageRect = lightboxStage.getBoundingClientRect();
+  imageSelectionBox.style.left = (imageRect.left - stageRect.left + x * imageRect.width) + 'px';
+  imageSelectionBox.style.top = (imageRect.top - stageRect.top + y * imageRect.height) + 'px';
+  imageSelectionBox.style.width = (width * imageRect.width) + 'px';
+  imageSelectionBox.style.height = (height * imageRect.height) + 'px';
+  imageSelectionBox.hidden = width < 0.01 || height < 0.01;
+}
+function anchorForSelection(selection){
+  const range = selection.getRangeAt(0);
+  const rect = range.getBoundingClientRect();
+  const context = range.commonAncestorContainer.nodeType === 1 ? range.commonAncestorContainer : range.commonAncestorContainer.parentElement;
+  const start = range.startContainer.parentElement || context || frame.contentDocument.body;
+  const end = range.endContainer.parentElement || start;
+  const contextElement = context || start;
+  selectedForScreenshot = contextElement;
+  return {
+    type: 'text_range',
+    anchor: {
+      startContainerSelector: cssFor(start),
+      startOffset: range.startOffset,
+      endContainerSelector: cssFor(end),
+      endOffset: range.endOffset,
+      selectedText: selection.toString(),
+      clientRects: [...range.getClientRects()].map(item => ({ x:item.x, y:item.y, width:item.width, height:item.height })),
+      planNodeId: contextElement.getAttribute('data-plan-node-id'),
+      cssSelector: cssFor(contextElement),
+      domPath: domPathFor(contextElement),
+      xpath: xpathFor(contextElement),
+      textQuote: { exact: selection.toString(), prefix: contextElement.textContent.slice(0, 80), suffix: contextElement.textContent.slice(-80) },
+      headingPath: headingPathFor(contextElement),
+      textPreview: selection.toString().slice(0,120),
+      outerHtmlPreview: contextElement.outerHTML.slice(0, 500),
+      rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+      viewport: { width: innerWidth, height: innerHeight }
+    },
+    rect
+  };
+}
+let frameListenersAttached = false;
+function attachFrameListeners(){
+  if (frameListenersAttached || !frame.contentDocument) return;
+  frameListenersAttached = true;
+  const doc = frame.contentDocument;
+  doc.addEventListener('mouseup', () => {
+    const selection = doc.getSelection();
+    if (!selection || selection.isCollapsed || !selection.toString().trim()) return;
+    pendingAnchor = anchorForSelection(selection);
+    composer.hidden = false;
+    body.focus();
+  }, true);
+  doc.addEventListener('click', event => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (selected) selected.classList.remove('plan-review-selected');
+    selected = event.target.closest('[data-plan-node-id]') || event.target;
+    selectedForScreenshot = selected;
+    selected.classList.add('plan-review-selected');
+    pendingAnchor = anchorForElement(selected, event);
+    if (selected.tagName.toLowerCase() === 'img') showLightbox(selected);
+    composer.hidden = false;
+    body.focus();
+  }, true);
+  doc.addEventListener('scroll', scheduleMarkerReflow, true);
+  frame.contentWindow?.addEventListener('scroll', scheduleMarkerReflow);
+  frame.contentWindow?.addEventListener('resize', scheduleMarkerReflow);
+}
+frame.addEventListener('load', () => { frameListenersAttached = false; attachFrameListeners(); mountWashiOverlay(); });
+window.addEventListener('resize', scheduleMarkerReflow);
+if (frame.contentDocument && frame.contentDocument.readyState !== 'loading') setTimeout(attachFrameListeners, 0);
+document.getElementById('close-lightbox').addEventListener('click', () => { lightbox.hidden = true; });
+document.getElementById('zoom-in').addEventListener('click', () => { zoom = Math.min(4, zoom + .25); applyImageTransform(); });
+document.getElementById('zoom-out').addEventListener('click', () => { zoom = Math.max(.5, zoom - .25); applyImageTransform(); });
+document.getElementById('zoom-reset').addEventListener('click', () => { zoom = 1; panX = 0; panY = 0; applyImageTransform(); });
+document.getElementById('pan-toggle').addEventListener('click', () => { panMode = !panMode; });
+document.getElementById('cancel-comment').addEventListener('click', () => { composer.hidden = true; });
+lightboxStage.addEventListener('mousedown', event => {
+  if (!selected || selected.tagName.toLowerCase() !== 'img') return;
+  if (panMode && zoom > 1) {
+    lightboxPanStart = { clientX: event.clientX, clientY: event.clientY, panX, panY };
+    return;
+  }
+  lightboxDragStart = lightboxImagePoint(event);
+  updateImageRectangle(lightboxDragStart, lightboxDragStart);
+});
+lightboxStage.addEventListener('mousemove', event => {
+  if (lightboxPanStart) {
+    panX = lightboxPanStart.panX + event.clientX - lightboxPanStart.clientX;
+    panY = lightboxPanStart.panY + event.clientY - lightboxPanStart.clientY;
+    applyImageTransform();
+    return;
+  }
+  if (!lightboxDragStart) return;
+  updateImageRectangle(lightboxDragStart, lightboxImagePoint(event));
+});
+window.addEventListener('mouseup', event => {
+  if (lightboxPanStart) {
+    lightboxPanStart = null;
+    return;
+  }
+  if (!lightboxDragStart) return;
+  updateImageRectangle(lightboxDragStart, lightboxImagePoint(event));
+  lightboxDragStart = null;
+});
+document.getElementById('submit-comment').addEventListener('click', async () => {
+  if (!pendingAnchor || !body.value.trim()) return;
+  const note = body.value;
+  const marker = addMarker(pendingAnchor.rect);
+  await new Promise(requestAnimationFrame);
+  await new Promise(requestAnimationFrame);
+  let screenshot;
+  try {
+    screenshot = await markerScreenshot(pendingAnchor);
+  } catch {
+    marker.remove();
+    alert('Unable to capture marker screenshot. Please retry after the plan finishes rendering.');
+    return;
+  }
+  const res = await fetch('/api/plans/'+planId+'/comments', {
+    method:'POST',
+    headers:{'content-type':'application/json'},
+    body: JSON.stringify({ versionId, body: note, anchorType:pendingAnchor.type, anchor: pendingAnchor.anchor, markerScreenshot: screenshot, createdBy:{ displayName: localStorage.getItem('plan-reviewer-name') || 'Anonymous reviewer' } })
+  });
+  const json = await res.json();
+  if (!json.ok) { marker.remove(); alert(json.error.message); }
+  body.value = '';
+  composer.hidden = true;
+  await loadMeta();
+});
+const source = new EventSource('/api/plans/'+planId+'/events?mode=queue');
+source.addEventListener('comment.created', loadMeta);
+source.addEventListener('comment.claimed', loadMeta);
+source.addEventListener('comment.acknowledged', loadMeta);
+source.addEventListener('comment.resolved', loadMeta);
+source.addEventListener('comment.released', loadMeta);
+loadMeta();
+`;
+
+function sendError(reply: FastifyReply, error: unknown) {
+  if (error instanceof PlanReviewError) {
+    reply.code(error.statusCode).send(fail(error));
+    return;
+  }
+  if (error instanceof ZodError) {
+    const wrapped = new PlanReviewError(
+      'validation_failed',
+      'Request body failed validation',
+      400,
+      { issues: error.issues },
+      'Correct the request payload to match the documented endpoint contract, then retry.'
+    );
+    reply.code(400).send(fail(wrapped));
+    return;
+  }
+  const wrapped = new PlanReviewError('internal_error', error instanceof Error ? error.message : String(error), 500);
+  reply.code(500).send(fail(wrapped));
+}
+
+export function createApp(options: AppOptions): FastifyInstance {
+  const app = Fastify({ logger: false });
+  const store = new PlanReviewStore(options.dbPath);
+  const bus = createEventBus();
+  const emitExpired = (planId?: string) => {
+    const events = store.releaseExpiredClaims(planId);
+    for (const event of events) bus.emitEvent(event);
+    return events;
+  };
+
+  app.addHook('onClose', async () => store.close());
+
+  app.get('/health', async () => ok({ status: 'ok' }));
+  app.get('/favicon.ico', async (_request, reply) => reply.code(204).send());
+  app.get('/client.css', async (_request, reply) => reply.type('text/css').send(clientCss));
+  app.get('/client.js', async (_request, reply) => reply.type('application/javascript').send(clientJs));
+  app.get('/vendor/html2canvas.js', async (_request, reply) => {
+    reply
+      .type('application/javascript')
+      .send(fs.readFileSync(path.join(path.dirname(resolvedModuleFile('html2canvas')), 'html2canvas.min.js')));
+  });
+  app.get('/vendor/finder.js', async (_request, reply) => {
+    reply.type('application/javascript').send(fs.readFileSync(resolvedModuleFile('@medv/finder')));
+  });
+  app.get('/vendor/washi.js', async (_request, reply) => {
+    reply.type('application/javascript').send(fs.readFileSync(resolvedModuleFile('@washi-ui/core')));
+  });
+
+  app.get('/', async (request, reply) => {
+    const query = request.query as { q?: string; repoKey?: string; status?: string };
+    reply.type('text/html').send(indexHtml(filterPlans(store.listPlans(), query).plans));
+  });
+
+  app.get('/api/plans', async (request) => {
+    const query = request.query as { q?: string; repoKey?: string; status?: string; limit?: string; cursor?: string };
+    const { plans, nextCursor } = filterPlans(store.listPlans(), query);
+    return ok({ plans, nextCursor });
+  });
+
+  app.post('/api/plans/register', async (request, reply) => {
+    try {
+      const input = registerPlanSchema.parse(request.body);
+      const rendered = renderPlan(input);
+      const result = store.registerPlan(input, rendered.renderedHtml, rendered.warnings);
+      bus.emitEvent(result.event);
+      return ok({
+        planId: result.planId,
+        versionId: result.versionId,
+        repoId: result.repoId,
+        reviewUrl: result.reviewUrl,
+        indexUrl: result.indexUrl,
+        watchCommand: result.watchCommand,
+        renderedWithWarnings: rendered.warnings
+      });
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.get('/p/:planId', async (request, reply) => {
+    try {
+      const { planId } = request.params as { planId: string };
+      const { plan } = store.getPlan(planId);
+      reply.type('text/html').send(reviewShell(plan.id));
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.get('/render/:planId', async (request, reply) => {
+    try {
+      const { planId } = request.params as { planId: string };
+      reply
+        .header('Content-Security-Policy', "default-src 'none'; script-src 'none'; connect-src 'none'; form-action 'none'; base-uri 'none'; style-src 'unsafe-inline'; img-src 'self' data: blob:")
+        .type('text/html')
+        .send(store.getRenderedHtml(planId));
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.get('/api/plans/:planId', async (request, reply) => {
+    try {
+	      const { planId } = request.params as { planId: string };
+	      const { plan, version } = store.getPlan(planId);
+	      emitExpired(plan.id);
+	      return ok({
+        plan,
+        latestVersion: version,
+        assets: store.listPlanAssets(version.id),
+        versions: [version],
+        counts: store.listPlans().find(item => item.plan.id === plan.id)?.counts ?? { pending: 0, claimed: 0, acknowledged: 0, resolved: 0 },
+        comments: store.listComments(plan.id),
+        reviewUrl: `/p/${plan.id}`
+      });
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.post('/api/plans/:planId/comments', async (request, reply) => {
+    try {
+      const { planId } = request.params as { planId: string };
+      const { plan } = store.getPlan(planId);
+      const result = store.createComment(plan.id, createCommentSchema.parse(request.body));
+      bus.emitEvent(result.event);
+      return ok(result);
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.get('/api/plans/:planId/comments', async (request, reply) => {
+    try {
+	      const { planId } = request.params as { planId: string };
+	      const query = request.query as { status?: string; anchorState?: string; sinceSequence?: string; versionId?: string };
+	      const { plan } = store.getPlan(planId);
+	      emitExpired(plan.id);
+	      return ok({
+        comments: store.listComments(plan.id, {
+          status: query.status,
+          anchorState: query.anchorState,
+          versionId: query.versionId,
+          sinceSequence: query.sinceSequence ? Number(query.sinceSequence) : undefined
+        })
+      });
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.post('/api/plans/:planId/comments/claim', async (request, reply) => {
+    try {
+      const { planId } = request.params as { planId: string };
+      const { plan } = store.getPlan(planId);
+      const agentId = request.headers['x-agent-id']?.toString() || 'plan-review-cli';
+      const result = store.claimComments(plan.id, claimCommentsSchema.parse(request.body), agentId);
+      for (const event of result.events) bus.emitEvent(event);
+      return ok(result);
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.post('/api/comments/:commentId/ack', async (request, reply) => {
+    try {
+	      const { commentId } = request.params as { commentId: string };
+	      const result = store.ackComment(commentId, ackCommentSchema.parse(request.body));
+	      for (const event of result.expiredEvents ?? []) bus.emitEvent(event);
+	      if ('event' in result && result.event) bus.emitEvent(result.event);
+      return ok({ comment: result.comment, alreadyAcknowledged: result.alreadyAcknowledged });
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.post('/api/comments/:commentId/resolve', async (request, reply) => {
+    try {
+      const { commentId } = request.params as { commentId: string };
+      const result = store.resolveComment(commentId, resolveCommentSchema.parse(request.body));
+      if ('event' in result && result.event) bus.emitEvent(result.event);
+      return ok({ comment: result.comment, alreadyResolved: result.alreadyResolved });
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.post('/api/comments/:commentId/release', async (request, reply) => {
+    try {
+      const { commentId } = request.params as { commentId: string };
+      const input = releaseCommentSchema.parse(request.body);
+      const result = store.releaseComment(commentId, input.claimId, input.reason);
+      bus.emitEvent(result.event);
+      return ok({ comment: result.comment });
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+	  app.get('/api/agent/queue', async (request) => {
+	    const query = request.query as { repoKey?: string; planId?: string; limit?: string };
+	    emitExpired(query.planId);
+	    return ok(store.queueSnapshot({
+      repoKey: query.repoKey,
+      planId: query.planId,
+      limit: query.limit ? Number(query.limit) : undefined
+    }));
+  });
+
+  app.get('/api/plans/:planId/events/poll', async (request, reply) => {
+    try {
+	      const { planId } = request.params as { planId: string };
+	      const query = request.query as { afterSequence?: string; mode?: 'all' | 'queue'; limit?: string };
+	      const { plan } = store.getPlan(planId);
+	      emitExpired(plan.id);
+	      return ok({
+        events: store.eventsAfter(plan.id, Number(query.afterSequence ?? 0), query.mode ?? 'queue', Number(query.limit ?? 200)),
+        latestSequence: store.eventsAfter(plan.id, 0, 'all', 10000).at(-1)?.sequence ?? 0,
+        retryAfterMs: 10000
+      });
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.get('/api/plans/:planId/events', async (request, reply) => {
+    const { planId } = request.params as { planId: string };
+    const query = request.query as { mode?: 'all' | 'queue' };
+    try {
+	      const { plan } = store.getPlan(planId);
+	      emitExpired(plan.id);
+	      const lastEventId = Number(request.headers['last-event-id'] ?? 0);
+      reply.hijack();
+      reply.raw.writeHead(200, {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive'
+      });
+      reply.raw.write(`event: connected\ndata: ${JSON.stringify({ serverTime: new Date().toISOString() })}\n\n`);
+      for (const event of store.eventsAfter(plan.id, lastEventId, query.mode ?? 'queue')) {
+        reply.raw.write(eventForSse(event));
+      }
+      const off = bus.onEvent(plan.id, event => {
+        if ((query.mode ?? 'queue') === 'queue' && !event.eventType.startsWith('comment.')) return;
+        reply.raw.write(eventForSse(event));
+      });
+	      const heartbeat = setInterval(() => {
+	        emitExpired(plan.id);
+	        reply.raw.write(`event: heartbeat\ndata: ${JSON.stringify({ latestSequence: store.eventsAfter(plan.id).at(-1)?.sequence ?? 0, serverTime: new Date().toISOString() })}\n\n`);
+      }, 15000);
+      request.raw.on('close', () => {
+        clearInterval(heartbeat);
+        off();
+      });
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.get('/assets/:assetId', async (request, reply) => {
+    try {
+      const { assetId } = request.params as { assetId: string };
+      const asset = store.getAsset(assetId);
+      reply.header('cache-control', 'public, max-age=31536000, immutable').type(asset.contentType).send(fs.readFileSync(asset.blobPath));
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  app.get('/comment-assets/:assetId', async (request, reply) => {
+    try {
+      const { assetId } = request.params as { assetId: string };
+      const asset = store.getAsset(assetId);
+      reply.header('cache-control', 'public, max-age=31536000, immutable').type(asset.contentType).send(fs.readFileSync(asset.blobPath));
+    } catch (error) {
+      sendError(reply, error);
+    }
+  });
+
+  return app;
+}

--- a/tools/plan-reviewer/src/server/app.ts
+++ b/tools/plan-reviewer/src/server/app.ts
@@ -628,7 +628,7 @@ export function createApp(options: AppOptions): FastifyInstance {
       const { planId } = request.params as { planId: string };
       const { plan } = store.getPlan(planId);
       const result = store.createComment(plan.id, createCommentSchema.parse(request.body));
-      bus.emitEvent(result.event);
+      if (result.created) bus.emitEvent(result.event);
       return ok(result);
     } catch (error) {
       sendError(reply, error);

--- a/tools/plan-reviewer/src/server/serve.ts
+++ b/tools/plan-reviewer/src/server/serve.ts
@@ -1,0 +1,10 @@
+import { createApp } from './app.js';
+
+export async function serve(options: { host: string; port: number; dbPath: string }) {
+  if (options.host === '0.0.0.0' || options.host === '::') {
+    console.warn(`WARNING: plan-reviewer is listening on ${options.host}:${options.port} without authentication. Anyone who can reach this service can view and comment on plans.`);
+  }
+  const app = createApp({ dbPath: options.dbPath });
+  await app.listen({ host: options.host, port: options.port });
+  return app;
+}

--- a/tools/plan-reviewer/src/storage/database.ts
+++ b/tools/plan-reviewer/src/storage/database.ts
@@ -479,32 +479,52 @@ export class PlanReviewStore {
       JOIN plan_versions v ON v.id = (
         SELECT id FROM plan_versions WHERE plan_id = p.id ORDER BY created_at DESC LIMIT 1
       )
-      WHERE p.id = ? OR p.slug = ?
+      WHERE p.id = ?
       LIMIT 1
-    `).get(identifier, identifier) as Record<string, string> | undefined;
-    if (!row) {
+    `).get(identifier) as Record<string, string> | undefined;
+    const slugRows = row ? [] : this.db.prepare(`
+      SELECT p.id, p.repo_id AS repoId, p.slug, p.plan_path AS planPath, r.repo_name AS repoName, r.repo_key AS repoKey,
+        v.id AS versionId, v.file_hash AS fileHash, v.branch, v.commit_sha AS commitSha,
+        v.html_blob_path AS htmlBlobPath, v.rendered_blob_path AS renderedBlobPath,
+        v.render_warnings_json AS renderWarningsJson
+      FROM plans p
+      JOIN repos r ON r.id = p.repo_id
+      JOIN plan_versions v ON v.id = (
+        SELECT id FROM plan_versions WHERE plan_id = p.id ORDER BY created_at DESC LIMIT 1
+      )
+      WHERE p.slug = ?
+      ORDER BY p.updated_at DESC
+      LIMIT 2
+    `).all(identifier) as Array<Record<string, string>>;
+    if (!row && slugRows.length > 1) {
+      throw new PlanReviewError('ambiguous_plan_slug', `Plan slug '${identifier}' matches multiple registered plans`, 409, {
+        matches: slugRows.map(item => ({ planId: item.id, repoKey: item.repoKey, planPath: item.planPath }))
+      }, 'Use the plan ID from plan-review index instead of the ambiguous slug.');
+    }
+    const selectedRow = row ?? slugRows[0];
+    if (!selectedRow) {
       throw new PlanReviewError('not_found', `Plan '${identifier}' was not found`, 404, {}, 'Register the plan first.');
     }
     return {
       plan: {
-        id: row.id,
-        repoId: row.repoId,
-        slug: row.slug,
-        planPath: row.planPath,
-        repoName: row.repoName,
-        repoKey: row.repoKey,
-        branch: row.branch,
-        commitSha: row.commitSha ?? undefined
+        id: selectedRow.id,
+        repoId: selectedRow.repoId,
+        slug: selectedRow.slug,
+        planPath: selectedRow.planPath,
+        repoName: selectedRow.repoName,
+        repoKey: selectedRow.repoKey,
+        branch: selectedRow.branch,
+        commitSha: selectedRow.commitSha ?? undefined
       },
       version: {
-        id: row.versionId,
-        planId: row.id,
-        fileHash: row.fileHash,
-        branch: row.branch,
-        commitSha: row.commitSha ?? undefined,
-        htmlBlobPath: row.htmlBlobPath,
-        renderedBlobPath: row.renderedBlobPath,
-        renderWarnings: parseJson(row.renderWarningsJson, [])
+        id: selectedRow.versionId,
+        planId: selectedRow.id,
+        fileHash: selectedRow.fileHash,
+        branch: selectedRow.branch,
+        commitSha: selectedRow.commitSha ?? undefined,
+        htmlBlobPath: selectedRow.htmlBlobPath,
+        renderedBlobPath: selectedRow.renderedBlobPath,
+        renderWarnings: parseJson(selectedRow.renderWarningsJson, [])
       }
     };
   }
@@ -720,22 +740,28 @@ export class PlanReviewStore {
   }
 
   listComments(planId: string, filters: { status?: string; anchorState?: string; sinceSequence?: number; versionId?: string } = {}) {
-    const clauses = ['plan_id = ?'];
+    const clauses = ['c.plan_id = ?'];
     const params: unknown[] = [planId];
     if (filters.versionId) {
-      clauses.push('version_id = ?');
+      clauses.push('c.version_id = ?');
       params.push(filters.versionId);
     }
     if (filters.status) {
-      clauses.push('status = ?');
+      clauses.push('c.status = ?');
       params.push(filters.status);
     }
     if (filters.sinceSequence) {
-      clauses.push('sequence > ?');
+      clauses.push('c.sequence > ?');
       params.push(filters.sinceSequence);
     }
     const rows = this.db
-      .prepare(`SELECT * FROM comments WHERE ${clauses.join(' AND ')} ORDER BY sequence ASC`)
+      .prepare(`
+        SELECT c.*, cl.id AS activeClaimId, cl.agent_id AS activeAgentId, cl.lease_expires_at AS activeLeaseExpiresAt
+        FROM comments c
+        LEFT JOIN claims cl ON cl.id = c.claim_id AND cl.released_at IS NULL AND cl.acknowledged_at IS NULL
+        WHERE ${clauses.join(' AND ')}
+        ORDER BY c.sequence ASC
+      `)
       .all(...params) as Array<Record<string, unknown>>;
     const currentVersion = this.getPlan(planId).version;
     const renderedHtml = fs.readFileSync(currentVersion.renderedBlobPath, 'utf8');
@@ -951,10 +977,11 @@ export class PlanReviewStore {
     }
     params.push(filters.limit ?? 50);
     const rows = this.db.prepare(`
-      SELECT c.*
+      SELECT c.*, cl.id AS activeClaimId, cl.agent_id AS activeAgentId, cl.lease_expires_at AS activeLeaseExpiresAt
       FROM comments c
       JOIN plans p ON p.id = c.plan_id
       JOIN repos r ON r.id = p.repo_id
+      LEFT JOIN claims cl ON cl.id = c.claim_id AND cl.released_at IS NULL AND cl.acknowledged_at IS NULL
       WHERE ${clauses.join(' AND ')}
       ORDER BY c.sequence ASC
       LIMIT ?

--- a/tools/plan-reviewer/src/storage/database.ts
+++ b/tools/plan-reviewer/src/storage/database.ts
@@ -260,6 +260,31 @@ export class PlanReviewStore {
     return event;
   }
 
+  private eventFromRow(row: Record<string, unknown>): StoredEvent {
+    return {
+      id: String(row.id),
+      planId: String(row.plan_id),
+      sequence: Number(row.sequence),
+      eventType: String(row.event_type),
+      commentId: row.comment_id ? String(row.comment_id) : undefined,
+      payload: parseJson(String(row.payload_json), {}),
+      createdAt: String(row.created_at)
+    };
+  }
+
+  private getCommentCreatedEvent(commentId: string): StoredEvent {
+    const row = this.db.prepare(`
+      SELECT * FROM comment_events
+      WHERE comment_id = ? AND event_type = 'comment.created'
+      ORDER BY sequence ASC
+      LIMIT 1
+    `).get(commentId) as Record<string, unknown> | undefined;
+    if (!row) {
+      throw new PlanReviewError('not_found', `Created event for comment '${commentId}' was not found`, 404);
+    }
+    return this.eventFromRow(row);
+  }
+
   private pruneEvents(planId: string): void {
     const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
     this.db
@@ -489,7 +514,7 @@ export class PlanReviewStore {
     return fs.readFileSync(version.renderedBlobPath, 'utf8');
   }
 
-  createComment(planId: string, input: CreateCommentInput): { comment: StoredComment; event: StoredEvent } {
+  createComment(planId: string, input: CreateCommentInput): { comment: StoredComment; event: StoredEvent; created: boolean } {
     const tx = this.db.transaction(() => {
       const version = this.db
         .prepare('SELECT id FROM plan_versions WHERE id = ? AND plan_id = ?')
@@ -504,7 +529,7 @@ export class PlanReviewStore {
         ? this.db.prepare('SELECT id FROM comments WHERE plan_id = ? AND client_mutation_id = ?').get(planId, input.clientMutationId) as { id: string } | undefined
         : undefined;
       if (duplicate) {
-        return { comment: this.getComment(duplicate.id), event: this.eventsAfter(planId, 0).at(-1)! };
+        return { comment: this.getComment(duplicate.id), event: this.getCommentCreatedEvent(duplicate.id), created: false };
       }
 
       const now = nowIso();
@@ -582,7 +607,7 @@ export class PlanReviewStore {
         commentId,
         comment
       }, commentId);
-      return { comment, event };
+      return { comment, event, created: true };
     });
     return tx();
   }
@@ -909,15 +934,7 @@ export class PlanReviewStore {
     const rows = this.db
       .prepare(`SELECT * FROM comment_events WHERE plan_id = ? AND sequence > ? ${eventFilter} ORDER BY sequence ASC LIMIT ?`)
       .all(planId, afterSequence, limit) as Array<Record<string, unknown>>;
-    return rows.map(row => ({
-      id: String(row.id),
-      planId: String(row.plan_id),
-      sequence: Number(row.sequence),
-      eventType: String(row.event_type),
-      commentId: row.comment_id ? String(row.comment_id) : undefined,
-      payload: parseJson(String(row.payload_json), {}),
-      createdAt: String(row.created_at)
-    }));
+    return rows.map(row => this.eventFromRow(row));
   }
 
   queueSnapshot(filters: { repoKey?: string; planId?: string; limit?: number }) {

--- a/tools/plan-reviewer/src/storage/database.ts
+++ b/tools/plan-reviewer/src/storage/database.ts
@@ -1,0 +1,967 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { nanoid } from 'nanoid';
+import type {
+  AckCommentInput,
+  ClaimCommentsInput,
+  CreateCommentInput,
+  RegisterPlanInput,
+  ResolveCommentInput
+} from '../schemas.js';
+import { ensureDir, PlanReviewError, sha256, shortHash, slugify } from '../util.js';
+
+export interface PlanRecord {
+  id: string;
+  repoId: string;
+  slug: string;
+  planPath: string;
+  repoName: string;
+  repoKey: string;
+  branch: string;
+  commitSha?: string;
+}
+
+export interface VersionRecord {
+  id: string;
+  planId: string;
+  fileHash: string;
+  branch: string;
+  commitSha?: string;
+  renderedBlobPath: string;
+  htmlBlobPath: string;
+  renderWarnings: unknown[];
+}
+
+export interface StoredEvent {
+  id: string;
+  planId: string;
+  sequence: number;
+  eventType: string;
+  commentId?: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface StoredComment {
+  id: string;
+  planId: string;
+  versionId: string;
+  sequence: number;
+  status: string;
+  body: string;
+  anchorType: string;
+  anchorState: string;
+  anchor: Record<string, unknown>;
+  screenshotAssetId?: string;
+  conversationPayload: Record<string, unknown>;
+  agentResponse?: Record<string, unknown>;
+  createdBy: Record<string, unknown>;
+  createdAt: string;
+  claim?: { id: string; agentId: string; leaseExpiresAt: string } | null;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function id(prefix: string): string {
+  return `${prefix}_${nanoid(12)}`;
+}
+
+function parseJson<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function hostname(): string {
+  try {
+    return os.hostname();
+  } catch {
+    return 'unknown-host';
+  }
+}
+
+function inferAssetContentType(sourceUrl: string, bytes: Buffer): string | null {
+  const ext = path.extname(sourceUrl.split(/[?#]/, 1)[0] || '').toLowerCase();
+  if (bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) || ext === '.png') return 'image/png';
+  if ((bytes[0] === 0xff && bytes[1] === 0xd8) || ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
+  if (bytes.subarray(0, 6).toString('ascii') === 'GIF87a' || bytes.subarray(0, 6).toString('ascii') === 'GIF89a' || ext === '.gif') return 'image/gif';
+  if (bytes.subarray(0, 4).toString('ascii') === 'RIFF' && bytes.subarray(8, 12).toString('ascii') === 'WEBP' || ext === '.webp') return 'image/webp';
+  if (bytes.subarray(0, 512).toString('utf8').trimStart().startsWith('<svg') || ext === '.svg') return 'image/svg+xml';
+  return null;
+}
+
+function inferAssetDimensions(bytes: Buffer): { width?: number; height?: number } {
+  const isPng = bytes.length >= 24 && bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  if (!isPng) return {};
+  return { width: bytes.readUInt32BE(16), height: bytes.readUInt32BE(20) };
+}
+
+export class PlanReviewStore {
+  private db: Database.Database;
+  private blobDir: string;
+
+  constructor(public dbPath: string) {
+    ensureDir(path.dirname(dbPath));
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.blobDir = path.join(path.dirname(dbPath), 'blobs');
+    ensureDir(this.blobDir);
+    this.migrate();
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  private migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS repos (
+        id TEXT PRIMARY KEY,
+        repo_key TEXT NOT NULL UNIQUE,
+        repo_name TEXT NOT NULL,
+        remote_url TEXT,
+        root_path TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS plans (
+        id TEXT PRIMARY KEY,
+        repo_id TEXT NOT NULL REFERENCES repos(id),
+        slug TEXT NOT NULL,
+        plan_path TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE(repo_id, plan_path, slug)
+      );
+      CREATE TABLE IF NOT EXISTS plan_versions (
+        id TEXT PRIMARY KEY,
+        plan_id TEXT NOT NULL REFERENCES plans(id),
+        file_hash TEXT NOT NULL,
+        branch TEXT NOT NULL,
+        commit_sha TEXT,
+        html_blob_path TEXT NOT NULL,
+        rendered_blob_path TEXT NOT NULL,
+        render_warnings_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE(plan_id, file_hash, branch, commit_sha)
+      );
+      CREATE TABLE IF NOT EXISTS plan_assets (
+        id TEXT PRIMARY KEY,
+        version_id TEXT NOT NULL REFERENCES plan_versions(id),
+        source_url TEXT NOT NULL,
+        asset_hash TEXT,
+        content_type TEXT,
+        width INTEGER,
+        height INTEGER,
+        blob_path TEXT,
+        status TEXT NOT NULL,
+        warning_json TEXT,
+        UNIQUE(version_id, source_url)
+      );
+      CREATE TABLE IF NOT EXISTS comments (
+        id TEXT PRIMARY KEY,
+        plan_id TEXT NOT NULL REFERENCES plans(id),
+        version_id TEXT NOT NULL REFERENCES plan_versions(id),
+        sequence INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        body TEXT NOT NULL,
+        anchor_type TEXT NOT NULL,
+        anchor_state TEXT NOT NULL,
+        anchor_json TEXT NOT NULL,
+        screenshot_asset_id TEXT,
+        conversation_payload_json TEXT NOT NULL,
+        agent_response_json TEXT,
+        created_by_json TEXT NOT NULL,
+        client_mutation_id TEXT,
+        claim_id TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE(plan_id, sequence),
+        UNIQUE(plan_id, client_mutation_id)
+      );
+      CREATE TABLE IF NOT EXISTS comment_assets (
+        id TEXT PRIMARY KEY,
+        comment_id TEXT REFERENCES comments(id),
+        asset_type TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        content_type TEXT NOT NULL,
+        width INTEGER,
+        height INTEGER,
+        capture_rect_json TEXT,
+        viewport_json TEXT,
+        blob_path TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS comment_events (
+        id TEXT PRIMARY KEY,
+        plan_id TEXT NOT NULL REFERENCES plans(id),
+        sequence INTEGER NOT NULL,
+        event_type TEXT NOT NULL,
+        comment_id TEXT,
+        client_mutation_id TEXT,
+        payload_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE(plan_id, sequence)
+      );
+      CREATE TABLE IF NOT EXISTS claims (
+        id TEXT PRIMARY KEY,
+        comment_id TEXT NOT NULL REFERENCES comments(id),
+        agent_id TEXT NOT NULL,
+        ack_client_mutation_id TEXT,
+        lease_expires_at TEXT NOT NULL,
+        released_at TEXT,
+        acknowledged_at TEXT,
+        created_at TEXT NOT NULL
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_active_claim
+        ON claims(comment_id)
+        WHERE released_at IS NULL AND acknowledged_at IS NULL;
+    `);
+  }
+
+  private nextEventSequence(planId: string): number {
+    const row = this.db
+      .prepare('SELECT COALESCE(MAX(sequence), 0) + 1 AS next FROM comment_events WHERE plan_id = ?')
+      .get(planId) as { next: number };
+    return row.next;
+  }
+
+  private nextCommentSequence(planId: string): number {
+    const row = this.db
+      .prepare('SELECT COALESCE(MAX(sequence), 0) + 1 AS next FROM comments WHERE plan_id = ?')
+      .get(planId) as { next: number };
+    return row.next;
+  }
+
+  private addEvent(planId: string, eventType: string, payload: Record<string, unknown>, commentId?: string): StoredEvent {
+    const event: StoredEvent = {
+      id: id('evt'),
+      planId,
+      sequence: this.nextEventSequence(planId),
+      eventType,
+      commentId,
+      payload: { ...payload, sequence: undefined },
+      createdAt: nowIso()
+    };
+    const payloadJson = JSON.stringify({ ...payload, sequence: event.sequence });
+    this.db
+      .prepare(`INSERT INTO comment_events (id, plan_id, sequence, event_type, comment_id, payload_json, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)`)
+      .run(event.id, planId, event.sequence, eventType, commentId ?? null, payloadJson, event.createdAt);
+    this.pruneEvents(planId);
+    event.payload = parseJson(payloadJson, {});
+    return event;
+  }
+
+  private pruneEvents(planId: string): void {
+    const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    this.db
+      .prepare(`DELETE FROM comment_events
+        WHERE plan_id = ?
+          AND created_at < ?
+          AND id NOT IN (
+            SELECT id FROM comment_events WHERE plan_id = ? ORDER BY sequence DESC LIMIT 10000
+          )`)
+      .run(planId, cutoff, planId);
+  }
+
+  private writeBlob(kind: string, name: string, content: Buffer | string): string {
+    const dir = path.join(this.blobDir, kind);
+    ensureDir(dir);
+    const file = path.join(dir, name);
+    fs.writeFileSync(file, content);
+    return file;
+  }
+
+  registerPlan(input: RegisterPlanInput, renderedHtml: string, renderWarnings: unknown[]) {
+    const tx = this.db.transaction(() => {
+      const now = nowIso();
+      const repoKey =
+        input.repoKey ||
+        input.remoteUrl ||
+        `${input.rootPath || process.cwd()}@${hostname()}`;
+      const repoId =
+        (this.db.prepare('SELECT id FROM repos WHERE repo_key = ?').get(repoKey) as { id: string } | undefined)
+          ?.id || id('repo');
+      this.db
+        .prepare(`INSERT INTO repos (id, repo_key, repo_name, remote_url, root_path, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(repo_key) DO UPDATE SET repo_name = excluded.repo_name, remote_url = excluded.remote_url,
+            root_path = excluded.root_path, updated_at = excluded.updated_at`)
+        .run(repoId, repoKey, input.repoName, input.remoteUrl ?? null, input.rootPath ?? null, now, now);
+
+      const baseSlug = input.slug || slugify(path.basename(input.planPath, path.extname(input.planPath)));
+      const existingPlan =
+        input.updateMode === 'new-thread'
+          ? undefined
+          : (this.db
+              .prepare('SELECT id FROM plans WHERE repo_id = ? AND plan_path = ? AND slug = ?')
+              .get(repoId, input.planPath, baseSlug) as { id: string } | undefined);
+      const planId = existingPlan?.id || id('plan');
+      const slug = input.updateMode === 'new-thread' ? `${baseSlug}-${shortHash(planId)}` : baseSlug;
+      this.db
+        .prepare(`INSERT INTO plans (id, repo_id, slug, plan_path, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(repo_id, plan_path, slug) DO UPDATE SET updated_at = excluded.updated_at`)
+        .run(planId, repoId, slug, input.planPath, now, now);
+
+      const htmlName = `${input.fileHash}.html`;
+      const renderedName = `${input.fileHash}.rendered.html`;
+      const htmlBlobPath = this.writeBlob('html', htmlName, input.html);
+      const renderedBlobPath = this.writeBlob('rendered', renderedName, renderedHtml);
+      const commitSha = input.commitSha ?? '';
+      const existingVersion = this.db
+        .prepare('SELECT id FROM plan_versions WHERE plan_id = ? AND file_hash = ? AND branch = ? AND commit_sha = ?')
+        .get(planId, input.fileHash, input.branch, commitSha) as { id: string } | undefined;
+      const versionId = existingVersion?.id || id('ver');
+      this.db
+        .prepare(`INSERT INTO plan_versions
+          (id, plan_id, file_hash, branch, commit_sha, html_blob_path, rendered_blob_path, render_warnings_json, created_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(plan_id, file_hash, branch, commit_sha) DO UPDATE SET
+            html_blob_path = excluded.html_blob_path, rendered_blob_path = excluded.rendered_blob_path,
+            created_at = excluded.created_at,
+            render_warnings_json = excluded.render_warnings_json`)
+        .run(
+          versionId,
+          planId,
+          input.fileHash,
+          input.branch,
+          commitSha,
+          htmlBlobPath,
+          renderedBlobPath,
+          JSON.stringify(renderWarnings),
+          now
+        );
+
+      for (const asset of input.assets ?? []) {
+        const bytes = asset.bytesBase64 ? Buffer.from(asset.bytesBase64, 'base64') : Buffer.from('');
+        const assetHash = bytes.length > 0 ? sha256(bytes) : null;
+        const blobPath = bytes.length > 0 && assetHash ? this.writeBlob('assets', assetHash, bytes) : null;
+        const contentType = bytes.length > 0 ? inferAssetContentType(asset.sourceUrl, bytes) : null;
+        const dimensions = bytes.length > 0 ? inferAssetDimensions(bytes) : {};
+        this.db
+          .prepare(`INSERT INTO plan_assets (id, version_id, source_url, asset_hash, content_type, width, height, blob_path, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(version_id, source_url) DO UPDATE SET asset_hash = excluded.asset_hash,
+              content_type = excluded.content_type, width = excluded.width, height = excluded.height,
+              blob_path = excluded.blob_path, status = excluded.status`)
+          .run(id('asset'), versionId, asset.sourceUrl, assetHash, contentType, dimensions.width ?? null, dimensions.height ?? null, blobPath, blobPath ? 'copied' : 'missing');
+      }
+
+      const event = this.addEvent(planId, 'plan.version.registered', {
+        planId,
+        versionId,
+        eventType: 'plan.version.registered'
+      });
+
+      return {
+        planId,
+        versionId,
+        repoId,
+        repoKey,
+        slug,
+        event,
+        reviewUrl: `/p/${planId}`,
+        indexUrl: '/',
+        watchCommand: `plan-review watch ${planId} --mode queue`
+      };
+    });
+    return tx();
+  }
+
+  listPlans() {
+    const rows = this.db.prepare(`
+      SELECT p.id, p.slug, p.plan_path AS planPath, r.repo_name AS repoName, r.repo_key AS repoKey,
+        v.id AS versionId, v.branch, v.commit_sha AS commitSha, v.file_hash AS fileHash,
+        p.updated_at AS planUpdatedAt,
+        SUM(CASE WHEN c.status = 'pending' THEN 1 ELSE 0 END) AS pending,
+        SUM(CASE WHEN c.status = 'claimed' THEN 1 ELSE 0 END) AS claimed,
+        SUM(CASE WHEN c.status = 'acknowledged' THEN 1 ELSE 0 END) AS acknowledged,
+        SUM(CASE WHEN c.status = 'resolved' THEN 1 ELSE 0 END) AS resolved,
+        MAX(COALESCE(c.updated_at, c.created_at)) AS commentActivityAt
+      FROM plans p
+      JOIN repos r ON r.id = p.repo_id
+      LEFT JOIN plan_versions v ON v.id = (
+        SELECT id FROM plan_versions WHERE plan_id = p.id ORDER BY created_at DESC LIMIT 1
+      )
+      LEFT JOIN comments c ON c.plan_id = p.id
+      GROUP BY p.id
+    `).all() as Array<Record<string, unknown>>;
+    return rows.map(row => {
+      const planUpdatedAt = String(row.planUpdatedAt ?? '');
+      const commentActivityAt = row.commentActivityAt ? String(row.commentActivityAt) : '';
+      const activityAt = commentActivityAt > planUpdatedAt ? commentActivityAt : planUpdatedAt;
+      return {
+      plan: {
+        id: row.id,
+        slug: row.slug,
+        planPath: row.planPath,
+        repoName: row.repoName,
+        repoKey: row.repoKey
+      },
+      latestVersion: {
+        id: row.versionId,
+        branch: row.branch,
+        commitSha: row.commitSha,
+        fileHash: row.fileHash
+      },
+      counts: {
+        pending: Number(row.pending ?? 0),
+        claimed: Number(row.claimed ?? 0),
+        acknowledged: Number(row.acknowledged ?? 0),
+        resolved: Number(row.resolved ?? 0)
+      },
+      activityAt,
+      reviewUrl: `/p/${row.id}`
+      };
+    }).sort((a, b) => String(b.activityAt).localeCompare(String(a.activityAt)));
+  }
+
+  listPlanAssets(versionId: string) {
+    const rows = this.db
+      .prepare(`SELECT id, source_url AS sourceUrl, asset_hash AS assetHash, content_type AS contentType,
+        width, height, status, warning_json AS warningJson
+        FROM plan_assets WHERE version_id = ? ORDER BY source_url`)
+      .all(versionId) as Array<Record<string, unknown>>;
+    return rows.map(row => ({
+      id: String(row.id),
+      sourceUrl: String(row.sourceUrl),
+      assetHash: row.assetHash ?? undefined,
+      contentType: row.contentType ?? undefined,
+      width: row.width ?? undefined,
+      height: row.height ?? undefined,
+      status: String(row.status),
+      warning: parseJson(row.warningJson as string | null, null)
+    }));
+  }
+
+  getPlan(identifier: string): { plan: PlanRecord; version: VersionRecord } {
+    const row = this.db.prepare(`
+      SELECT p.id, p.repo_id AS repoId, p.slug, p.plan_path AS planPath, r.repo_name AS repoName, r.repo_key AS repoKey,
+        v.id AS versionId, v.file_hash AS fileHash, v.branch, v.commit_sha AS commitSha,
+        v.html_blob_path AS htmlBlobPath, v.rendered_blob_path AS renderedBlobPath,
+        v.render_warnings_json AS renderWarningsJson
+      FROM plans p
+      JOIN repos r ON r.id = p.repo_id
+      JOIN plan_versions v ON v.id = (
+        SELECT id FROM plan_versions WHERE plan_id = p.id ORDER BY created_at DESC LIMIT 1
+      )
+      WHERE p.id = ? OR p.slug = ?
+      LIMIT 1
+    `).get(identifier, identifier) as Record<string, string> | undefined;
+    if (!row) {
+      throw new PlanReviewError('not_found', `Plan '${identifier}' was not found`, 404, {}, 'Register the plan first.');
+    }
+    return {
+      plan: {
+        id: row.id,
+        repoId: row.repoId,
+        slug: row.slug,
+        planPath: row.planPath,
+        repoName: row.repoName,
+        repoKey: row.repoKey,
+        branch: row.branch,
+        commitSha: row.commitSha ?? undefined
+      },
+      version: {
+        id: row.versionId,
+        planId: row.id,
+        fileHash: row.fileHash,
+        branch: row.branch,
+        commitSha: row.commitSha ?? undefined,
+        htmlBlobPath: row.htmlBlobPath,
+        renderedBlobPath: row.renderedBlobPath,
+        renderWarnings: parseJson(row.renderWarningsJson, [])
+      }
+    };
+  }
+
+  getRenderedHtml(identifier: string): string {
+    const { version } = this.getPlan(identifier);
+    return fs.readFileSync(version.renderedBlobPath, 'utf8');
+  }
+
+  createComment(planId: string, input: CreateCommentInput): { comment: StoredComment; event: StoredEvent } {
+    const tx = this.db.transaction(() => {
+      const version = this.db
+        .prepare('SELECT id FROM plan_versions WHERE id = ? AND plan_id = ?')
+        .get(input.versionId, planId) as { id: string } | undefined;
+      if (!version) {
+        throw new PlanReviewError('validation_failed', 'Comment versionId must belong to the requested plan', 400, {
+          planId,
+          versionId: input.versionId
+        });
+      }
+      const duplicate = input.clientMutationId
+        ? this.db.prepare('SELECT id FROM comments WHERE plan_id = ? AND client_mutation_id = ?').get(planId, input.clientMutationId) as { id: string } | undefined
+        : undefined;
+      if (duplicate) {
+        return { comment: this.getComment(duplicate.id), event: this.eventsAfter(planId, 0).at(-1)! };
+      }
+
+      const now = nowIso();
+      const commentId = id('cmt');
+      const sequence = this.nextCommentSequence(planId);
+      let screenshotAssetId: string | undefined;
+      let screenshotAsset: {
+        contentHash: string;
+        blobPath: string;
+        width: number;
+        height: number;
+        captureRect: unknown;
+        viewport: unknown;
+      } | undefined;
+      if (input.markerScreenshot) {
+        screenshotAssetId = id('asset');
+        const bytes = Buffer.from(input.markerScreenshot.bytesBase64, 'base64');
+        const contentHash = sha256(bytes);
+        const blobPath = this.writeBlob('comment-assets', `${contentHash}.png`, bytes);
+        screenshotAsset = {
+          contentHash,
+          blobPath,
+          width: input.markerScreenshot.width,
+          height: input.markerScreenshot.height,
+          captureRect: input.markerScreenshot.captureRect,
+          viewport: input.markerScreenshot.viewport
+        };
+      }
+
+      const createdByName = input.createdBy?.displayName?.trim() || 'Anonymous reviewer';
+      const conversationPayload = this.buildConversationPayload(planId, commentId, sequence, input, screenshotAssetId);
+      this.db
+        .prepare(`INSERT INTO comments
+          (id, plan_id, version_id, sequence, status, body, anchor_type, anchor_state, anchor_json,
+            screenshot_asset_id, conversation_payload_json, created_by_json, client_mutation_id, created_at, updated_at)
+          VALUES (?, ?, ?, ?, 'pending', ?, ?, 'mapped', ?, ?, ?, ?, ?, ?, ?)`)
+        .run(
+          commentId,
+          planId,
+          input.versionId,
+          sequence,
+          input.body,
+          input.anchorType,
+          JSON.stringify(input.anchor),
+          screenshotAssetId ?? null,
+          JSON.stringify(conversationPayload),
+          JSON.stringify({ type: 'reviewer', displayName: createdByName }),
+          input.clientMutationId ?? null,
+          now,
+          now
+        );
+      if (screenshotAssetId && screenshotAsset) {
+        this.db
+          .prepare(`INSERT INTO comment_assets
+            (id, comment_id, asset_type, content_hash, content_type, width, height, capture_rect_json, viewport_json, blob_path, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+          .run(
+            screenshotAssetId,
+            commentId,
+            'marker_screenshot',
+            screenshotAsset.contentHash,
+            'image/png',
+            screenshotAsset.width,
+            screenshotAsset.height,
+            JSON.stringify(screenshotAsset.captureRect),
+            JSON.stringify(screenshotAsset.viewport),
+            screenshotAsset.blobPath,
+            now
+          );
+      }
+      const comment = this.getComment(commentId);
+      const event = this.addEvent(planId, 'comment.created', {
+        eventType: 'comment.created',
+        planId,
+        commentId,
+        comment
+      }, commentId);
+      return { comment, event };
+    });
+    return tx();
+  }
+
+  private buildConversationPayload(
+    planId: string,
+    commentId: string,
+    markerNumber: number,
+    input: CreateCommentInput,
+    screenshotAssetId?: string
+  ) {
+    const textPreview =
+      String(input.anchor.textPreview ?? input.anchor.selectedText ?? input.anchor.cssSelector ?? input.anchorType);
+    return {
+      type: 'browser.comment.v1',
+      commentId,
+      conversationHint: {
+        mode: 'append-to-active-thread',
+        title: `Comment ${markerNumber} on ${textPreview.slice(0, 80)}`,
+        summary: input.body.slice(0, 240)
+      },
+      evidence: {
+        reviewUrl: `/p/${planId}`,
+        selector: input.anchor.cssSelector,
+        markerNumber,
+        textPreview,
+        screenshotAssetId
+      },
+      body: input.body
+    };
+  }
+
+  getComment(commentId: string): StoredComment {
+    const row = this.db.prepare(`
+      SELECT c.*, cl.id AS activeClaimId, cl.agent_id AS activeAgentId, cl.lease_expires_at AS activeLeaseExpiresAt
+      FROM comments c
+      LEFT JOIN claims cl ON cl.id = c.claim_id AND cl.released_at IS NULL AND cl.acknowledged_at IS NULL
+      WHERE c.id = ?
+    `).get(commentId) as Record<string, unknown> | undefined;
+    if (!row) {
+      throw new PlanReviewError('not_found', `Comment '${commentId}' was not found`, 404);
+    }
+    return this.commentFromRow(row);
+  }
+
+  private commentFromRow(row: Record<string, unknown>): StoredComment {
+    return {
+      id: String(row.id),
+      planId: String(row.plan_id),
+      versionId: String(row.version_id),
+      sequence: Number(row.sequence),
+      status: String(row.status),
+      body: String(row.body),
+      anchorType: String(row.anchor_type),
+      anchorState: String(row.anchor_state),
+      anchor: parseJson(String(row.anchor_json), {}),
+      screenshotAssetId: row.screenshot_asset_id ? String(row.screenshot_asset_id) : undefined,
+      conversationPayload: parseJson(String(row.conversation_payload_json), {}),
+      agentResponse: row.agent_response_json ? parseJson(String(row.agent_response_json), {}) : undefined,
+      createdBy: parseJson(String(row.created_by_json), {}),
+      createdAt: String(row.created_at),
+      claim: row.activeClaimId
+        ? {
+            id: String(row.activeClaimId),
+            agentId: String(row.activeAgentId),
+            leaseExpiresAt: String(row.activeLeaseExpiresAt)
+          }
+        : null
+    };
+  }
+
+  private remapAnchorState(comment: StoredComment, currentVersion: VersionRecord, renderedHtml: string): StoredComment {
+    if (comment.versionId === currentVersion.id) return comment;
+
+    const anchor = comment.anchor;
+    const planNodeId = typeof anchor.planNodeId === 'string' ? anchor.planNodeId : undefined;
+    const cssSelector = typeof anchor.cssSelector === 'string' ? anchor.cssSelector : undefined;
+    const cssId = cssSelector?.startsWith('#') ? cssSelector.slice(1) : undefined;
+    const imageHash = typeof anchor.imageHash === 'string' ? anchor.imageHash : undefined;
+    const sourceUrl = typeof anchor.sourceUrl === 'string' ? anchor.sourceUrl : undefined;
+    const exact = typeof (anchor.textQuote as { exact?: unknown } | undefined)?.exact === 'string'
+      ? (anchor.textQuote as { exact: string }).exact
+      : undefined;
+    const selectedText = typeof anchor.selectedText === 'string' ? anchor.selectedText : undefined;
+    const textPreview = typeof anchor.textPreview === 'string' ? anchor.textPreview : undefined;
+
+    const nodeMatches = Boolean(planNodeId && renderedHtml.includes(`data-plan-node-id="${planNodeId}"`));
+    const quoteMatches = Boolean(
+      (exact && renderedHtml.includes(exact)) ||
+      (selectedText && renderedHtml.includes(selectedText)) ||
+      (textPreview && renderedHtml.includes(textPreview))
+    );
+
+    if ((imageHash && renderedHtml.includes(imageHash)) || (nodeMatches && quoteMatches)) {
+      return { ...comment, anchorState: 'mapped' };
+    }
+
+    if (
+      nodeMatches ||
+      (cssId && renderedHtml.includes(`id="${cssId}"`)) ||
+      (sourceUrl && renderedHtml.includes(sourceUrl)) ||
+      (exact && renderedHtml.includes(exact)) ||
+      (selectedText && renderedHtml.includes(selectedText)) ||
+      (textPreview && renderedHtml.includes(textPreview))
+    ) {
+      return { ...comment, anchorState: 'stale' };
+    }
+
+    return { ...comment, anchorState: 'unmapped' };
+  }
+
+  listComments(planId: string, filters: { status?: string; anchorState?: string; sinceSequence?: number; versionId?: string } = {}) {
+    const clauses = ['plan_id = ?'];
+    const params: unknown[] = [planId];
+    if (filters.versionId) {
+      clauses.push('version_id = ?');
+      params.push(filters.versionId);
+    }
+    if (filters.status) {
+      clauses.push('status = ?');
+      params.push(filters.status);
+    }
+    if (filters.sinceSequence) {
+      clauses.push('sequence > ?');
+      params.push(filters.sinceSequence);
+    }
+    const rows = this.db
+      .prepare(`SELECT * FROM comments WHERE ${clauses.join(' AND ')} ORDER BY sequence ASC`)
+      .all(...params) as Array<Record<string, unknown>>;
+    const currentVersion = this.getPlan(planId).version;
+    const renderedHtml = fs.readFileSync(currentVersion.renderedBlobPath, 'utf8');
+    const comments = rows.map(row => this.remapAnchorState(this.commentFromRow(row), currentVersion, renderedHtml));
+    return filters.anchorState ? comments.filter(comment => comment.anchorState === filters.anchorState) : comments;
+  }
+
+  releaseExpiredClaims(planId?: string): StoredEvent[] {
+    const now = nowIso();
+    const rows = this.db.prepare(`
+      SELECT cl.id, cl.comment_id AS commentId, c.plan_id AS planId
+      FROM claims cl
+      JOIN comments c ON c.id = cl.comment_id
+      WHERE cl.released_at IS NULL AND cl.acknowledged_at IS NULL AND cl.lease_expires_at <= ?
+        ${planId ? 'AND c.plan_id = ?' : ''}
+    `).all(...(planId ? [now, planId] : [now])) as Array<{ id: string; commentId: string; planId: string }>;
+    const tx = this.db.transaction(() => {
+      const events: StoredEvent[] = [];
+      for (const row of rows) {
+        this.db.prepare('UPDATE claims SET released_at = ? WHERE id = ?').run(now, row.id);
+        this.db.prepare("UPDATE comments SET status = 'pending', claim_id = NULL, updated_at = ? WHERE id = ?").run(now, row.commentId);
+        events.push(this.addEvent(row.planId, 'comment.released', {
+          eventType: 'comment.released',
+          planId: row.planId,
+          commentId: row.commentId,
+          reason: 'lease_expired'
+        }, row.commentId));
+      }
+      return events;
+    });
+    return tx();
+  }
+
+  claimComments(planId: string, input: ClaimCommentsInput, agentId = 'plan-review-cli') {
+    const tx = this.db.transaction(() => {
+      const expiredEvents = this.releaseExpiredClaims(planId);
+      if (input.mode === 'one' && input.commentIds?.length) {
+        throw new PlanReviewError('validation_failed', 'mode=one does not accept commentIds', 400);
+      }
+      if (input.mode === 'selected' && (!input.commentIds || input.commentIds.length === 0)) {
+        throw new PlanReviewError('validation_failed', 'mode=selected requires commentIds', 400);
+      }
+      if (input.mode === 'selected' && input.limit) {
+        throw new PlanReviewError('validation_failed', 'mode=selected does not accept limit', 400);
+      }
+      if (input.mode === 'bulk' && input.commentIds?.length) {
+        throw new PlanReviewError('validation_failed', 'mode=bulk does not accept commentIds', 400);
+      }
+
+      const limit = input.mode === 'one' ? 1 : input.limit ?? 50;
+      const comments =
+        input.mode === 'selected'
+          ? input.commentIds!.map(commentId => this.getComment(commentId))
+          : this.listComments(planId, { status: 'pending' }).slice(0, limit);
+      const leaseExpiresAt = new Date(Date.now() + input.leaseSeconds * 1000).toISOString();
+      const claimed: StoredComment[] = [];
+      const events: StoredEvent[] = [...expiredEvents];
+      const skipped: Array<{ commentId: string; reason: string }> = [];
+      for (const comment of comments) {
+        if (comment.planId !== planId || comment.status !== 'pending') {
+          if (input.mode === 'selected' && comment.status === 'claimed') {
+            throw new PlanReviewError('claim_conflict', `Comment ${comment.id} is already claimed`, 409, {
+              currentHolder: comment.claim?.agentId,
+              leaseExpiresAt: comment.claim?.leaseExpiresAt
+            });
+          }
+          skipped.push({ commentId: comment.id, reason: 'not_pending' });
+          continue;
+        }
+        const claimId = id('claim');
+        try {
+          this.db
+            .prepare(`INSERT INTO claims (id, comment_id, agent_id, lease_expires_at, created_at)
+              VALUES (?, ?, ?, ?, ?)`)
+            .run(claimId, comment.id, agentId, leaseExpiresAt, nowIso());
+        } catch {
+          if (input.mode === 'selected') {
+            throw new PlanReviewError('claim_conflict', `Comment ${comment.id} is already claimed`, 409);
+          }
+          skipped.push({ commentId: comment.id, reason: 'claim_conflict' });
+          continue;
+        }
+        this.db
+          .prepare("UPDATE comments SET status = 'claimed', claim_id = ?, updated_at = ? WHERE id = ?")
+          .run(claimId, nowIso(), comment.id);
+        const updated = this.getComment(comment.id);
+        claimed.push(updated);
+        const event = this.addEvent(planId, 'comment.claimed', {
+          eventType: 'comment.claimed',
+          planId,
+          commentId: comment.id,
+          comment: updated
+        }, comment.id);
+        events.push(event);
+      }
+      return { claimed, events, leaseExpiresAt, skipped };
+    });
+    return tx();
+  }
+
+  ackComment(commentId: string, input: AckCommentInput) {
+    const tx = this.db.transaction(() => {
+      let comment = this.getComment(commentId);
+      const expiredEvents = this.releaseExpiredClaims(comment.planId);
+      comment = this.getComment(commentId);
+      if (comment.status === 'acknowledged' || comment.status === 'resolved') {
+        return { comment, alreadyAcknowledged: true, expiredEvents };
+      }
+      const claim = this.db
+        .prepare(`SELECT * FROM claims WHERE id = ? AND comment_id = ? AND released_at IS NULL AND acknowledged_at IS NULL`)
+        .get(input.claimId, commentId) as Record<string, unknown> | undefined;
+      if (!claim) {
+        throw new PlanReviewError('claim_required', 'Ack requires an active matching claim', 409, { commentId }, 'Claim the comment, then retry ack with --claim <claim-id>.');
+      }
+      const now = nowIso();
+      this.db.prepare('UPDATE claims SET acknowledged_at = ?, ack_client_mutation_id = ? WHERE id = ?')
+        .run(now, input.clientMutationId ?? null, input.claimId);
+      this.db
+        .prepare("UPDATE comments SET status = 'acknowledged', agent_response_json = ?, updated_at = ? WHERE id = ?")
+        .run(JSON.stringify(input.action ?? {}), now, commentId);
+      const updated = this.getComment(commentId);
+      const event = this.addEvent(comment.planId, 'comment.acknowledged', {
+        eventType: 'comment.acknowledged',
+        planId: comment.planId,
+        commentId,
+        comment: updated
+      }, commentId);
+      return { comment: updated, alreadyAcknowledged: false, event, expiredEvents };
+    });
+    return tx();
+  }
+
+  resolveComment(commentId: string, input: ResolveCommentInput) {
+    const tx = this.db.transaction(() => {
+      const comment = this.getComment(commentId);
+      if (comment.status === 'resolved') {
+        return { comment, alreadyResolved: true };
+      }
+      if (comment.status === 'claimed') {
+        throw new PlanReviewError(
+          'invalid_state',
+          'Claimed comments must be acknowledged before they can be resolved',
+          409,
+          { commentId, status: comment.status },
+          'Ack the active claim, or release it back to pending before resolving.'
+        );
+      }
+      const now = nowIso();
+      this.db
+        .prepare("UPDATE comments SET status = 'resolved', agent_response_json = ?, updated_at = ? WHERE id = ?")
+        .run(JSON.stringify({ resolutionNote: input.resolutionNote, ...(input.action ?? {}) }), now, commentId);
+      const updated = this.getComment(commentId);
+      const event = this.addEvent(comment.planId, 'comment.resolved', {
+        eventType: 'comment.resolved',
+        planId: comment.planId,
+        commentId,
+        comment: updated
+      }, commentId);
+      return { comment: updated, alreadyResolved: false, event };
+    });
+    return tx();
+  }
+
+  releaseComment(commentId: string, claimId: string, reason = 'released') {
+    const tx = this.db.transaction(() => {
+      const comment = this.getComment(commentId);
+      if (comment.status === 'acknowledged' || comment.status === 'resolved') {
+        throw new PlanReviewError('invalid_state', 'Acknowledged or resolved comments cannot be released back to pending', 409, { commentId, status: comment.status });
+      }
+      const claim = this.db
+        .prepare(`SELECT id FROM claims WHERE id = ? AND comment_id = ? AND released_at IS NULL AND acknowledged_at IS NULL`)
+        .get(claimId, commentId) as { id: string } | undefined;
+      if (!claim) {
+        throw new PlanReviewError('claim_required', 'Release requires an active matching claim', 409, { commentId }, 'Claim the comment, then retry release with the active claim id.');
+      }
+      const now = nowIso();
+      this.db.prepare('UPDATE claims SET released_at = ? WHERE id = ? AND comment_id = ?').run(now, claimId, commentId);
+      this.db.prepare("UPDATE comments SET status = 'pending', claim_id = NULL, updated_at = ? WHERE id = ?").run(now, commentId);
+      const updated = this.getComment(commentId);
+      const event = this.addEvent(comment.planId, 'comment.released', {
+        eventType: 'comment.released',
+        planId: comment.planId,
+        commentId,
+        reason,
+        comment: updated
+      }, commentId);
+      return { comment: updated, event };
+    });
+    return tx();
+  }
+
+  eventsAfter(planId: string, afterSequence = 0, mode: 'all' | 'queue' = 'all', limit = 200): StoredEvent[] {
+    const eventFilter = mode === 'queue'
+      ? "AND event_type IN ('comment.created','comment.claimed','comment.acknowledged','comment.resolved','comment.released')"
+      : '';
+    const rows = this.db
+      .prepare(`SELECT * FROM comment_events WHERE plan_id = ? AND sequence > ? ${eventFilter} ORDER BY sequence ASC LIMIT ?`)
+      .all(planId, afterSequence, limit) as Array<Record<string, unknown>>;
+    return rows.map(row => ({
+      id: String(row.id),
+      planId: String(row.plan_id),
+      sequence: Number(row.sequence),
+      eventType: String(row.event_type),
+      commentId: row.comment_id ? String(row.comment_id) : undefined,
+      payload: parseJson(String(row.payload_json), {}),
+      createdAt: String(row.created_at)
+    }));
+  }
+
+  queueSnapshot(filters: { repoKey?: string; planId?: string; limit?: number }) {
+    this.releaseExpiredClaims(filters.planId);
+    const clauses = ["c.status = 'pending'"];
+    const params: unknown[] = [];
+    if (filters.planId) {
+      clauses.push('c.plan_id = ?');
+      params.push(filters.planId);
+    }
+    if (filters.repoKey) {
+      clauses.push('r.repo_key = ?');
+      params.push(filters.repoKey);
+    }
+    params.push(filters.limit ?? 50);
+    const rows = this.db.prepare(`
+      SELECT c.*
+      FROM comments c
+      JOIN plans p ON p.id = c.plan_id
+      JOIN repos r ON r.id = p.repo_id
+      WHERE ${clauses.join(' AND ')}
+      ORDER BY c.sequence ASC
+      LIMIT ?
+    `).all(...params) as Array<Record<string, unknown>>;
+    const latestRows = this.db.prepare(`
+      SELECT plan_id AS planId, MAX(sequence) AS latestSequence
+      FROM comment_events
+      GROUP BY plan_id
+    `).all() as Array<{ planId: string; latestSequence: number }>;
+    return {
+      items: rows.map(row => this.commentFromRow(row)),
+      latestSequenceByPlan: Object.fromEntries(latestRows.map(row => [row.planId, row.latestSequence]))
+    };
+  }
+
+  getAsset(assetId: string): { contentType: string; blobPath: string } {
+    const row = this.db.prepare(`
+      SELECT content_type AS contentType, blob_path AS blobPath FROM comment_assets WHERE id = ?
+      UNION ALL
+      SELECT content_type AS contentType, blob_path AS blobPath FROM plan_assets WHERE id = ?
+      UNION ALL
+      SELECT content_type AS contentType, blob_path AS blobPath FROM plan_assets WHERE asset_hash = ?
+    `).get(assetId, assetId, assetId) as { contentType?: string; blobPath: string | null } | undefined;
+    if (!row?.blobPath) throw new PlanReviewError('not_found', `Asset '${assetId}' was not found`, 404);
+    return { contentType: row.contentType || 'application/octet-stream', blobPath: row.blobPath };
+  }
+}

--- a/tools/plan-reviewer/src/storage/database.ts
+++ b/tools/plan-reviewer/src/storage/database.ts
@@ -338,7 +338,7 @@ export class PlanReviewStore {
         .run(planId, repoId, slug, input.planPath, now, now);
 
       const htmlName = `${input.fileHash}.html`;
-      const renderedName = `${input.fileHash}.rendered.html`;
+      const renderedName = `${sha256(renderedHtml)}.rendered.html`;
       const htmlBlobPath = this.writeBlob('html', htmlName, input.html);
       const renderedBlobPath = this.writeBlob('rendered', renderedName, renderedHtml);
       const commitSha = input.commitSha ?? '';

--- a/tools/plan-reviewer/src/test-fixtures/e2e-run.ts
+++ b/tools/plan-reviewer/src/test-fixtures/e2e-run.ts
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import { chromium, request } from 'playwright';
+import { createApp } from '../server/app.js';
+import { sha256 } from '../util.js';
+
+const app = createApp({ dbPath: `/tmp/plan-reviewer-e2e-${process.pid}.sqlite` });
+await app.listen({ host: '127.0.0.1', port: 0 });
+const address = app.server.address();
+if (!address || typeof address === 'string') throw new Error('server did not bind to a TCP port');
+const baseUrl = `http://127.0.0.1:${address.port}`;
+
+try {
+  const context = await request.newContext({ baseURL: baseUrl });
+  const imageBytesBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lqSL4wAAAABJRU5ErkJggg==';
+  const html = '<!doctype html><html><body><main><div style="height:240px"></div><section id="dom-annotation"><h1>DOM annotation</h1><p>Plan index target.</p></section><section id="text-annotation"><h2>Text annotation</h2><p id="text-target">Text range context target for reviewer selection.</p></section><figure><img src="./diagram.png" alt="image annotation" width="120" height="90"></figure><div style="height:1200px"></div></main></body></html>';
+  const register = await context.post('/api/plans/register', {
+    data: {
+      repoKey: 'e2e-repo',
+      repoName: 'e2e',
+      rootPath: '/tmp/e2e',
+      branch: 'main',
+      commitSha: 'e2e',
+      planPath: 'thoughts/plans/e2e.html',
+      slug: 'e2e',
+      html,
+      fileHash: sha256(html),
+      assets: [{ sourceUrl: './diagram.png', absolutePath: '/tmp/e2e/diagram.png', bytesBase64: imageBytesBase64 }],
+      updateMode: 'upsert'
+    }
+  });
+  assert.equal(register.ok(), true);
+  const registered = (await register.json()).data as { planId: string; versionId: string };
+
+  const index = await context.get('/');
+  assert.equal(index.ok(), true);
+  assert.match(await index.text(), /Plan Review Index/);
+
+  const rendered = await context.get(`/render/${registered.planId}`);
+  assert.equal(rendered.ok(), true);
+  const renderedHtml = await rendered.text();
+  assert.match(renderedHtml, /data-plan-node-id="dom-annotation"/);
+  const assetPath = renderedHtml.match(/src="(\/assets\/[^"]+)"/)?.[1];
+  assert.ok(assetPath);
+  const planAsset = await context.get(assetPath);
+  assert.equal(planAsset.ok(), true);
+  assert.equal(planAsset.headers()['cache-control'], 'public, max-age=31536000, immutable');
+
+  const domComment = await context.post(`/api/plans/${registered.planId}/comments`, {
+    data: {
+      versionId: registered.versionId,
+      body: 'DOM annotation comment',
+      anchorType: 'dom',
+      anchor: { planNodeId: 'dom-annotation', cssSelector: '#dom-annotation', textPreview: 'DOM annotation' }
+    }
+  });
+  assert.equal(domComment.ok(), true);
+
+  const imageComment = await context.post(`/api/plans/${registered.planId}/comments`, {
+    data: {
+      versionId: registered.versionId,
+      body: 'Image annotation comment',
+      anchorType: 'image',
+      anchor: {
+        cssSelector: 'img[alt="image annotation"]',
+        sourceUrl: './diagram.png',
+        naturalSize: { width: 1, height: 1 },
+        normalizedRect: { x: 0, y: 0, width: 1, height: 1 }
+      }
+    }
+  });
+  assert.equal(imageComment.ok(), true);
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.goto(`${baseUrl}/p/${registered.planId}`);
+    await page.evaluate(() => {
+      const globals = window as typeof window & { html2canvas?: unknown; __html2canvasCalls?: number };
+      globals.__html2canvasCalls = 0;
+      globals.html2canvas = async (element: HTMLElement) => {
+        globals.__html2canvasCalls = (globals.__html2canvasCalls ?? 0) + 1;
+        const canvas = document.createElement('canvas');
+        canvas.width = 360;
+        canvas.height = 220;
+        const ctx = canvas.getContext('2d')!;
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#0f172a';
+        ctx.font = '16px system-ui';
+        ctx.fillText(element.textContent?.trim().slice(0, 80) || element.tagName, 16, 40);
+        return canvas;
+      };
+    });
+    await page.waitForSelector('#plan-frame');
+    await page.waitForFunction(() => document.querySelector<HTMLIFrameElement>('#plan-frame')?.contentDocument?.querySelector('#dom-annotation'));
+    await page.evaluate(() => {
+      const iframe = document.querySelector<HTMLIFrameElement>('#plan-frame');
+      const target = iframe?.contentDocument?.querySelector('#dom-annotation');
+      target?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: iframe?.contentWindow ?? window }));
+    });
+    await page.waitForFunction(() => document.querySelector<HTMLElement>('#composer')?.hidden === false);
+    await page.fill('#comment-body', 'Browser DOM annotation comment');
+    await page.click('#submit-comment');
+    await page.waitForFunction(() => document.querySelectorAll('.marker').length > 0);
+    assert.equal(await page.locator('.marker').count(), 1);
+    assert.equal(await page.locator('.marker').first().evaluate(marker => marker.getAttribute('style')?.includes('NaN')), false);
+    await page.waitForFunction(() => document.querySelector('#comments')?.textContent?.includes('Browser DOM annotation comment'));
+    assert.equal(await page.evaluate(() => (window as typeof window & { __html2canvasCalls?: number }).__html2canvasCalls), 1);
+    const markerTopBeforeScroll = await page.locator('.marker').first().evaluate(marker => marker.getBoundingClientRect().top);
+    await page.evaluate(() => document.querySelector<HTMLIFrameElement>('#plan-frame')?.contentWindow?.scrollTo(0, 120));
+    await page.waitForFunction(
+      before => Math.abs((document.querySelector('.marker')?.getBoundingClientRect().top ?? before) - before) > 20,
+      markerTopBeforeScroll
+    );
+    await page.evaluate(() => document.querySelector<HTMLIFrameElement>('#plan-frame')?.contentWindow?.scrollTo(0, 0));
+
+    await page.evaluate(() => {
+      const iframe = document.querySelector<HTMLIFrameElement>('#plan-frame')!;
+      const doc = iframe.contentDocument!;
+      const target = doc.querySelector('#text-target')!;
+      const text = target.firstChild!;
+      const range = doc.createRange();
+      range.setStart(text, 0);
+      range.setEnd(text, 18);
+      const selection = doc.getSelection()!;
+      selection.removeAllRanges();
+      selection.addRange(range);
+      target.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, view: iframe.contentWindow ?? window }));
+    });
+    await page.waitForFunction(() => document.querySelector<HTMLElement>('#composer')?.hidden === false);
+    await page.fill('#comment-body', 'Browser text annotation comment');
+    await page.click('#submit-comment');
+    await page.waitForFunction(() => document.querySelector('#comments')?.textContent?.includes('Browser text annotation comment'));
+    assert.equal(await page.evaluate(() => (window as typeof window & { __html2canvasCalls?: number }).__html2canvasCalls), 2);
+
+    await page.evaluate(() => {
+      const iframe = document.querySelector<HTMLIFrameElement>('#plan-frame');
+      const target = iframe?.contentDocument?.querySelector('img[alt="image annotation"]');
+      target?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: iframe?.contentWindow ?? window }));
+    });
+    await page.waitForSelector('#lightbox:not([hidden])');
+    await page.click('#zoom-in');
+    await page.click('#zoom-in');
+    await page.click('#pan-toggle');
+    const stageBox = await page.locator('#lightbox-stage').boundingBox();
+    assert.ok(stageBox);
+    await page.mouse.move(stageBox.x + stageBox.width * 0.5, stageBox.y + stageBox.height * 0.5);
+    await page.mouse.down();
+    await page.mouse.move(stageBox.x + stageBox.width * 0.55, stageBox.y + stageBox.height * 0.55);
+    await page.mouse.up();
+    await page.click('#pan-toggle');
+    const imageBox = await page.locator('#lightbox-image').boundingBox();
+    assert.ok(imageBox);
+    await page.mouse.move(imageBox.x + imageBox.width * 0.25, imageBox.y + imageBox.height * 0.25);
+    await page.mouse.down();
+    await page.mouse.move(imageBox.x + imageBox.width * 0.75, imageBox.y + imageBox.height * 0.65);
+    await page.mouse.up();
+    await page.waitForSelector('#image-selection-box:not([hidden])');
+    await page.fill('#comment-body', 'Browser image annotation comment');
+    await page.click('#submit-comment');
+    await page.waitForFunction(() => document.querySelector('#comments')?.textContent?.includes('Browser image annotation comment'));
+    assert.equal(await page.evaluate(() => (window as typeof window & { __html2canvasCalls?: number }).__html2canvasCalls), 3);
+    assert.match(await page.locator('#comments').innerText(), /image · mapped/);
+    await page.reload();
+    await page.waitForFunction(() => document.querySelector('#comments')?.textContent?.includes('Browser image annotation comment'));
+    await page.waitForFunction(() => document.querySelectorAll('.marker').length >= 3);
+  } finally {
+    await browser.close();
+  }
+
+  const comments = await context.get(`/api/plans/${registered.planId}/comments`);
+  const commentData = (await comments.json()).data.comments as Array<{ body: string; screenshotAssetId?: string; anchor?: { selectedText?: string; planNodeId?: string; domPath?: string; xpath?: string; textQuote?: unknown; normalizedPoint?: unknown; normalizedRect?: { width: number; height: number }; displayedRect?: unknown; zoomState?: { scale: number; panX?: number; panY?: number }; imageHash?: string } }>;
+  const uiComment = commentData.find(comment => comment.body === 'Browser DOM annotation comment');
+  assert.ok(uiComment?.screenshotAssetId);
+  const uiTextComment = commentData.find(comment => comment.body === 'Browser text annotation comment');
+  assert.equal(uiTextComment?.anchor?.selectedText, 'Text range context');
+  assert.equal(uiTextComment.anchor.planNodeId, 'text-target');
+  assert.ok(uiTextComment.anchor.domPath);
+  assert.ok(uiTextComment.anchor.xpath);
+  assert.ok(uiTextComment.anchor.textQuote);
+  const uiImageComment = commentData.find(comment => comment.body === 'Browser image annotation comment');
+  assert.ok(uiImageComment?.anchor?.normalizedPoint);
+  assert.ok(uiImageComment.anchor.normalizedRect);
+  assert.equal(uiImageComment.anchor.normalizedRect.width > 0, true);
+  assert.equal(uiImageComment.anchor.normalizedRect.height > 0, true);
+  assert.ok(uiImageComment.anchor.displayedRect);
+  assert.equal(typeof uiImageComment.anchor.zoomState?.scale, 'number');
+  assert.equal((uiImageComment.anchor.zoomState?.panX ?? 0) !== 0 || (uiImageComment.anchor.zoomState?.panY ?? 0) !== 0, true);
+  assert.equal(typeof uiImageComment.anchor.imageHash, 'string');
+  const asset = await context.get(`/comment-assets/${uiComment.screenshotAssetId}`);
+  assert.equal(asset.ok(), true);
+  const assetBody = await asset.body();
+  assert.ok(assetBody.length > 100, `expected non-trivial marker screenshot, got ${assetBody.length} bytes`);
+
+  await context.dispose();
+  console.log('e2e scenarios passed: plan index, dom annotation, image annotation');
+} finally {
+  await app.close();
+}

--- a/tools/plan-reviewer/src/test-fixtures/run.ts
+++ b/tools/plan-reviewer/src/test-fixtures/run.ts
@@ -88,6 +88,7 @@ async function sseLatency(): Promise<void> {
     const response = await fetch(`${baseUrl}/api/plans/${planId}/events?mode=queue`, {
       headers: { accept: 'text/event-stream' }
     });
+    assert.equal(response.ok, true, `SSE subscribe failed: ${response.status}`);
     if (!response.body) throw new Error('SSE response did not include a body');
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
@@ -95,7 +96,13 @@ async function sseLatency(): Promise<void> {
     const readUntilComment = async (commentId: string, timeoutMs: number) => {
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
-        const read = await reader.read();
+        const remainingMs = Math.max(1, deadline - Date.now());
+        const read = await Promise.race([
+          reader.read(),
+          new Promise<ReadableStreamReadResult<Uint8Array>>((_resolve, reject) =>
+            setTimeout(() => reject(new Error(`SSE timed out waiting for ${commentId}`)), remainingMs)
+          )
+        ]);
         if (read.done) break;
         buffer += decoder.decode(read.value);
         let index: number;

--- a/tools/plan-reviewer/src/test-fixtures/run.ts
+++ b/tools/plan-reviewer/src/test-fixtures/run.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { createApp } from '../server/app.js';
+import { sha256 } from '../util.js';
+
+function argValue(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+async function withServer<T>(scenario: string, run: (baseUrl: string) => Promise<T>): Promise<T> {
+  const app = createApp({ dbPath: `/tmp/plan-reviewer-fixture-${process.pid}-${scenario}.sqlite` });
+  await app.listen({ host: '127.0.0.1', port: 0 });
+  const address = app.server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind to a TCP port');
+  try {
+    return await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await app.close();
+  }
+}
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, {
+    ...init,
+    headers: { 'content-type': 'application/json', ...(init?.headers ?? {}) }
+  });
+  const body = await response.json();
+  if (!response.ok || !body.ok) throw new Error(`${url} failed: ${response.status} ${JSON.stringify(body)}`);
+  return body.data as T;
+}
+
+async function register(baseUrl: string) {
+  const html = '<!doctype html><html><body><section id="fixture"><h1>Fixture plan</h1><p>Queue me.</p></section></body></html>';
+  return requestJson<{ planId: string; versionId: string }>(`${baseUrl}/api/plans/register`, {
+    method: 'POST',
+    body: JSON.stringify({
+      repoKey: 'fixture-repo',
+      repoName: 'fixture',
+      rootPath: '/tmp/fixture',
+      branch: 'main',
+      commitSha: 'fixture',
+      planPath: 'thoughts/plans/fixture.html',
+      slug: 'fixture',
+      html,
+      fileHash: sha256(html),
+      updateMode: 'upsert'
+    })
+  });
+}
+
+async function createComment(baseUrl: string, planId: string, versionId: string) {
+  return requestJson<{ comment: { id: string; status: string } }>(`${baseUrl}/api/plans/${planId}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({
+      versionId,
+      body: 'Fixture comment',
+      anchorType: 'dom',
+      anchor: {
+        planNodeId: 'fixture',
+        cssSelector: '#fixture',
+        textPreview: 'Fixture plan',
+        rect: { x: 0, y: 0, width: 100, height: 50 },
+        viewport: { width: 800, height: 600 }
+      }
+    })
+  });
+}
+
+async function seededCommentStream(): Promise<void> {
+  await withServer('seeded-comment-stream', async baseUrl => {
+    const { planId, versionId } = await register(baseUrl);
+    const { comment } = await createComment(baseUrl, planId, versionId);
+    assert.equal(comment.status, 'pending');
+
+    const poll = await requestJson<{ events: Array<{ eventType: string; payload: { commentId: string } }> }>(
+      `${baseUrl}/api/plans/${planId}/events/poll?afterSequence=0&mode=queue`
+    );
+    assert.equal(poll.events[0].eventType, 'comment.created');
+    assert.equal(poll.events[0].payload.commentId, comment.id);
+  });
+}
+
+async function sseLatency(): Promise<void> {
+  await withServer('sse-latency', async baseUrl => {
+    const samples = Number(argValue('--samples') ?? 50);
+    const p95Ms = Number(argValue('--p95-ms') ?? 1000);
+    const { planId, versionId } = await register(baseUrl);
+    const response = await fetch(`${baseUrl}/api/plans/${planId}/events?mode=queue`, {
+      headers: { accept: 'text/event-stream' }
+    });
+    if (!response.body) throw new Error('SSE response did not include a body');
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    const readUntilComment = async (commentId: string, timeoutMs: number) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const read = await reader.read();
+        if (read.done) break;
+        buffer += decoder.decode(read.value);
+        let index: number;
+        while ((index = buffer.indexOf('\n\n')) >= 0) {
+          const raw = buffer.slice(0, index);
+          buffer = buffer.slice(index + 2);
+          const dataLine = raw.split('\n').find(line => line.startsWith('data:'));
+          if (!dataLine) continue;
+          const data = JSON.parse(dataLine.slice(5).trim());
+          if (data.commentId === commentId || data.comment?.id === commentId) return;
+        }
+      }
+      throw new Error(`SSE timed out waiting for ${commentId}`);
+    };
+    const latencies: number[] = [];
+    for (let index = 0; index < samples; index += 1) {
+      const { comment } = await createComment(baseUrl, planId, versionId);
+      const started = Date.now();
+      await readUntilComment(comment.id, p95Ms);
+      latencies.push(Date.now() - started);
+    }
+    await reader.cancel();
+    const sorted = [...latencies].sort((a, b) => a - b);
+    const p95 = sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)];
+    assert.equal(p95 <= p95Ms, true, `p95 ${p95}ms exceeded ${p95Ms}ms across ${samples} samples`);
+  });
+}
+
+async function queueClaimAck(): Promise<void> {
+  await withServer('queue-claim-ack', async baseUrl => {
+    const { planId, versionId } = await register(baseUrl);
+    const { comment } = await createComment(baseUrl, planId, versionId);
+    const claim = await requestJson<{ claimed: Array<{ id: string; claim: { id: string } }> }>(`${baseUrl}/api/plans/${planId}/comments/claim`, {
+      method: 'POST',
+      body: JSON.stringify({ mode: 'one' })
+    });
+    assert.equal(claim.claimed[0].id, comment.id);
+    const ack = await requestJson<{ comment: { status: string } }>(`${baseUrl}/api/comments/${comment.id}/ack`, {
+      method: 'POST',
+      body: JSON.stringify({ claimId: claim.claimed[0].claim.id, action: { responseSummary: 'acked' } })
+    });
+    assert.equal(ack.comment.status, 'acknowledged');
+  });
+}
+
+const scenario = argValue('--scenario') ?? 'all';
+if (scenario === 'seeded-comment-stream' || scenario === 'all') await seededCommentStream();
+if (scenario === 'sse-latency' || scenario === 'all') await sseLatency();
+if (scenario === 'queue-claim-ack' || scenario === 'all') await queueClaimAck();
+console.log(`fixture scenario passed: ${scenario}`);

--- a/tools/plan-reviewer/src/util.ts
+++ b/tools/plan-reviewer/src/util.ts
@@ -1,0 +1,64 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export class PlanReviewError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public statusCode = 400,
+    public details: unknown = {},
+    public nextAction = ''
+  ) {
+    super(message);
+  }
+}
+
+export function ok<T>(data: T) {
+  return { ok: true as const, data };
+}
+
+export function fail(error: PlanReviewError) {
+  return {
+    ok: false as const,
+    error: {
+      code: error.code,
+      message: error.message,
+      details: error.details,
+      nextAction: error.nextAction
+    }
+  };
+}
+
+export function sha256(data: string | Buffer): string {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+export function shortHash(data: string): string {
+  return sha256(data).slice(0, 12);
+}
+
+export function defaultDataDir(): string {
+  return path.join(os.homedir(), '.plan-reviewer');
+}
+
+export function defaultDbPath(): string {
+  return path.join(defaultDataDir(), 'plan-reviewer.sqlite');
+}
+
+export function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+export function slugify(input: string): string {
+  const slug = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || `plan-${shortHash(input)}`;
+}
+
+export function jsonClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/tools/plan-reviewer/tsconfig.json
+++ b/tools/plan-reviewer/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Plan

`thoughts/plans/html-plan-review-service.html`

## In scope

- Adds `tools/plan-reviewer`, a Node 20 ESM TypeScript daemon/CLI for registering HTML plans, rendering sanitized review shells, creating DOM/text/image comments, and delivering queue events over SSE with polling fallback.
- Adds Homebrew formula `Formula/plan-reviewer.rb` with launchctl service defaults for `0.0.0.0:4317`, local tap install, reproducible npm-based formula build, and caveats for stopping the service and deleting `~/.plan-reviewer` data.
- Adds durable SQLite storage, asset/comment-asset handling, marker screenshots, queue claim/ack/resolve/release lifecycle, and browser-comment conversation payloads for host adapters.

## Verification

- `cd tools/plan-reviewer && bun run test` passed.
- `cd tools/plan-reviewer && bun run test:e2e -- --grep "dom annotation|image annotation|plan index"` passed.
- `cd tools/plan-reviewer && bun run test:fixtures -- --scenario seeded-comment-stream` passed.
- `cd tools/plan-reviewer && bun run test:fixtures -- --scenario sse-latency --samples 50 --p95-ms 1000` passed.
- `cd tools/plan-reviewer && bun run test:fixtures -- --scenario queue-claim-ack` passed.
- `cd tools/plan-reviewer && node dist/bin/plan-review.js --help` passed.
- `brew reinstall local/ai-configs/plan-reviewer` passed from the local tap on this branch.
- `brew test local/ai-configs/plan-reviewer` passed.
- `brew services start local/ai-configs/plan-reviewer`; `GET /health` returned `{"ok":true,"data":{"status":"ok"}}`; service was stopped.

## Reviews

- Codex scoped implementation review: `PASS_SCOPED`, no findings.
- Claude scoped implementation review: `PASS_SCOPED`, no findings.
- Final focused Homebrew packaging review after formula fixes: Codex `PASS_SCOPED`, Claude `PASS_SCOPED`, no findings.

## Deferred follow-ups

None required for the plan scope. Future hosted/public distribution can replace the local-tap `file://` formula source with a tagged release artifact.

## Residual risk

The MVP is intentionally unauthenticated and defaults to `0.0.0.0:4317`; the README and formula caveats document local-network exposure and local-only override guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the Plan Review Service — local web app with rendered HTML plans, browser annotations, comment lifecycle, SSE/polling events, and asset hosting.
  * Added a CLI (plan-review) to register plans, index/watch events, claim/ack/resolve/release comments, and export NDJSON conversation output.
  * Added Homebrew formula and background service for easy install/run.

* **Documentation**
  * Added architecture & implementation plan and a comprehensive README with API contracts and usage.

* **Tests**
  * Added extensive unit, integration, and E2E contract tests covering rendering, API semantics, CLI, and storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->