### PR TITLE
Add authoritative plan source sync

### DIFF
--- a/thoughts/plans/html-plan-reviewer-authoritative-sync.html
+++ b/thoughts/plans/html-plan-reviewer-authoritative-sync.html
@@ -56,7 +56,7 @@
 </head>
 <body>
 <main>
-  <p class="badge">Status: draft plan for browser review</p>
+  <p class="badge">Status: implementation complete pending scoped reviews/PR</p>
   <h1 id="title">HTML Plan Reviewer Authoritative Source Sync</h1>
   <p class="muted">Make the repository plan file the single source of truth. The service may keep rendered/cached copies, but those copies must be derived from and refreshed from the authoritative file after registration.</p>
 
@@ -123,12 +123,12 @@
   <section id="phase-plan">
     <h2>Progress</h2>
     <ul>
-      <li id="phase-p1-contract"><input type="checkbox" /> P1: Lock source-sync contracts in schemas and tests</li>
-      <li id="phase-p2-storage"><input type="checkbox" /> P2: Persist authoritative source metadata and migrations</li>
-      <li id="phase-p3-watcher"><input type="checkbox" /> P3: Add debounced filesystem watcher and startup rehydration</li>
-      <li id="phase-p4-browser"><input type="checkbox" /> P4: Auto-refresh browser render on plan-version events</li>
-      <li id="phase-p5-cli"><input type="checkbox" /> P5: Update CLI/docs/skill for authoritative sync behavior</li>
-      <li id="phase-p6-verify"><input type="checkbox" /> P6: Run unit, fixture, and e2e verification</li>
+      <li id="phase-p1-contract"><input type="checkbox" checked /> P1: Lock source-sync contracts in schemas and tests</li>
+      <li id="phase-p2-storage"><input type="checkbox" checked /> P2: Persist authoritative source metadata and migrations</li>
+      <li id="phase-p3-watcher"><input type="checkbox" checked /> P3: Add debounced filesystem watcher and startup rehydration</li>
+      <li id="phase-p4-browser"><input type="checkbox" checked /> P4: Auto-refresh browser render on plan-version events</li>
+      <li id="phase-p5-cli"><input type="checkbox" checked /> P5: Update CLI/docs/skill for authoritative sync behavior</li>
+      <li id="phase-p6-verify"><input type="checkbox" checked /> P6: Run unit, fixture, and e2e verification</li>
     </ul>
   </section>
 

--- a/tools/plan-reviewer/README.md
+++ b/tools/plan-reviewer/README.md
@@ -27,7 +27,15 @@ plan-review register thoughts/plans/my-plan.html --repo auto --branch auto --com
 plan-review index
 ```
 
-Open the printed review URL. The browser shell renders sanitized HTML in a no-script iframe and keeps the comment UI in the parent page. Selecting a DOM element opens the composer; image and text comments use the same comment API with `anchorType: "image"` or `anchorType: "text_range"`.
+Open the printed review URL. By default, registration live-links the local source file: the repo HTML file is authoritative, service blobs are derived cache/history, and later edits to the file sync into the latest rendered version automatically. Open review pages reload their iframe when a synced version is available.
+
+Use `--snapshot` only when you want a detached historical review that will not watch the source file:
+
+```bash
+plan-review register thoughts/plans/my-plan.html --snapshot
+```
+
+The browser shell renders sanitized HTML in a no-script iframe and keeps the comment UI in the parent page. Selecting a DOM element opens the composer; image and text comments use the same comment API with `anchorType: "image"` or `anchorType: "text_range"`. If the service cannot read a live-linked source file, it keeps serving the last good rendered version and exposes the sync failure in the API and sidebar.
 
 ## Agent Watch Contract
 
@@ -45,7 +53,7 @@ Accept: text/event-stream
 Last-Event-ID: <last-seen-sequence>
 ```
 
-SSE frames use `id: <sequence>`, `event: comment.created|comment.claimed|comment.acknowledged|comment.resolved|comment.released`, and JSON `data`. On reconnect, `Last-Event-ID` replays later events. Heartbeats are sent every 15 seconds. If SSE is unavailable, agents poll:
+SSE frames use `id: <sequence>`, `event: comment.created|comment.claimed|comment.acknowledged|comment.resolved|comment.released`, and JSON `data`. Non-queue event streams also include `plan.version.registered`, `plan.version.synced`, and `plan.sync.failed` for browser refresh/status updates. On reconnect, `Last-Event-ID` replays later events. Heartbeats are sent every 15 seconds. If SSE is unavailable, agents poll:
 
 ```http
 GET /api/plans/:planId/events/poll?afterSequence=<last-seen-sequence>&mode=queue

--- a/tools/plan-reviewer/bun.lock
+++ b/tools/plan-reviewer/bun.lock
@@ -8,6 +8,7 @@
         "@medv/finder": "^4.0.2",
         "@washi-ui/core": "^1.0.2",
         "better-sqlite3": "^12.4.6",
+        "chokidar": "^4.0.3",
         "commander": "^12.1.0",
         "fastify": "^5.6.2",
         "html2canvas": "^1.4.1",
@@ -124,6 +125,8 @@
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
@@ -254,6 +257,8 @@
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 

--- a/tools/plan-reviewer/package-lock.json
+++ b/tools/plan-reviewer/package-lock.json
@@ -11,6 +11,7 @@
         "@medv/finder": "^4.0.2",
         "@washi-ui/core": "^1.0.2",
         "better-sqlite3": "^12.4.6",
+        "chokidar": "^4.0.3",
         "commander": "^12.1.0",
         "fastify": "^5.6.2",
         "html2canvas": "^1.4.1",
@@ -742,6 +743,21 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "license": "ISC"
@@ -1468,6 +1484,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/real-require": {

--- a/tools/plan-reviewer/package.json
+++ b/tools/plan-reviewer/package.json
@@ -20,6 +20,7 @@
     "@medv/finder": "^4.0.2",
     "@washi-ui/core": "^1.0.2",
     "better-sqlite3": "^12.4.6",
+    "chokidar": "^4.0.3",
     "commander": "^12.1.0",
     "fastify": "^5.6.2",
     "html2canvas": "^1.4.1",

--- a/tools/plan-reviewer/src/__tests__/contracts.test.ts
+++ b/tools/plan-reviewer/src/__tests__/contracts.test.ts
@@ -828,6 +828,55 @@ test('registration reports failed source sync when API source path is unreadable
   }
 });
 
+test('filesystem source watches missing relative image creation', async () => {
+  const app = createApp({ dbPath: tempDbPath('source-missing-asset-watch') });
+  const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-review-missing-asset-watch-'));
+  const sourcePath = path.join(sourceDir, 'asset-plan.html');
+  const imagePath = path.join(sourceDir, 'diagram.png');
+  const html = '<!doctype html><html><body><main><img src="./diagram.png" alt="Diagram"></main></body></html>';
+  fs.writeFileSync(sourcePath, html);
+  const stat = fs.statSync(sourcePath);
+  const waitFor = async (predicate: () => Promise<boolean>) => {
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      if (await predicate()) return;
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    assert.fail('timed out waiting for missing asset sync');
+  };
+  try {
+    const registered = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        planPath: 'asset-plan.html',
+        slug: 'asset-plan',
+        html,
+        fileHash: sha256(html),
+        sourcePath,
+        sourceMtimeMs: stat.mtimeMs,
+        sourceSize: stat.size,
+        watchMode: 'filesystem',
+        assets: [{ sourceUrl: './diagram.png', absolutePath: imagePath }]
+      })
+    });
+    assert.equal(registered.statusCode, 200);
+    const planId = registered.json().data.planId;
+    const missingRendered = await app.inject({ method: 'GET', url: `/render/${planId}` });
+    assert.match(missingRendered.body, /Missing image: \.\/diagram\.png/);
+
+    fs.writeFileSync(imagePath, Buffer.from('created-image'));
+    const createdHash = sha256(Buffer.from('created-image'));
+    await waitFor(async () => {
+      const rendered = await app.inject({ method: 'GET', url: `/render/${planId}` });
+      return rendered.body.includes(`/assets/${createdHash}`);
+    });
+  } finally {
+    await app.close();
+    fs.rmSync(sourceDir, { recursive: true, force: true });
+  }
+});
+
 test('filesystem source watches relative image changes even when HTML is unchanged', async () => {
   const app = createApp({ dbPath: tempDbPath('source-asset-watch') });
   const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-review-asset-watch-'));
@@ -875,6 +924,14 @@ test('filesystem source watches relative image changes even when HTML is unchang
     });
     const synced = await app.inject({ method: 'GET', url: `/api/plans/${planId}` });
     assert.equal(synced.json().data.latestVersion.syncOrigin, 'filesystem_watch');
+
+    fs.rmSync(imagePath);
+    await waitFor(async () => {
+      const rendered = await app.inject({ method: 'GET', url: `/render/${planId}` });
+      return /Missing image: \.\/diagram\.png/.test(rendered.body);
+    });
+    const deleted = await app.inject({ method: 'GET', url: `/api/plans/${planId}` });
+    assert.equal(deleted.json().data.plan.lastSyncStatus, 'synced');
   } finally {
     await app.close();
     fs.rmSync(sourceDir, { recursive: true, force: true });

--- a/tools/plan-reviewer/src/__tests__/contracts.test.ts
+++ b/tools/plan-reviewer/src/__tests__/contracts.test.ts
@@ -832,6 +832,64 @@ test('registration reports failed source sync when API source path is unreadable
   }
 });
 
+test('filesystem source recovery watcher syncs after startup read failure', async () => {
+  const dbPath = tempDbPath('source-recovery-watch');
+  const app = createApp({ dbPath });
+  const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-review-source-recovery-'));
+  const sourcePath = path.join(sourceDir, 'recovery-plan.html');
+  const html = '<!doctype html><html><body><main><p>Original</p></main></body></html>';
+  fs.writeFileSync(sourcePath, html);
+  const stat = fs.statSync(sourcePath);
+  const waitFor = async (predicate: () => Promise<boolean>) => {
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      if (await predicate()) return;
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    assert.fail('timed out waiting for recovery sync');
+  };
+  let recoveryApp = app;
+  try {
+    const registered = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        planPath: 'recovery-plan.html',
+        slug: 'recovery-plan',
+        html,
+        fileHash: sha256(html),
+        sourcePath,
+        sourceMtimeMs: stat.mtimeMs,
+        sourceSize: stat.size,
+        watchMode: 'filesystem',
+        assets: []
+      })
+    });
+    assert.equal(registered.statusCode, 200);
+    const planId = registered.json().data.planId;
+    await app.close();
+
+    fs.rmSync(sourcePath);
+    recoveryApp = createApp({ dbPath });
+    await waitFor(async () => {
+      const current = await recoveryApp.inject({ method: 'GET', url: `/api/plans/${planId}` });
+      return current.json().data.plan.lastSyncStatus === 'failed';
+    });
+
+    const recoveredHtml = '<!doctype html><html><body><main><p>Recovered</p></main></body></html>';
+    fs.writeFileSync(sourcePath, recoveredHtml);
+    await waitFor(async () => {
+      const rendered = await recoveryApp.inject({ method: 'GET', url: `/render/${planId}` });
+      return rendered.body.includes('Recovered');
+    });
+    const recovered = await recoveryApp.inject({ method: 'GET', url: `/api/plans/${planId}` });
+    assert.equal(recovered.json().data.plan.lastSyncStatus, 'synced');
+  } finally {
+    await recoveryApp.close();
+    fs.rmSync(sourceDir, { recursive: true, force: true });
+  }
+});
+
 test('filesystem source watches missing relative image creation', async () => {
   const app = createApp({ dbPath: tempDbPath('source-missing-asset-watch') });
   const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-review-missing-asset-watch-'));

--- a/tools/plan-reviewer/src/__tests__/contracts.test.ts
+++ b/tools/plan-reviewer/src/__tests__/contracts.test.ts
@@ -19,6 +19,10 @@ import { domAnchor, registeredApp, sampleHtml, sampleRegisterPayload, tempDbPath
 test('schemas validate locked registration, comment, and claim contracts', () => {
   const register = registerPlanSchema.parse(sampleRegisterPayload());
   assert.equal(register.updateMode, 'upsert');
+  assert.throws(
+    () => registerPlanSchema.parse(sampleRegisterPayload({ watchMode: 'filesystem' })),
+    /sourcePath is required/
+  );
 
   const comment = createCommentSchema.parse({
     versionId: 'ver_1',

--- a/tools/plan-reviewer/src/__tests__/contracts.test.ts
+++ b/tools/plan-reviewer/src/__tests__/contracts.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import http from 'node:http';
 import { spawn, spawnSync } from 'node:child_process';
 import test from 'node:test';
@@ -735,4 +736,202 @@ test('Homebrew formula locks the daemon service contract', () => {
   assert.match(formula, /error_log_path var\/"log\/plan-reviewer\.err\.log"/);
   assert.match(formula, /brew services stop plan-reviewer/);
   assert.match(formula, /rm -rf ~\/\.plan-reviewer/);
+});
+
+test('registration stores authoritative source metadata and version origin', async () => {
+  const app = createApp({ dbPath: tempDbPath('source-contract') });
+  const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-review-source-'));
+  const sourcePath = path.join(sourceDir, 'sample-plan.html');
+  const html = sampleHtml();
+  fs.writeFileSync(sourcePath, html);
+  const stat = fs.statSync(sourcePath);
+  try {
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        sourcePath,
+        sourceMtimeMs: stat.mtimeMs,
+        sourceSize: stat.size,
+        watchMode: 'filesystem'
+      })
+    });
+    assert.equal(first.statusCode, 200);
+    assert.equal(first.json().data.sourceSync.active, true);
+    const planId = first.json().data.planId;
+    const versionId = first.json().data.versionId;
+
+    const same = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        sourcePath,
+        sourceMtimeMs: stat.mtimeMs,
+        sourceSize: stat.size,
+        watchMode: 'filesystem'
+      })
+    });
+    assert.equal(same.statusCode, 200);
+    assert.equal(same.json().data.planId, planId);
+    assert.equal(same.json().data.versionId, versionId);
+
+    const changedHtml = sampleHtml().replace('Register the plan.', 'Register and sync the plan.');
+    const changedStat = fs.statSync(sourcePath);
+    const changed = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        html: changedHtml,
+        fileHash: sha256(changedHtml),
+        sourcePath,
+        sourceMtimeMs: changedStat.mtimeMs,
+        sourceSize: changedStat.size,
+        watchMode: 'filesystem'
+      })
+    });
+    assert.equal(changed.statusCode, 200);
+    assert.equal(changed.json().data.planId, planId);
+    assert.notEqual(changed.json().data.versionId, versionId);
+
+    const meta = await app.inject({ method: 'GET', url: `/api/plans/${planId}` });
+    assert.equal(meta.json().data.plan.sourcePath, sourcePath);
+    assert.equal(meta.json().data.plan.watchMode, 'filesystem');
+    assert.equal(meta.json().data.plan.lastSyncStatus, 'synced');
+    assert.equal(meta.json().data.latestVersion.syncOrigin, 'manual_register');
+  } finally {
+    await app.close();
+    fs.rmSync(sourceDir, { recursive: true, force: true });
+  }
+});
+
+test('registration reports failed source sync when API source path is unreadable', async () => {
+  const app = createApp({ dbPath: tempDbPath('source-register-failure') });
+  const sourcePath = path.join(os.tmpdir(), `plan-review-missing-${process.pid}.html`);
+  try {
+    fs.rmSync(sourcePath, { force: true });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        sourcePath,
+        sourceMtimeMs: 0,
+        sourceSize: 0,
+        watchMode: 'filesystem'
+      })
+    });
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().data.sourceSync.active, false);
+    assert.equal(response.json().data.sourceSync.status, 'failed');
+    assert.match(response.json().data.sourceSync.error.message, /ENOENT|no such file/i);
+  } finally {
+    await app.close();
+  }
+});
+
+test('filesystem source watches relative image changes even when HTML is unchanged', async () => {
+  const app = createApp({ dbPath: tempDbPath('source-asset-watch') });
+  const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-review-asset-watch-'));
+  const sourcePath = path.join(sourceDir, 'asset-plan.html');
+  const imagePath = path.join(sourceDir, 'diagram.png');
+  const html = '<!doctype html><html><body><main><img src="./diagram.png" alt="Diagram"></main></body></html>';
+  fs.writeFileSync(sourcePath, html);
+  fs.writeFileSync(imagePath, Buffer.from('first-image'));
+  const stat = fs.statSync(sourcePath);
+  const waitFor = async (predicate: () => Promise<boolean>) => {
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      if (await predicate()) return;
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    assert.fail('timed out waiting for asset sync');
+  };
+  try {
+    const registered = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        planPath: 'asset-plan.html',
+        slug: 'asset-plan',
+        html,
+        fileHash: sha256(html),
+        sourcePath,
+        sourceMtimeMs: stat.mtimeMs,
+        sourceSize: stat.size,
+        watchMode: 'filesystem',
+        assets: [{ sourceUrl: './diagram.png', absolutePath: imagePath, bytesBase64: Buffer.from('first-image').toString('base64') }]
+      })
+    });
+    assert.equal(registered.statusCode, 200);
+    const planId = registered.json().data.planId;
+    const firstRendered = await app.inject({ method: 'GET', url: `/render/${planId}` });
+    const firstHash = sha256(Buffer.from('first-image'));
+    const secondHash = sha256(Buffer.from('second-image'));
+    assert.match(firstRendered.body, new RegExp(`/assets/${firstHash}`));
+
+    fs.writeFileSync(imagePath, Buffer.from('second-image'));
+    await waitFor(async () => {
+      const rendered = await app.inject({ method: 'GET', url: `/render/${planId}` });
+      return rendered.body.includes(`/assets/${secondHash}`);
+    });
+    const synced = await app.inject({ method: 'GET', url: `/api/plans/${planId}` });
+    assert.equal(synced.json().data.latestVersion.syncOrigin, 'filesystem_watch');
+  } finally {
+    await app.close();
+    fs.rmSync(sourceDir, { recursive: true, force: true });
+  }
+});
+
+test('filesystem source changes create a synced latest version and failures keep last good render', async () => {
+  const app = createApp({ dbPath: tempDbPath('source-watch') });
+  const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-review-watch-'));
+  const sourcePath = path.join(sourceDir, 'sample-plan.html');
+  fs.writeFileSync(sourcePath, sampleHtml());
+  const stat = fs.statSync(sourcePath);
+  const waitFor = async (predicate: () => Promise<boolean>) => {
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      if (await predicate()) return;
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    assert.fail('timed out waiting for source sync');
+  };
+  try {
+    const registered = await app.inject({
+      method: 'POST',
+      url: '/api/plans/register',
+      payload: sampleRegisterPayload({
+        sourcePath,
+        sourceMtimeMs: stat.mtimeMs,
+        sourceSize: stat.size,
+        watchMode: 'filesystem'
+      })
+    });
+    assert.equal(registered.statusCode, 200);
+    const planId = registered.json().data.planId;
+    const firstVersionId = registered.json().data.versionId;
+
+    const changedHtml = sampleHtml().replace('Reviewers can select this section.', 'Reviewers see live synced content.');
+    fs.writeFileSync(sourcePath, changedHtml);
+    await waitFor(async () => {
+      const meta = await app.inject({ method: 'GET', url: `/api/plans/${planId}` });
+      return meta.json().data.latestVersion.id !== firstVersionId;
+    });
+    const synced = await app.inject({ method: 'GET', url: `/api/plans/${planId}` });
+    assert.equal(synced.json().data.latestVersion.syncOrigin, 'filesystem_watch');
+    const rendered = await app.inject({ method: 'GET', url: `/render/${planId}?versionId=${synced.json().data.latestVersion.id}` });
+    assert.match(rendered.body, /Reviewers see live synced content/);
+
+    fs.rmSync(sourcePath);
+    await waitFor(async () => {
+      const meta = await app.inject({ method: 'GET', url: `/api/plans/${planId}` });
+      return meta.json().data.plan.lastSyncStatus === 'failed';
+    });
+    const failed = await app.inject({ method: 'GET', url: `/api/plans/${planId}` });
+    assert.match(failed.json().data.plan.lastSyncError.message, /missing|ENOENT|Source file/i);
+    const lastGood = await app.inject({ method: 'GET', url: `/render/${planId}` });
+    assert.match(lastGood.body, /Reviewers see live synced content/);
+  } finally {
+    await app.close();
+    fs.rmSync(sourceDir, { recursive: true, force: true });
+  }
 });

--- a/tools/plan-reviewer/src/__tests__/helpers.ts
+++ b/tools/plan-reviewer/src/__tests__/helpers.ts
@@ -33,6 +33,7 @@ export function sampleRegisterPayload(overrides: Record<string, unknown> = {}) {
     slug: 'sample-plan',
     html,
     fileHash: sha256(html),
+    watchMode: 'snapshot' as const,
     assets: [
       {
         sourceUrl: './diagram.png',

--- a/tools/plan-reviewer/src/cli.ts
+++ b/tools/plan-reviewer/src/cli.ts
@@ -16,6 +16,7 @@ interface RegisterResponse {
   reviewUrl: string;
   indexUrl: string;
   watchCommand: string;
+  sourceSync?: { watchMode: 'filesystem' | 'snapshot'; sourcePath?: string; status?: string; active?: boolean };
   renderedWithWarnings: Array<{ code: string; detail: string }>;
 }
 
@@ -124,10 +125,11 @@ function writeWatchState(filePath: string, key: string, sequence: number): void 
   fs.writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`);
 }
 
-async function registerPlan(filePath: string, options: { url?: string; json?: boolean; repo?: string; branch?: string; commit?: string; newThread?: boolean }) {
+async function registerPlan(filePath: string, options: { url?: string; json?: boolean; repo?: string; branch?: string; commit?: string; newThread?: boolean; snapshot?: boolean }) {
   const serviceUrl = resolveServiceUrl(options.url);
   const absolute = path.resolve(filePath);
   const html = fs.readFileSync(absolute, 'utf8');
+  const stat = fs.statSync(absolute);
   const meta = repoMetadata(path.dirname(absolute));
   const branch = options.branch && options.branch !== 'auto' ? options.branch : meta.branch;
   const commitSha = options.commit && options.commit !== 'auto' ? options.commit : meta.commitSha;
@@ -143,6 +145,10 @@ async function registerPlan(filePath: string, options: { url?: string; json?: bo
     slug: slugify(path.basename(filePath, path.extname(filePath))),
     html,
     fileHash: sha256(html),
+    sourcePath: options.snapshot ? undefined : absolute,
+    sourceMtimeMs: options.snapshot ? undefined : stat.mtimeMs,
+    sourceSize: options.snapshot ? undefined : stat.size,
+    watchMode: options.snapshot ? 'snapshot' as const : 'filesystem' as const,
     assets: discoverImageAssets(html, absolute),
     updateMode: options.newThread ? 'new-thread' as const : 'upsert' as const
   };
@@ -155,7 +161,8 @@ async function registerPlan(filePath: string, options: { url?: string; json?: bo
     printJson(data);
     return;
   }
-  process.stdout.write(`Plan ID: ${data.planId}\nIndex URL: ${fullUrl(serviceUrl, data.indexUrl)}\nReview URL: ${fullUrl(serviceUrl, data.reviewUrl)}\nWatch command: ${data.watchCommand} --url ${serviceUrl}\n`);
+  const sync = data.sourceSync?.active ? `active (${data.sourceSync.sourcePath})` : 'snapshot';
+  process.stdout.write(`Plan ID: ${data.planId}\nIndex URL: ${fullUrl(serviceUrl, data.indexUrl)}\nReview URL: ${fullUrl(serviceUrl, data.reviewUrl)}\nSource sync: ${sync}\nWatch command: ${data.watchCommand} --url ${serviceUrl}\n`);
 }
 
 async function printIndex(options: { url?: string; json?: boolean; q?: string; repoKey?: string; limit?: string; cursor?: string }) {
@@ -405,6 +412,7 @@ export async function main(argv: string[] = process.argv.slice(2)) {
     .option('--branch <branch>')
     .option('--commit <commit>')
     .option('--new-thread')
+    .option('--snapshot', 'register a detached snapshot instead of live filesystem sync')
     .option('--json')
     .action(registerPlan);
 

--- a/tools/plan-reviewer/src/schemas.ts
+++ b/tools/plan-reviewer/src/schemas.ts
@@ -46,6 +46,14 @@ export const registerPlanSchema = z.object({
     bytesBase64: z.string().optional()
   })).optional(),
   updateMode: z.enum(['upsert', 'new-thread']).default('upsert')
+}).superRefine((input, context) => {
+  if (input.watchMode === 'filesystem' && !input.sourcePath) {
+    context.addIssue({
+      code: 'custom',
+      path: ['sourcePath'],
+      message: 'sourcePath is required when watchMode is filesystem'
+    });
+  }
 });
 
 export const createCommentSchema = z.object({

--- a/tools/plan-reviewer/src/schemas.ts
+++ b/tools/plan-reviewer/src/schemas.ts
@@ -11,6 +11,8 @@ export const eventTypeSchema = z.enum([
   'comment.resolved',
   'comment.released',
   'plan.version.registered',
+  'plan.version.synced',
+  'plan.sync.failed',
   'heartbeat'
 ]);
 
@@ -34,6 +36,10 @@ export const registerPlanSchema = z.object({
   slug: z.string().optional(),
   html: z.string().min(1),
   fileHash: z.string().min(1),
+  sourcePath: z.string().min(1).optional(),
+  sourceMtimeMs: z.number().nonnegative().optional(),
+  sourceSize: z.number().int().nonnegative().optional(),
+  watchMode: z.enum(['filesystem', 'snapshot']).default('snapshot'),
   assets: z.array(z.object({
     sourceUrl: z.string().min(1),
     absolutePath: z.string().optional(),

--- a/tools/plan-reviewer/src/server/app.ts
+++ b/tools/plan-reviewer/src/server/app.ts
@@ -14,6 +14,7 @@ import {
 } from '../schemas.js';
 import { renderPlan } from '../render/render.js';
 import { PlanReviewStore, type StoredEvent } from '../storage/database.js';
+import { SourceSyncService } from './sourceSync.js';
 import { fail, ok, PlanReviewError } from '../util.js';
 
 export interface AppOptions {
@@ -104,7 +105,7 @@ function reviewShell(planId: string): string {
     <link rel="stylesheet" href="/client.css">
   </head><body data-plan-id="${escapedPlanId}">
     <div id="app">
-      <aside id="sidebar"><h1>Comments</h1><div id="comments"></div></aside>
+      <aside id="sidebar"><h1>Comments</h1><div id="sync-warning" hidden></div><div id="comments"></div></aside>
       <main id="review"><iframe id="plan-frame" sandbox="allow-same-origin" src="/render/${escapedPlanId}"></iframe><div id="hover-selection-box" class="selection-box hover" hidden></div><div id="active-selection-box" class="selection-box active" hidden></div></main>
     </div>
     <div id="lightbox" class="lightbox" hidden><header><button id="zoom-out">-</button><button id="zoom-reset">Reset</button><button id="zoom-in">+</button><button id="pan-toggle">Pan</button><button id="close-lightbox">Close</button></header><div id="lightbox-stage" class="lightbox-stage"><img id="lightbox-image" alt=""><div id="image-selection-box" hidden></div></div></div>
@@ -123,7 +124,7 @@ body{margin:0;background:#0b1020;color:#e5e7eb;font-family:system-ui,sans-serif}
 #app{display:grid;grid-template-columns:minmax(0,1fr) 320px;min-height:100vh}
 #review{grid-column:1;position:relative}#sidebar{grid-column:2;grid-row:1;border-left:1px solid #2b364d;padding:16px;background:#111827}
 #plan-frame{width:100%;height:100vh;border:0;background:white}.selection-box,.comment-anchor{position:fixed;pointer-events:none;border-radius:6px;transition:left .08s ease,top .08s ease,width .08s ease,height .08s ease}.selection-box{z-index:8;box-shadow:0 0 0 9999px rgba(2,6,23,.08),0 10px 24px rgba(0,0,0,.25)}.selection-box.hover{border:2px solid rgba(125,211,252,.9);background:rgba(56,189,248,.10)}.selection-box.active{z-index:9;border:3px solid #38bdf8;background:rgba(56,189,248,.16);box-shadow:0 0 0 4px rgba(56,189,248,.18),0 12px 32px rgba(0,0,0,.35)}.comment-anchor{z-index:7}.comment-anchor.pending{border:3px solid #a855f7;background:rgba(168,85,247,.22);box-shadow:0 0 0 4px rgba(168,85,247,.16),0 12px 30px rgba(0,0,0,.28)}.comment-anchor.addressed{border:2px dotted rgba(216,180,254,.9);background:transparent;box-shadow:none}.comment-anchor-label{position:absolute;right:-10px;top:-12px;min-width:24px;height:24px;border-radius:999px;display:grid;place-items:center;padding:0 6px;background:#7e22ce;color:white;border:2px solid #f3e8ff;font-weight:800;font-size:12px;box-shadow:0 8px 18px rgba(0,0,0,.35)}.comment-anchor.addressed .comment-anchor-label{display:none}.comment-row{border:1px solid #2b364d;padding:10px;margin:8px 0;border-radius:8px;background:#0f172a}.comment-row small{color:#a7b0c0}.marker{position:absolute;z-index:9;width:24px;height:24px;border-radius:50%;display:grid;place-items:center;background:#0ea5e9;color:white;border:2px solid #dbeafe;font-weight:700;box-shadow:0 8px 18px rgba(0,0,0,.35);pointer-events:none}
-#composer{position:fixed;right:340px;top:80px;background:#0f172a;border:1px solid #38bdf8;padding:12px;border-radius:8px;z-index:20;box-shadow:0 12px 32px rgba(0,0,0,.4)}
+#sync-warning{border:1px solid #f59e0b;background:rgba(245,158,11,.12);color:#fde68a;border-radius:8px;padding:10px;margin:8px 0 14px;font-size:13px}#composer{position:fixed;right:340px;top:80px;background:#0f172a;border:1px solid #38bdf8;padding:12px;border-radius:8px;z-index:20;box-shadow:0 12px 32px rgba(0,0,0,.4)}
 #composer textarea{width:260px;height:90px;background:#020617;color:#e5e7eb;border:1px solid #2b364d;border-radius:6px;padding:8px;display:block}
 	#composer button{margin-top:8px;margin-right:8px}.plan-review-selected{outline:3px solid #38bdf8!important;box-shadow:0 0 0 4px rgba(56,189,248,.2)!important}.lightbox{position:fixed;inset:36px 360px 36px 36px;background:#020617;border:1px solid #38bdf8;z-index:12;display:grid;grid-template-rows:auto 1fr}.lightbox[hidden]{display:none}.lightbox header{display:flex;gap:8px;padding:10px;border-bottom:1px solid #2b364d}.lightbox img{max-width:100%;max-height:100%;place-self:center;transform-origin:center}.lightbox-stage{display:grid;overflow:hidden;position:relative}#image-selection-box{position:absolute;border:2px solid #38bdf8;background:rgba(56,189,248,.2);pointer-events:none}
 `;
@@ -137,6 +138,7 @@ const frame = document.getElementById('plan-frame');
 const composer = document.getElementById('composer');
 const body = document.getElementById('comment-body');
 const comments = document.getElementById('comments');
+const syncWarning = document.getElementById('sync-warning');
 const hoverSelectionBox = document.getElementById('hover-selection-box');
 const activeSelectionBox = document.getElementById('active-selection-box');
 const lightbox = document.getElementById('lightbox');
@@ -162,19 +164,30 @@ async function loadMeta(options = {}){
   const res = await fetch('/api/plans/'+planId);
   const json = await res.json();
   const latestVersionId = json.data.latestVersion.id;
-  if (options.reloadPlan && versionId && latestVersionId !== versionId) {
+  if (options.reloadPlan && versionId && (latestVersionId !== versionId || options.forceReloadPlan)) {
     clearPendingSelection();
     frame.src = '/render/'+encodeURIComponent(planId)+'?versionId='+encodeURIComponent(latestVersionId)+'&t='+Date.now();
   }
   versionId = latestVersionId;
+  renderSyncWarning(json.data.plan);
   renderComments(json.data.comments || []);
+}
+function renderSyncWarning(plan){
+  if (!plan || plan.lastSyncStatus !== 'failed') {
+    syncWarning.hidden = true;
+    syncWarning.textContent = '';
+    return;
+  }
+  const error = plan.lastSyncError || {};
+  syncWarning.textContent = 'Source sync failed for ' + (plan.sourcePath || plan.planPath) + ': ' + (error.message || 'unknown error');
+  syncWarning.hidden = false;
 }
 function handlePlanVersionEvent(event){
   try {
     const data = JSON.parse(event.data || '{}');
-    if (data.versionId && data.versionId === versionId) return;
+    if (event.type !== 'plan.version.synced' && data.versionId && data.versionId === versionId) return;
   } catch {}
-  loadMeta({ reloadPlan: true });
+  loadMeta({ reloadPlan: true, forceReloadPlan: event.type === 'plan.version.synced' });
 }
 function renderComments(items){
   renderMarkers(items);
@@ -523,7 +536,7 @@ function attachFrameListeners(){
   frame.contentWindow?.addEventListener('scroll', scheduleMarkerReflow);
   frame.contentWindow?.addEventListener('resize', scheduleMarkerReflow);
 }
-frame.addEventListener('load', () => { frameListenersAttached = false; attachFrameListeners(); mountWashiOverlay(); });
+frame.addEventListener('load', () => { frameListenersAttached = false; attachFrameListeners(); mountWashiOverlay(); redrawMarkers(); });
 window.addEventListener('resize', scheduleMarkerReflow);
 if (frame.contentDocument && frame.contentDocument.readyState !== 'loading') setTimeout(attachFrameListeners, 0);
 document.getElementById('close-lightbox').addEventListener('click', () => { lightbox.hidden = true; });
@@ -587,6 +600,7 @@ document.getElementById('submit-comment').addEventListener('click', async () => 
 const source = new EventSource('/api/plans/'+planId+'/events?mode=all');
 source.addEventListener('plan.version.registered', handlePlanVersionEvent);
 source.addEventListener('plan.version.synced', handlePlanVersionEvent);
+source.addEventListener('plan.sync.failed', () => loadMeta());
 source.addEventListener('comment.created', () => loadMeta());
 source.addEventListener('comment.claimed', () => loadMeta());
 source.addEventListener('comment.acknowledged', () => loadMeta());
@@ -619,13 +633,18 @@ export function createApp(options: AppOptions): FastifyInstance {
   const app = Fastify({ logger: false });
   const store = new PlanReviewStore(options.dbPath);
   const bus = createEventBus();
+  const sourceSync = new SourceSyncService(store, bus);
+  void sourceSync.rehydrateFromStore();
   const emitExpired = (planId?: string) => {
     const events = store.releaseExpiredClaims(planId);
     for (const event of events) bus.emitEvent(event);
     return events;
   };
 
-  app.addHook('onClose', async () => store.close());
+  app.addHook('onClose', async () => {
+    await sourceSync.close();
+    store.close();
+  });
 
   app.get('/health', async () => ok({ status: 'ok' }));
   app.get('/favicon.ico', async (_request, reply) => reply.code(204).send());
@@ -664,6 +683,8 @@ export function createApp(options: AppOptions): FastifyInstance {
       const rendered = renderPlan(input);
       const result = store.registerPlan(input, rendered.renderedHtml, rendered.warnings);
       bus.emitEvent(result.event);
+      await sourceSync.register(result.planId);
+      const { plan } = store.getPlan(result.planId);
       return ok({
         planId: result.planId,
         versionId: result.versionId,
@@ -671,6 +692,13 @@ export function createApp(options: AppOptions): FastifyInstance {
         reviewUrl: result.reviewUrl,
         indexUrl: result.indexUrl,
         watchCommand: result.watchCommand,
+        sourceSync: {
+          watchMode: plan.watchMode,
+          sourcePath: plan.sourcePath,
+          status: plan.lastSyncStatus,
+          error: plan.lastSyncError,
+          active: plan.watchMode === 'filesystem' && plan.lastSyncStatus !== 'failed'
+        },
         renderedWithWarnings: rendered.warnings
       });
     } catch (error) {
@@ -691,10 +719,11 @@ export function createApp(options: AppOptions): FastifyInstance {
   app.get('/render/:planId', async (request, reply) => {
     try {
       const { planId } = request.params as { planId: string };
+      const query = request.query as { versionId?: string };
       reply
         .header('Content-Security-Policy', "default-src 'none'; script-src 'none'; connect-src 'none'; form-action 'none'; base-uri 'none'; style-src 'unsafe-inline'; img-src 'self' data: blob:")
         .type('text/html')
-        .send(store.getRenderedHtml(planId));
+        .send(store.getRenderedHtml(planId, query.versionId));
     } catch (error) {
       sendError(reply, error);
     }

--- a/tools/plan-reviewer/src/server/app.ts
+++ b/tools/plan-reviewer/src/server/app.ts
@@ -185,6 +185,8 @@ function renderSyncWarning(plan){
 function handlePlanVersionEvent(event){
   try {
     const data = JSON.parse(event.data || '{}');
+    // Non-sync events for the current version are no-ops; synced events always
+    // call loadMeta with forceReloadPlan because asset-only changes can reuse versionId.
     if (event.type !== 'plan.version.synced' && data.versionId && data.versionId === versionId) return;
   } catch {}
   loadMeta({ reloadPlan: true, forceReloadPlan: event.type === 'plan.version.synced' });

--- a/tools/plan-reviewer/src/server/sourceSync.ts
+++ b/tools/plan-reviewer/src/server/sourceSync.ts
@@ -91,6 +91,7 @@ export class SourceSyncService {
       }
     } catch (error) {
       this.fail(planId, error, 'watch_register');
+      return;
     }
     const watcher = chokidar.watch([...new Set(watchPaths)], {
       ignoreInitial: true,
@@ -147,6 +148,7 @@ export class SourceSyncService {
       if (!stat.isFile()) throw new Error(`Source path is not a file: ${plan.sourcePath}`);
       const html = fs.readFileSync(plan.sourcePath, 'utf8');
       const fileHash = sha256(html);
+      const htmlChanged = fileHash !== version.fileHash;
       const assets = discoverSourceAssets(html, plan.sourcePath);
       const payload: RegisterPlanInput = {
         repoKey: plan.repoKey,
@@ -171,7 +173,7 @@ export class SourceSyncService {
       }
       const result = this.store.registerPlan(payload, rendered.renderedHtml, rendered.warnings, 'filesystem_watch');
       this.bus.emitEvent(result.event);
-      void this.register(plan.id);
+      if (htmlChanged) void this.register(plan.id);
     } catch (error) {
       this.fail(plan.id, error, reason);
     }

--- a/tools/plan-reviewer/src/server/sourceSync.ts
+++ b/tools/plan-reviewer/src/server/sourceSync.ts
@@ -35,7 +35,11 @@ export function discoverSourceAssets(html: string, sourcePath: string) {
       assets.push({ sourceUrl });
       continue;
     }
-    if (!fs.existsSync(absolutePath) || !isLocalImagePath(sourceUrl)) {
+    if (!isLocalImagePath(sourceUrl)) {
+      assets.push({ sourceUrl });
+      continue;
+    }
+    if (!fs.existsSync(absolutePath)) {
       assets.push({ sourceUrl, absolutePath });
       continue;
     }
@@ -83,7 +87,7 @@ export class SourceSyncService {
     try {
       const html = fs.readFileSync(plan.sourcePath, 'utf8');
       for (const asset of discoverSourceAssets(html, plan.sourcePath)) {
-        if (asset.absolutePath && asset.bytesBase64) watchPaths.push(asset.absolutePath);
+        if (asset.absolutePath) watchPaths.push(asset.absolutePath);
       }
     } catch (error) {
       this.fail(planId, error, 'watch_register');
@@ -94,7 +98,13 @@ export class SourceSyncService {
     });
     watcher.on('add', () => this.schedule(planId));
     watcher.on('change', () => this.schedule(planId));
-    watcher.on('unlink', () => this.fail(planId, new Error(`Source file is missing: ${plan.sourcePath}`)));
+    watcher.on('unlink', changedPath => {
+      if (path.resolve(changedPath) === path.resolve(plan.sourcePath!)) {
+        this.fail(planId, new Error(`Source file is missing: ${plan.sourcePath}`));
+      } else {
+        this.schedule(planId);
+      }
+    });
     watcher.on('error', (error: unknown) => this.fail(planId, error));
     this.watchers.set(planId, watcher);
     await new Promise<void>(resolve => watcher.once('ready', resolve));

--- a/tools/plan-reviewer/src/server/sourceSync.ts
+++ b/tools/plan-reviewer/src/server/sourceSync.ts
@@ -1,0 +1,181 @@
+import chokidar, { type FSWatcher } from 'chokidar';
+import fs from 'node:fs';
+import path from 'node:path';
+import { findImageSources } from '../htmlImages.js';
+import { renderPlan } from '../render/render.js';
+import type { RegisterPlanInput } from '../schemas.js';
+import { PlanReviewStore, type StoredEvent } from '../storage/database.js';
+import { sha256 } from '../util.js';
+
+interface EventEmitterTarget {
+  emitEvent(event: StoredEvent): void;
+}
+
+function isLocalImagePath(sourceUrl: string): boolean {
+  return ['.gif', '.jpg', '.jpeg', '.png', '.svg', '.webp'].includes(
+    path.extname(sourceUrl.split(/[?#]/, 1)[0] || '').toLowerCase()
+  );
+}
+
+function isInsideDirectory(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+export function discoverSourceAssets(html: string, sourcePath: string) {
+  const planDir = path.dirname(sourcePath);
+  const absolutePlanDir = path.resolve(planDir);
+  const realPlanDir = fs.realpathSync(planDir);
+  const assets: Array<{ sourceUrl: string; absolutePath?: string; bytesBase64?: string }> = [];
+  for (const sourceUrl of findImageSources(html)) {
+    if (/^(data:|blob:|https?:\/\/|\/)/i.test(sourceUrl)) continue;
+    const filesystemSource = sourceUrl.split(/[?#]/, 1)[0] || sourceUrl;
+    const absolutePath = path.resolve(planDir, filesystemSource);
+    if (!isInsideDirectory(absolutePlanDir, absolutePath)) {
+      assets.push({ sourceUrl });
+      continue;
+    }
+    if (!fs.existsSync(absolutePath) || !isLocalImagePath(sourceUrl)) {
+      assets.push({ sourceUrl, absolutePath });
+      continue;
+    }
+    const realAssetPath = fs.realpathSync(absolutePath);
+    if (!isInsideDirectory(realPlanDir, realAssetPath) || !fs.statSync(realAssetPath).isFile()) {
+      assets.push({ sourceUrl });
+      continue;
+    }
+    assets.push({
+      sourceUrl,
+      absolutePath: realAssetPath,
+      bytesBase64: fs.readFileSync(realAssetPath).toString('base64')
+    });
+  }
+  return assets;
+}
+
+export class SourceSyncService {
+  private watchers = new Map<string, FSWatcher>();
+  private timers = new Map<string, NodeJS.Timeout>();
+  private chains = new Map<string, Promise<void>>();
+
+  constructor(private store: PlanReviewStore, private bus: EventEmitterTarget) {}
+
+  async close(): Promise<void> {
+    for (const timer of this.timers.values()) clearTimeout(timer);
+    this.timers.clear();
+    const watchers = [...this.watchers.values()];
+    this.watchers.clear();
+    await Promise.all(watchers.map(watcher => watcher.close()));
+  }
+
+  async rehydrateFromStore(): Promise<void> {
+    for (const item of this.store.listFilesystemPlans()) {
+      await this.register(item.planId);
+      void this.syncNow(item.planId, 'startup');
+    }
+  }
+
+  async register(planId: string): Promise<void> {
+    const { plan } = this.store.getPlan(planId);
+    await this.unregister(planId);
+    if (plan.watchMode !== 'filesystem' || !plan.sourcePath) return;
+    const watchPaths = [plan.sourcePath];
+    try {
+      const html = fs.readFileSync(plan.sourcePath, 'utf8');
+      for (const asset of discoverSourceAssets(html, plan.sourcePath)) {
+        if (asset.absolutePath && asset.bytesBase64) watchPaths.push(asset.absolutePath);
+      }
+    } catch (error) {
+      this.fail(planId, error, 'watch_register');
+    }
+    const watcher = chokidar.watch([...new Set(watchPaths)], {
+      ignoreInitial: true,
+      awaitWriteFinish: false
+    });
+    watcher.on('add', () => this.schedule(planId));
+    watcher.on('change', () => this.schedule(planId));
+    watcher.on('unlink', () => this.fail(planId, new Error(`Source file is missing: ${plan.sourcePath}`)));
+    watcher.on('error', (error: unknown) => this.fail(planId, error));
+    this.watchers.set(planId, watcher);
+    await new Promise<void>(resolve => watcher.once('ready', resolve));
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  async unregister(planId: string): Promise<void> {
+    const timer = this.timers.get(planId);
+    if (timer) clearTimeout(timer);
+    this.timers.delete(planId);
+    const watcher = this.watchers.get(planId);
+    if (!watcher) return;
+    this.watchers.delete(planId);
+    await watcher.close();
+  }
+
+  schedule(planId: string): void {
+    const existing = this.timers.get(planId);
+    if (existing) clearTimeout(existing);
+    this.timers.set(planId, setTimeout(() => {
+      this.timers.delete(planId);
+      void this.syncNow(planId, 'filesystem_watch');
+    }, 500));
+  }
+
+  syncNow(planId: string, reason: 'startup' | 'filesystem_watch' | 'manual'): Promise<void> {
+    const previous = this.chains.get(planId) ?? Promise.resolve();
+    const next = previous.then(() => this.performSync(planId, reason), () => this.performSync(planId, reason));
+    this.chains.set(planId, next.finally(() => {
+      if (this.chains.get(planId) === next) this.chains.delete(planId);
+    }));
+    return next;
+  }
+
+  private async performSync(planId: string, reason: string): Promise<void> {
+    const { plan, version } = this.store.getPlan(planId);
+    if (plan.watchMode !== 'filesystem' || !plan.sourcePath) return;
+    try {
+      const stat = fs.statSync(plan.sourcePath);
+      if (!stat.isFile()) throw new Error(`Source path is not a file: ${plan.sourcePath}`);
+      const html = fs.readFileSync(plan.sourcePath, 'utf8');
+      const fileHash = sha256(html);
+      const assets = discoverSourceAssets(html, plan.sourcePath);
+      const payload: RegisterPlanInput = {
+        repoKey: plan.repoKey,
+        repoName: plan.repoName,
+        branch: plan.branch,
+        commitSha: plan.commitSha,
+        planPath: plan.planPath,
+        slug: plan.slug,
+        html,
+        fileHash,
+        sourcePath: plan.sourcePath,
+        sourceMtimeMs: stat.mtimeMs,
+        sourceSize: stat.size,
+        watchMode: 'filesystem',
+        assets,
+        updateMode: 'upsert'
+      };
+      const rendered = renderPlan(payload);
+      if (fileHash === version.fileHash && sha256(rendered.renderedHtml) === sha256(this.store.getRenderedHtml(plan.id, version.id))) {
+        this.bus.emitEvent(this.store.markPlanSyncSucceeded(plan.id, version.id));
+        return;
+      }
+      const result = this.store.registerPlan(payload, rendered.renderedHtml, rendered.warnings, 'filesystem_watch');
+      this.bus.emitEvent(result.event);
+      void this.register(plan.id);
+    } catch (error) {
+      this.fail(plan.id, error, reason);
+    }
+  }
+
+  private fail(planId: string, error: unknown, reason = 'filesystem_watch'): void {
+    const message = error instanceof Error ? error.message : String(error);
+    const code = error && typeof error === 'object' && 'code' in error ? String((error as { code?: unknown }).code) : undefined;
+    const event = this.store.markPlanSyncFailed(planId, {
+      message,
+      code,
+      reason,
+      nextAction: 'Fix source file permissions/path or run plan-review register <path> --snapshot to keep a detached review.'
+    });
+    this.bus.emitEvent(event);
+  }
+}

--- a/tools/plan-reviewer/src/server/sourceSync.ts
+++ b/tools/plan-reviewer/src/server/sourceSync.ts
@@ -59,6 +59,7 @@ export function discoverSourceAssets(html: string, sourcePath: string) {
 
 export class SourceSyncService {
   private watchers = new Map<string, FSWatcher>();
+  private recoveryWatchers = new Set<string>();
   private timers = new Map<string, NodeJS.Timeout>();
   private chains = new Map<string, Promise<void>>();
 
@@ -69,6 +70,7 @@ export class SourceSyncService {
     this.timers.clear();
     const watchers = [...this.watchers.values()];
     this.watchers.clear();
+    this.recoveryWatchers.clear();
     await Promise.all(watchers.map(watcher => watcher.close()));
   }
 
@@ -91,6 +93,21 @@ export class SourceSyncService {
       }
     } catch (error) {
       this.fail(planId, error, 'watch_register');
+      const watcher = chokidar.watch(plan.sourcePath, {
+        ignoreInitial: true,
+        awaitWriteFinish: false
+      });
+      const recover = () => {
+        void this.register(planId).then(() => this.schedule(planId));
+      };
+      watcher.on('add', recover);
+      watcher.on('change', recover);
+      watcher.on('unlink', () => this.fail(planId, new Error(`Source file is missing: ${plan.sourcePath}`)));
+      watcher.on('error', (watchError: unknown) => this.fail(planId, watchError));
+      this.watchers.set(planId, watcher);
+      this.recoveryWatchers.add(planId);
+      await new Promise<void>(resolve => watcher.once('ready', resolve));
+      await new Promise(resolve => setTimeout(resolve, 100));
       return;
     }
     const watcher = chokidar.watch([...new Set(watchPaths)], {
@@ -116,6 +133,7 @@ export class SourceSyncService {
     const timer = this.timers.get(planId);
     if (timer) clearTimeout(timer);
     this.timers.delete(planId);
+    this.recoveryWatchers.delete(planId);
     const watcher = this.watchers.get(planId);
     if (!watcher) return;
     this.watchers.delete(planId);
@@ -149,6 +167,7 @@ export class SourceSyncService {
       const html = fs.readFileSync(plan.sourcePath, 'utf8');
       const fileHash = sha256(html);
       const htmlChanged = fileHash !== version.fileHash;
+      const needsWatcherRefresh = this.recoveryWatchers.has(plan.id);
       const assets = discoverSourceAssets(html, plan.sourcePath);
       const payload: RegisterPlanInput = {
         repoKey: plan.repoKey,
@@ -169,11 +188,12 @@ export class SourceSyncService {
       const rendered = renderPlan(payload);
       if (fileHash === version.fileHash && sha256(rendered.renderedHtml) === sha256(this.store.getRenderedHtml(plan.id, version.id))) {
         this.bus.emitEvent(this.store.markPlanSyncSucceeded(plan.id, version.id));
+        if (needsWatcherRefresh) void this.register(plan.id);
         return;
       }
       const result = this.store.registerPlan(payload, rendered.renderedHtml, rendered.warnings, 'filesystem_watch');
       this.bus.emitEvent(result.event);
-      if (htmlChanged) void this.register(plan.id);
+      if (htmlChanged || needsWatcherRefresh) void this.register(plan.id);
     } catch (error) {
       this.fail(plan.id, error, reason);
     }

--- a/tools/plan-reviewer/src/storage/database.ts
+++ b/tools/plan-reviewer/src/storage/database.ts
@@ -21,6 +21,11 @@ export interface PlanRecord {
   repoKey: string;
   branch: string;
   commitSha?: string;
+  sourcePath?: string;
+  watchMode: 'filesystem' | 'snapshot';
+  lastSyncAt?: string;
+  lastSyncStatus?: string;
+  lastSyncError?: Record<string, unknown> | null;
 }
 
 export interface VersionRecord {
@@ -32,6 +37,9 @@ export interface VersionRecord {
   renderedBlobPath: string;
   htmlBlobPath: string;
   renderWarnings: unknown[];
+  sourceMtimeMs?: number;
+  sourceSize?: number;
+  syncOrigin: 'manual_register' | 'filesystem_watch';
 }
 
 export interface StoredEvent {
@@ -103,6 +111,14 @@ function inferAssetDimensions(bytes: Buffer): { width?: number; height?: number 
   return { width: bytes.readUInt32BE(16), height: bytes.readUInt32BE(20) };
 }
 
+function optionalString(value: unknown): string | undefined {
+  return value === null || value === undefined || value === '' ? undefined : String(value);
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return value === null || value === undefined ? undefined : Number(value);
+}
+
 export class PlanReviewStore {
   private db: Database.Database;
   private blobDir: string;
@@ -136,6 +152,11 @@ export class PlanReviewStore {
         repo_id TEXT NOT NULL REFERENCES repos(id),
         slug TEXT NOT NULL,
         plan_path TEXT NOT NULL,
+        source_path TEXT,
+        watch_mode TEXT NOT NULL DEFAULT 'snapshot',
+        last_sync_at TEXT,
+        last_sync_status TEXT,
+        last_sync_error_json TEXT,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
         UNIQUE(repo_id, plan_path, slug)
@@ -149,6 +170,9 @@ export class PlanReviewStore {
         html_blob_path TEXT NOT NULL,
         rendered_blob_path TEXT NOT NULL,
         render_warnings_json TEXT NOT NULL,
+        source_mtime_ms REAL,
+        source_size INTEGER,
+        sync_origin TEXT NOT NULL DEFAULT 'manual_register',
         created_at TEXT NOT NULL,
         UNIQUE(plan_id, file_hash, branch, commit_sha)
       );
@@ -224,6 +248,21 @@ export class PlanReviewStore {
         ON claims(comment_id)
         WHERE released_at IS NULL AND acknowledged_at IS NULL;
     `);
+    this.ensureColumn('plans', 'source_path', 'TEXT');
+    this.ensureColumn('plans', 'watch_mode', "TEXT NOT NULL DEFAULT 'snapshot'");
+    this.ensureColumn('plans', 'last_sync_at', 'TEXT');
+    this.ensureColumn('plans', 'last_sync_status', 'TEXT');
+    this.ensureColumn('plans', 'last_sync_error_json', 'TEXT');
+    this.ensureColumn('plan_versions', 'source_mtime_ms', 'REAL');
+    this.ensureColumn('plan_versions', 'source_size', 'INTEGER');
+    this.ensureColumn('plan_versions', 'sync_origin', "TEXT NOT NULL DEFAULT 'manual_register'");
+  }
+
+  private ensureColumn(table: string, column: string, definition: string): void {
+    const columns = this.db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+    if (!columns.some(item => item.name === column)) {
+      this.db.prepare(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`).run();
+    }
   }
 
   private nextEventSequence(planId: string): number {
@@ -305,7 +344,7 @@ export class PlanReviewStore {
     return file;
   }
 
-  registerPlan(input: RegisterPlanInput, renderedHtml: string, renderWarnings: unknown[]) {
+  registerPlan(input: RegisterPlanInput, renderedHtml: string, renderWarnings: unknown[], syncOrigin: 'manual_register' | 'filesystem_watch' = 'manual_register') {
     const tx = this.db.transaction(() => {
       const now = nowIso();
       const repoKey =
@@ -331,11 +370,16 @@ export class PlanReviewStore {
               .get(repoId, input.planPath, baseSlug) as { id: string } | undefined);
       const planId = existingPlan?.id || id('plan');
       const slug = input.updateMode === 'new-thread' ? `${baseSlug}-${shortHash(planId)}` : baseSlug;
+      const watchMode = input.watchMode ?? 'snapshot';
+      const lastSyncStatus = watchMode === 'filesystem' ? 'synced' : 'snapshot';
       this.db
-        .prepare(`INSERT INTO plans (id, repo_id, slug, plan_path, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?)
-          ON CONFLICT(repo_id, plan_path, slug) DO UPDATE SET updated_at = excluded.updated_at`)
-        .run(planId, repoId, slug, input.planPath, now, now);
+        .prepare(`INSERT INTO plans (id, repo_id, slug, plan_path, source_path, watch_mode, last_sync_at, last_sync_status, last_sync_error_json, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(repo_id, plan_path, slug) DO UPDATE SET updated_at = excluded.updated_at,
+            source_path = excluded.source_path, watch_mode = excluded.watch_mode,
+            last_sync_at = excluded.last_sync_at, last_sync_status = excluded.last_sync_status,
+            last_sync_error_json = excluded.last_sync_error_json`)
+        .run(planId, repoId, slug, input.planPath, input.sourcePath ?? null, watchMode, now, lastSyncStatus, null, now, now);
 
       const htmlName = `${input.fileHash}.html`;
       const renderedName = `${sha256(renderedHtml)}.rendered.html`;
@@ -348,11 +392,12 @@ export class PlanReviewStore {
       const versionId = existingVersion?.id || id('ver');
       this.db
         .prepare(`INSERT INTO plan_versions
-          (id, plan_id, file_hash, branch, commit_sha, html_blob_path, rendered_blob_path, render_warnings_json, created_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          (id, plan_id, file_hash, branch, commit_sha, html_blob_path, rendered_blob_path, render_warnings_json, source_mtime_ms, source_size, sync_origin, created_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(plan_id, file_hash, branch, commit_sha) DO UPDATE SET
             html_blob_path = excluded.html_blob_path, rendered_blob_path = excluded.rendered_blob_path,
-            created_at = excluded.created_at,
+            source_mtime_ms = excluded.source_mtime_ms, source_size = excluded.source_size,
+            sync_origin = excluded.sync_origin, created_at = excluded.created_at,
             render_warnings_json = excluded.render_warnings_json`)
         .run(
           versionId,
@@ -363,6 +408,9 @@ export class PlanReviewStore {
           htmlBlobPath,
           renderedBlobPath,
           JSON.stringify(renderWarnings),
+          input.sourceMtimeMs ?? null,
+          input.sourceSize ?? null,
+          syncOrigin,
           now
         );
 
@@ -381,10 +429,14 @@ export class PlanReviewStore {
           .run(id('asset'), versionId, asset.sourceUrl, assetHash, contentType, dimensions.width ?? null, dimensions.height ?? null, blobPath, blobPath ? 'copied' : 'missing');
       }
 
-      const event = this.addEvent(planId, 'plan.version.registered', {
+      const eventType = syncOrigin === 'filesystem_watch' ? 'plan.version.synced' : 'plan.version.registered';
+      const event = this.addEvent(planId, eventType, {
         planId,
         versionId,
-        eventType: 'plan.version.registered'
+        eventType,
+        sourcePath: input.sourcePath,
+        watchMode,
+        lastSyncStatus
       });
 
       return {
@@ -393,6 +445,7 @@ export class PlanReviewStore {
         repoId,
         repoKey,
         slug,
+        sourceSync: { watchMode, sourcePath: input.sourcePath, status: lastSyncStatus, active: watchMode === 'filesystem' },
         event,
         reviewUrl: `/p/${planId}`,
         indexUrl: '/',
@@ -404,8 +457,11 @@ export class PlanReviewStore {
 
   listPlans() {
     const rows = this.db.prepare(`
-      SELECT p.id, p.slug, p.plan_path AS planPath, r.repo_name AS repoName, r.repo_key AS repoKey,
+      SELECT p.id, p.slug, p.plan_path AS planPath, p.source_path AS sourcePath, p.watch_mode AS watchMode,
+        p.last_sync_at AS lastSyncAt, p.last_sync_status AS lastSyncStatus, p.last_sync_error_json AS lastSyncErrorJson,
+        r.repo_name AS repoName, r.repo_key AS repoKey,
         v.id AS versionId, v.branch, v.commit_sha AS commitSha, v.file_hash AS fileHash,
+        v.source_mtime_ms AS sourceMtimeMs, v.source_size AS sourceSize, v.sync_origin AS syncOrigin,
         p.updated_at AS planUpdatedAt,
         SUM(CASE WHEN c.status = 'pending' THEN 1 ELSE 0 END) AS pending,
         SUM(CASE WHEN c.status = 'claimed' THEN 1 ELSE 0 END) AS claimed,
@@ -430,13 +486,21 @@ export class PlanReviewStore {
         slug: row.slug,
         planPath: row.planPath,
         repoName: row.repoName,
-        repoKey: row.repoKey
+        repoKey: row.repoKey,
+        sourcePath: optionalString(row.sourcePath),
+        watchMode: (row.watchMode ?? 'snapshot') as 'filesystem' | 'snapshot',
+        lastSyncAt: optionalString(row.lastSyncAt),
+        lastSyncStatus: optionalString(row.lastSyncStatus),
+        lastSyncError: parseJson(row.lastSyncErrorJson as string | null, null)
       },
       latestVersion: {
         id: row.versionId,
         branch: row.branch,
         commitSha: row.commitSha,
-        fileHash: row.fileHash
+        fileHash: row.fileHash,
+        sourceMtimeMs: optionalNumber(row.sourceMtimeMs),
+        sourceSize: optionalNumber(row.sourceSize),
+        syncOrigin: (row.syncOrigin ?? 'manual_register') as 'manual_register' | 'filesystem_watch'
       },
       counts: {
         pending: Number(row.pending ?? 0),
@@ -470,10 +534,13 @@ export class PlanReviewStore {
 
   getPlan(identifier: string): { plan: PlanRecord; version: VersionRecord } {
     const row = this.db.prepare(`
-      SELECT p.id, p.repo_id AS repoId, p.slug, p.plan_path AS planPath, r.repo_name AS repoName, r.repo_key AS repoKey,
+      SELECT p.id, p.repo_id AS repoId, p.slug, p.plan_path AS planPath, p.source_path AS sourcePath,
+        p.watch_mode AS watchMode, p.last_sync_at AS lastSyncAt, p.last_sync_status AS lastSyncStatus,
+        p.last_sync_error_json AS lastSyncErrorJson, r.repo_name AS repoName, r.repo_key AS repoKey,
         v.id AS versionId, v.file_hash AS fileHash, v.branch, v.commit_sha AS commitSha,
         v.html_blob_path AS htmlBlobPath, v.rendered_blob_path AS renderedBlobPath,
-        v.render_warnings_json AS renderWarningsJson
+        v.render_warnings_json AS renderWarningsJson, v.source_mtime_ms AS sourceMtimeMs,
+        v.source_size AS sourceSize, v.sync_origin AS syncOrigin
       FROM plans p
       JOIN repos r ON r.id = p.repo_id
       JOIN plan_versions v ON v.id = (
@@ -483,10 +550,13 @@ export class PlanReviewStore {
       LIMIT 1
     `).get(identifier) as Record<string, string> | undefined;
     const slugRows = row ? [] : this.db.prepare(`
-      SELECT p.id, p.repo_id AS repoId, p.slug, p.plan_path AS planPath, r.repo_name AS repoName, r.repo_key AS repoKey,
+      SELECT p.id, p.repo_id AS repoId, p.slug, p.plan_path AS planPath, p.source_path AS sourcePath,
+        p.watch_mode AS watchMode, p.last_sync_at AS lastSyncAt, p.last_sync_status AS lastSyncStatus,
+        p.last_sync_error_json AS lastSyncErrorJson, r.repo_name AS repoName, r.repo_key AS repoKey,
         v.id AS versionId, v.file_hash AS fileHash, v.branch, v.commit_sha AS commitSha,
         v.html_blob_path AS htmlBlobPath, v.rendered_blob_path AS renderedBlobPath,
-        v.render_warnings_json AS renderWarningsJson
+        v.render_warnings_json AS renderWarningsJson, v.source_mtime_ms AS sourceMtimeMs,
+        v.source_size AS sourceSize, v.sync_origin AS syncOrigin
       FROM plans p
       JOIN repos r ON r.id = p.repo_id
       JOIN plan_versions v ON v.id = (
@@ -514,7 +584,12 @@ export class PlanReviewStore {
         repoName: selectedRow.repoName,
         repoKey: selectedRow.repoKey,
         branch: selectedRow.branch,
-        commitSha: selectedRow.commitSha ?? undefined
+        commitSha: selectedRow.commitSha ?? undefined,
+        sourcePath: optionalString(selectedRow.sourcePath),
+        watchMode: (selectedRow.watchMode ?? 'snapshot') as 'filesystem' | 'snapshot',
+        lastSyncAt: optionalString(selectedRow.lastSyncAt),
+        lastSyncStatus: optionalString(selectedRow.lastSyncStatus),
+        lastSyncError: parseJson(selectedRow.lastSyncErrorJson, null)
       },
       version: {
         id: selectedRow.versionId,
@@ -524,14 +599,50 @@ export class PlanReviewStore {
         commitSha: selectedRow.commitSha ?? undefined,
         htmlBlobPath: selectedRow.htmlBlobPath,
         renderedBlobPath: selectedRow.renderedBlobPath,
-        renderWarnings: parseJson(selectedRow.renderWarningsJson, [])
+        renderWarnings: parseJson(selectedRow.renderWarningsJson, []),
+        sourceMtimeMs: optionalNumber(selectedRow.sourceMtimeMs),
+        sourceSize: optionalNumber(selectedRow.sourceSize),
+        syncOrigin: (selectedRow.syncOrigin ?? 'manual_register') as 'manual_register' | 'filesystem_watch'
       }
     };
   }
 
-  getRenderedHtml(identifier: string): string {
-    const { version } = this.getPlan(identifier);
-    return fs.readFileSync(version.renderedBlobPath, 'utf8');
+  getRenderedHtml(identifier: string, versionId?: string): string {
+    const { plan, version } = this.getPlan(identifier);
+    if (!versionId) return fs.readFileSync(version.renderedBlobPath, 'utf8');
+    const row = this.db.prepare('SELECT rendered_blob_path AS renderedBlobPath FROM plan_versions WHERE id = ? AND plan_id = ?')
+      .get(versionId, plan.id) as { renderedBlobPath: string } | undefined;
+    if (!row) throw new PlanReviewError('not_found', `Version '${versionId}' was not found for plan '${plan.id}'`, 404);
+    return fs.readFileSync(row.renderedBlobPath, 'utf8');
+  }
+
+  listFilesystemPlans(): Array<{ planId: string }> {
+    const rows = this.db.prepare("SELECT id AS planId FROM plans WHERE watch_mode = 'filesystem' AND source_path IS NOT NULL ORDER BY updated_at DESC").all() as Array<{ planId: string }>;
+    return rows;
+  }
+
+  markPlanSyncSucceeded(planId: string, versionId?: string): StoredEvent {
+    const now = nowIso();
+    this.db.prepare("UPDATE plans SET last_sync_at = ?, last_sync_status = 'synced', last_sync_error_json = NULL, updated_at = ? WHERE id = ?")
+      .run(now, now, planId);
+    return this.addEvent(planId, 'plan.version.synced', {
+      eventType: 'plan.version.synced',
+      planId,
+      versionId,
+      lastSyncStatus: 'synced'
+    });
+  }
+
+  markPlanSyncFailed(planId: string, error: Record<string, unknown>): StoredEvent {
+    const now = nowIso();
+    this.db.prepare("UPDATE plans SET last_sync_at = ?, last_sync_status = 'failed', last_sync_error_json = ?, updated_at = ? WHERE id = ?")
+      .run(now, JSON.stringify(error), now, planId);
+    return this.addEvent(planId, 'plan.sync.failed', {
+      eventType: 'plan.sync.failed',
+      planId,
+      lastSyncStatus: 'failed',
+      error
+    });
   }
 
   createComment(planId: string, input: CreateCommentInput): { comment: StoredComment; event: StoredEvent; created: boolean } {

--- a/tools/plan-reviewer/src/storage/database.ts
+++ b/tools/plan-reviewer/src/storage/database.ts
@@ -116,7 +116,9 @@ function optionalString(value: unknown): string | undefined {
 }
 
 function optionalNumber(value: unknown): number | undefined {
-  return value === null || value === undefined ? undefined : Number(value);
+  if (value === null || value === undefined) return undefined;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
 }
 
 export class PlanReviewStore {

--- a/tools/plan-reviewer/src/test-fixtures/e2e-run.ts
+++ b/tools/plan-reviewer/src/test-fixtures/e2e-run.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { chromium, request } from 'playwright';
 import { createApp } from '../server/app.js';
 import { sha256 } from '../util.js';
@@ -101,15 +104,15 @@ try {
     await page.waitForFunction(() => document.querySelector<HTMLElement>('#composer')?.hidden === false);
     await page.fill('#comment-body', 'Browser DOM annotation comment');
     await page.click('#submit-comment');
-    await page.waitForFunction(() => document.querySelectorAll('.marker').length > 0);
-    assert.equal(await page.locator('.marker').count(), 1);
-    assert.equal(await page.locator('.marker').first().evaluate(marker => marker.getAttribute('style')?.includes('NaN')), false);
     await page.waitForFunction(() => document.querySelector('#comments')?.textContent?.includes('Browser DOM annotation comment'));
+    await page.waitForFunction(() => document.querySelectorAll('.comment-anchor').length > 0);
+    assert.equal(await page.locator('.comment-anchor').count(), 1);
+    assert.equal(await page.locator('.comment-anchor').first().evaluate(marker => marker.getAttribute('style')?.includes('NaN')), false);
     assert.equal(await page.evaluate(() => (window as typeof window & { __html2canvasCalls?: number }).__html2canvasCalls), 1);
-    const markerTopBeforeScroll = await page.locator('.marker').first().evaluate(marker => marker.getBoundingClientRect().top);
+    const markerTopBeforeScroll = await page.locator('.comment-anchor').first().evaluate(marker => marker.getBoundingClientRect().top);
     await page.evaluate(() => document.querySelector<HTMLIFrameElement>('#plan-frame')?.contentWindow?.scrollTo(0, 120));
     await page.waitForFunction(
-      before => Math.abs((document.querySelector('.marker')?.getBoundingClientRect().top ?? before) - before) > 20,
+      before => Math.abs((document.querySelector('.comment-anchor')?.getBoundingClientRect().top ?? before) - before) > 20,
       markerTopBeforeScroll
     );
     await page.evaluate(() => document.querySelector<HTMLIFrameElement>('#plan-frame')?.contentWindow?.scrollTo(0, 0));
@@ -163,9 +166,51 @@ try {
     assert.match(await page.locator('#comments').innerText(), /image · mapped/);
     await page.reload();
     await page.waitForFunction(() => document.querySelector('#comments')?.textContent?.includes('Browser image annotation comment'));
-    await page.waitForFunction(() => document.querySelectorAll('.marker').length >= 3);
+    await page.waitForFunction(() => document.querySelectorAll('.comment-anchor').length >= 3);
   } finally {
     await browser.close();
+  }
+
+  const syncDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-review-e2e-sync-'));
+  const syncPath = path.join(syncDir, 'live-plan.html');
+  const syncHtmlV1 = '<!doctype html><html><body><main><section id="sync-target"><h1>Plan sync</h1><p>Source sync v1</p></section></main></body></html>';
+  fs.writeFileSync(syncPath, syncHtmlV1);
+  const syncStat = fs.statSync(syncPath);
+  const syncRegister = await context.post('/api/plans/register', {
+    data: {
+      repoKey: 'e2e-sync-repo',
+      repoName: 'e2e-sync',
+      rootPath: syncDir,
+      branch: 'main',
+      commitSha: 'e2e-sync',
+      planPath: 'live-plan.html',
+      slug: 'e2e-sync',
+      html: syncHtmlV1,
+      fileHash: sha256(syncHtmlV1),
+      sourcePath: syncPath,
+      sourceMtimeMs: syncStat.mtimeMs,
+      sourceSize: syncStat.size,
+      watchMode: 'filesystem',
+      updateMode: 'upsert'
+    }
+  });
+  assert.equal(syncRegister.ok(), true);
+  const syncRegistered = (await syncRegister.json()).data as { planId: string; versionId: string };
+  const syncBrowser = await chromium.launch({ headless: true });
+  try {
+    const syncPage = await syncBrowser.newPage();
+    await syncPage.goto(`${baseUrl}/p/${syncRegistered.planId}`);
+    await syncPage.waitForFunction(() => document.querySelector<HTMLIFrameElement>('#plan-frame')?.contentDocument?.body?.textContent?.includes('Source sync v1'));
+    const syncHtmlV2 = syncHtmlV1.replace('Source sync v1', 'Source sync v2');
+    fs.writeFileSync(syncPath, syncHtmlV2);
+    await syncPage.waitForFunction(() => document.querySelector<HTMLIFrameElement>('#plan-frame')?.contentDocument?.body?.textContent?.includes('Source sync v2'));
+    fs.rmSync(syncPath);
+    await syncPage.waitForFunction(() => document.querySelector<HTMLElement>('#sync-warning')?.hidden === false);
+    fs.writeFileSync(syncPath, syncHtmlV2);
+    await syncPage.waitForFunction(() => document.querySelector<HTMLElement>('#sync-warning')?.hidden === true);
+  } finally {
+    await syncBrowser.close();
+    fs.rmSync(syncDir, { recursive: true, force: true });
   }
 
   const comments = await context.get(`/api/plans/${registered.planId}/comments`);
@@ -193,7 +238,7 @@ try {
   assert.ok(assetBody.length > 100, `expected non-trivial marker screenshot, got ${assetBody.length} bytes`);
 
   await context.dispose();
-  console.log('e2e scenarios passed: plan index, dom annotation, image annotation');
+  console.log('e2e scenarios passed: plan index, dom annotation, image annotation, plan sync');
 } finally {
   await app.close();
 }


### PR DESCRIPTION
## Plan

`thoughts/plans/html-plan-reviewer-authoritative-sync.html`

## In-scope summary

- Adds authoritative source metadata and compatible SQLite migrations for live-linked plan files.
- Adds central-service filesystem sync via `chokidar`, including startup rehydration, debounce/serialization, relative image watching, last-good-render failure handling, and sync events.
- Updates browser review pages to reload on plan sync events and show sync failures in the sidebar.
- Makes `plan-review register` default to live filesystem sync, with `--snapshot` for detached reviews.
- Updates README and the local `html-plan-reviewer` skill guidance.

## Verification

- `cd tools/plan-reviewer && bun run test` — pass, 22/22.
- `cd tools/plan-reviewer && bun run test:e2e -- --grep "plan sync|plan index"` — pass; reports plan index, DOM annotation, image annotation, plan sync.

## Reviews

- Codex review verdict: `VERDICT: PASS_SCOPED`.
- Claude review verdict: `VERDICT: PASS_SCOPED`.

## Deferred out-of-scope follow-ups

- No-op source sync events can still force iframe reloads; possible UX polish later.
- Server `discoverSourceAssets` duplicates the CLI asset discovery algorithm; possible consolidation later.

## Known residual risks

- The `/Users/anichols/.agents/skills/html-plan-reviewer/SKILL.md` update is outside this git repository and is not included in this PR diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Plan reviews now synchronize automatically when source files change, updating rendered assets in real-time.
  * Introduced `--snapshot` flag for registering detached plan copies without live-filesystem linking.
  * Added sync status warnings and indicators to the plan review interface.

* **Documentation**
  * Updated plan-review registration documentation covering live-linking behavior, SSE sync events, and fallback handling.

* **Chores**
  * Added filesystem watch dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->