### PR TITLE
Fix pi-vcc continuation after active compaction

### DIFF
--- a/_pi/packages/pi-vcc/README.md
+++ b/_pi/packages/pi-vcc/README.md
@@ -10,6 +10,7 @@ Vendored into `ai-configs` from `sting8k/pi-vcc` so this repo can ship a pinned 
   - `/pi-vcc` carries the `__PI_VCC_MANUAL_BYPASS__` marker directly in-source so repo-managed auto-compaction and manual compaction both use pi-vcc without global patching
   - the compaction hook keeps the repo-local agent-only fallback tail and shifts the cut backward so a live `toolResult` never outlives its matching assistant tool call
   - this vendored copy intentionally does **not** append the upstream `vcc_recall` reminder note to every summary; this repo keeps the pre-existing summary output contract while still stripping older injected note lines during merge
+  - when pi-vcc compacts while an agent turn is still in flight, it sends a follow-up continue prompt after compaction so the agent resumes instead of stalling
   - local tests and harnesses cover the repo-specific compaction safety contract and package-wide verification flow
 
 Algorithmic conversation compactor for [Pi](https://github.com/badlogic/pi-mono). No LLM calls — produces a brief transcript via extraction and formatting.

--- a/_pi/packages/pi-vcc/src/details.ts
+++ b/_pi/packages/pi-vcc/src/details.ts
@@ -4,4 +4,5 @@ export interface PiVccCompactionDetails {
   sections: string[];
   sourceMessageCount: number;
   previousSummaryUsed: boolean;
+  interruptedInFlightTurn?: boolean;
 }

--- a/_pi/packages/pi-vcc/src/hooks/before-compact.ts
+++ b/_pi/packages/pi-vcc/src/hooks/before-compact.ts
@@ -9,6 +9,11 @@ import type { PiVccCompactionDetails } from "../details";
 const CONFIG_PATH = join(homedir(), ".pi", "agent", "pi-vcc-config.json");
 const MIN_MESSAGES_TO_COMPACT = 3;
 const AGENT_ONLY_FALLBACK_TAIL_MESSAGES = 4;
+const CONTINUE_AFTER_COMPACTION_PROMPT =
+  "Continue from where you left off. Pi-vcc compacted the active in-flight conversation; resume the next concrete step without summarizing the compaction.";
+const CONTINUE_AFTER_COMPACTION_DELAY_MS = 50;
+const CONTINUE_AFTER_COMPACTION_RETRY_MS = 100;
+const CONTINUE_AFTER_COMPACTION_MAX_WAIT_MS = 5000;
 
 export interface CompactionStats {
   summarized: number;
@@ -118,11 +123,48 @@ function buildOwnCut(branchEntries: any[]): { messages: any[]; firstKeptEntryId:
 }
 
 export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
+  let agentTurnActive = false;
+  let continueAfterNextCompaction = false;
+  let continueTimer: ReturnType<typeof setTimeout> | undefined;
+
+  pi.on("agent_start", () => {
+    agentTurnActive = true;
+  });
+
+  pi.on("agent_end", () => {
+    agentTurnActive = false;
+  });
+
+  pi.on("session_compact", (event, ctx) => {
+    if (!continueAfterNextCompaction) return;
+    continueAfterNextCompaction = false;
+
+    const details = event.compactionEntry.details as PiVccCompactionDetails | undefined;
+    if (details?.compactor !== "pi-vcc") return;
+    if (continueTimer) return;
+
+    const startedAt = Date.now();
+    const deliverContinue = () => {
+      if (!ctx.isIdle() && Date.now() - startedAt < CONTINUE_AFTER_COMPACTION_MAX_WAIT_MS) {
+        continueTimer = setTimeout(deliverContinue, CONTINUE_AFTER_COMPACTION_RETRY_MS);
+        return;
+      }
+
+      continueTimer = undefined;
+      pi.sendUserMessage(CONTINUE_AFTER_COMPACTION_PROMPT, { deliverAs: "followUp" });
+    };
+
+    continueTimer = setTimeout(deliverContinue, CONTINUE_AFTER_COMPACTION_DELAY_MS);
+  });
+
   pi.on("session_before_compact", (event) => {
     const { preparation, branchEntries } = event;
+    const compactingActiveTurn = agentTurnActive;
+    if (compactingActiveTurn) agentTurnActive = false;
 
     const ownCut = buildOwnCut(branchEntries as any[]);
     if (!ownCut) return { cancel: true };
+    if (compactingActiveTurn) continueAfterNextCompaction = true;
 
     const agentMessages = ownCut.messages;
     const firstKeptEntryId = ownCut.firstKeptEntryId;
@@ -192,6 +234,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
       sections: [...summary.matchAll(/^\[(.+?)\]/gm)].map((m) => m[1]),
       sourceMessageCount: agentMessages.length,
       previousSummaryUsed: Boolean(preparation.previousSummary),
+      interruptedInFlightTurn: compactingActiveTurn,
     };
 
     return {

--- a/_pi/packages/pi-vcc/tests/before-compact.test.ts
+++ b/_pi/packages/pi-vcc/tests/before-compact.test.ts
@@ -10,16 +10,28 @@ mock.module("@mariozechner/pi-coding-agent", () => ({
   convertToLlm: (messages: any[]) => messages,
 }));
 
-const getBeforeCompactHandler = async () => {
+const getRegisteredHandlers = async () => {
   const { registerBeforeCompactHook } = await import("../src/hooks/before-compact");
+  const handlers: Record<string, Array<(event: any, ctx?: any) => any>> = {};
+  const sentUserMessages: Array<{ content: string; options: any }> = [];
+  const ctx = { isIdle: () => true };
 
-  let handler: ((event: any) => any) | undefined;
   registerBeforeCompactHook({
-    on: (eventName: string, callback: (event: any) => any) => {
-      if (eventName === "session_before_compact") handler = callback;
+    on: (eventName: string, callback: (event: any, ctx?: any) => any) => {
+      handlers[eventName] ??= [];
+      handlers[eventName].push(callback);
+    },
+    sendUserMessage: (content: string, options: any) => {
+      sentUserMessages.push({ content, options });
     },
   } as any);
 
+  return { handlers, sentUserMessages, ctx };
+};
+
+const getBeforeCompactHandler = async () => {
+  const { handlers } = await getRegisteredHandlers();
+  const handler = handlers.session_before_compact?.[0];
   if (!handler) throw new Error("session_before_compact handler was not registered");
   return handler;
 };
@@ -35,6 +47,15 @@ const basePreparation = {
     edited: [],
   },
 };
+
+const compactableEntries = () => [
+  messageEntry("1", userMsg("Investigate the compaction bug")),
+  messageEntry("2", assistantText("I found the hook.")),
+  messageEntry("3", userMsg("Follow-up request")),
+  messageEntry("4", assistantText("Working on it.")),
+];
+
+const delay = (ms = 75) => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe("before-compact cut policy", () => {
   it("falls back to compacting long agent-only tails", async () => {
@@ -96,5 +117,50 @@ describe("before-compact cut policy", () => {
     expect(result.compaction.firstKeptEntryId).toBe("3");
     expect(result.compaction.summary).toContain("First request");
     expect(result.compaction.summary).not.toContain("Follow-up request");
+  });
+});
+
+describe("active compaction continuation", () => {
+  it("prompts the agent to continue after compacting an in-flight turn", async () => {
+    const { handlers, sentUserMessages, ctx } = await getRegisteredHandlers();
+
+    handlers.agent_start[0]({ type: "agent_start" });
+    const result = handlers.session_before_compact[0]({
+      preparation: basePreparation,
+      branchEntries: compactableEntries(),
+    });
+
+    expect(result.compaction.details.interruptedInFlightTurn).toBe(true);
+
+    handlers.session_compact[0]({
+      type: "session_compact",
+      compactionEntry: { details: result.compaction.details },
+      fromExtension: true,
+    }, ctx);
+    await delay();
+
+    expect(sentUserMessages).toHaveLength(1);
+    expect(sentUserMessages[0].content).toContain("Continue from where you left off.");
+    expect(sentUserMessages[0].options).toEqual({ deliverAs: "followUp" });
+  });
+
+  it("does not prompt after ordinary idle compaction", async () => {
+    const { handlers, sentUserMessages, ctx } = await getRegisteredHandlers();
+
+    const result = handlers.session_before_compact[0]({
+      preparation: basePreparation,
+      branchEntries: compactableEntries(),
+    });
+
+    expect(result.compaction.details.interruptedInFlightTurn).toBe(false);
+
+    handlers.session_compact[0]({
+      type: "session_compact",
+      compactionEntry: { details: result.compaction.details },
+      fromExtension: true,
+    }, ctx);
+    await delay();
+
+    expect(sentUserMessages).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary\n- detect when pi-vcc compacts an active in-flight agent turn\n- send a follow-up continuation prompt after compaction completes\n- record interruptedInFlightTurn metadata and document behavior\n\n## Verification\n- PI_VCC_SESSION_MANAGER_PATH=/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/dist/core/session-manager.js bun test _pi/packages/pi-vcc/tests\n- E2E smoke with gpt-5.3-codex-spark verified compaction, continuation prompt injection, and SMOKE_CONTINUED_AFTER_COMPACTION response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved conversation continuity by automatically sending a follow-up prompt when compaction occurs during an active agent turn, preventing the conversation from stalling.

* **Documentation**
  * Updated package documentation to describe the new follow-up "continue" prompt behavior triggered after compaction.

* **Tests**
  * Extended test coverage to validate the new conversation continuation feature and confirm proper prompt delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->