### PR TITLE
Selectively uptake pi-vcc upstream fixes

### DIFF
--- a/_pi/packages/pi-vcc/README.md
+++ b/_pi/packages/pi-vcc/README.md
@@ -3,14 +3,18 @@
 Vendored into `ai-configs` from `sting8k/pi-vcc` so this repo can ship a pinned local install plus repo-specific compaction behavior.
 
 - Source: `https://github.com/sting8k/pi-vcc`
-- Upstream version: `0.3.6`
-- Upstream commit snapshot: `5c50dfc20189ddbc1459b911ead00e31d2c408dd`
+- Local package version: `0.3.6-ai-configs.1`
+- Reviewed upstream version: `0.3.15`
+- Reviewed upstream commit: `b4c9099c78863769bec8f6f3ee3861c1e094db9e`
 - License: MIT
-- Local changes:
+- Local changes and selective uptake:
   - `/pi-vcc` carries the `__PI_VCC_MANUAL_BYPASS__` marker directly in-source so repo-managed auto-compaction and manual compaction both use pi-vcc without global patching
   - the compaction hook keeps the repo-local agent-only fallback tail and shifts the cut backward so a live `toolResult` never outlives its matching assistant tool call
+  - when pi-vcc compacts before the assistant has finished its response, it sends a follow-up continue prompt after compaction so the agent resumes instead of stalling; compactions at the completed-response boundary stay silent
+  - high-value upstream `0.3.15` uptake is intentionally narrow: TUI-safe wrapping for final compiled summaries plus `bashExecution` normalization/search/report correctness fixes
+  - this vendored copy preserves redaction, including compressed bash command redaction, even though upstream removed `src/core/redact.ts`
   - this vendored copy intentionally does **not** append the upstream `vcc_recall` reminder note to every summary; this repo keeps the pre-existing summary output contract while still stripping older injected note lines during merge
-  - when pi-vcc compacts while an agent turn is still in flight, it sends a follow-up continue prompt after compaction so the agent resumes instead of stalling
+  - this vendored copy intentionally skips upstream active-lineage recall, commits-section extraction, settings scaffold, compact-all sentinel/orphan recovery, broad summary-quality churn, peer dependency range changes, tool-error omission, and binary demo assets
   - local tests and harnesses cover the repo-specific compaction safety contract and package-wide verification flow
 
 Algorithmic conversation compactor for [Pi](https://github.com/badlogic/pi-mono). No LLM calls — produces a brief transcript via extraction and formatting.
@@ -47,7 +51,7 @@ Measured on real session JSONLs under `~/.pi/agent/sessions` (chars = rendered m
 ## Features
 
 - **No LLM** — purely algorithmic, zero extra API cost
-- **Brief transcript** — chronological conversation flow, each tool call collapsed to a one-liner with `(#N)` refs, text truncated to keep it compact
+- **Brief transcript** — chronological conversation flow, each tool call collapsed to a one-liner with `(#N)` refs, `bashExecution` commands rendered as user actions, text truncated to keep it compact
 - **4 semantic sections** — session goal, files & changes, outstanding context, user preferences
 - **Bounded merge** — rolling sections re-capped after merge instead of growing unbounded
 - **Lossless recall** — `vcc_recall` reads raw session JSONL, so old history stays searchable across compactions
@@ -55,7 +59,8 @@ Measured on real session JSONLs under `~/.pi/agent/sessions` (chars = rendered m
 - **Result ranking** — search results ranked by term relevance, rare terms weighted higher than common ones
 - **`/pi-vcc-recall`** — slash command to search history directly, results shown as collapsible message and auto-fed to agent as context
 - **Fallback cut** — still works when Pi core returns nothing to summarize
-- **Redaction** — strips passwords, API keys, secrets
+- **TUI-safe wrapping** — wraps long compiled summary lines so Pi's terminal UI stays readable
+- **Redaction** — strips passwords, API keys, secrets, with redaction preserved as the final compiled-output safety transform
 - **`/pi-vcc`** — manual compaction on demand
 
 ## Install
@@ -183,8 +188,8 @@ Typical workflow: **search → find relevant entry indices → expand those indi
 3. **Build sections** — extract goal, file paths, blockers, preferences
 4. **Brief transcript** — chronological conversation flow, tool calls collapsed to one-liners, text truncated
 5. **Format** — render into bracketed sections + transcript
-6. **Redact** — strip passwords, API keys, secrets
-7. **Merge** — if previous summary exists: sticky sections merge, volatile sections replace, transcript rolls
+6. **Merge** — if previous summary exists: sticky sections merge, volatile sections replace, transcript rolls
+7. **Wrap + redact** — wrap long final summary lines and apply final redaction for passwords, API keys, secrets
 
 ## Debug
 

--- a/_pi/packages/pi-vcc/package.json
+++ b/_pi/packages/pi-vcc/package.json
@@ -2,7 +2,7 @@
   "name": "@adnichols/pi-vcc",
   "private": true,
   "version": "0.3.6-ai-configs.1",
-  "description": "Vendored pi-vcc extension for pi with upstream 0.3.6 plus repo-specific compaction fixes",
+  "description": "Vendored pi-vcc extension for pi with selective upstream 0.3.15 fixes plus repo-specific compaction behavior",
   "main": "index.ts",
   "keywords": [
     "pi-package",

--- a/_pi/packages/pi-vcc/src/core/brief.ts
+++ b/_pi/packages/pi-vcc/src/core/brief.ts
@@ -157,8 +157,8 @@ export const buildBriefSections = (blocks: NormalizedBlock[]): BriefLine[] => {
         const ref = b.sourceIndex != null ? ` (#${b.sourceIndex})` : "";
         if (cmd) {
           push("[user]", `$ ${cmd}${ref}`);
+          lastHeader = "[user]";
         }
-        lastHeader = "[user]";
         break;
       }
       case "assistant": {

--- a/_pi/packages/pi-vcc/src/core/brief.ts
+++ b/_pi/packages/pi-vcc/src/core/brief.ts
@@ -152,6 +152,15 @@ export const buildBriefSections = (blocks: NormalizedBlock[]): BriefLine[] => {
         lastHeader = "[user]";
         break;
       }
+      case "bash": {
+        const cmd = redact(compressBash(b.command));
+        const ref = b.sourceIndex != null ? ` (#${b.sourceIndex})` : "";
+        if (cmd) {
+          push("[user]", `$ ${cmd}${ref}`);
+        }
+        lastHeader = "[user]";
+        break;
+      }
       case "assistant": {
         const text = truncateTokens(b.text, TRUNCATE_ASSISTANT);
         if (text) {

--- a/_pi/packages/pi-vcc/src/core/format.ts
+++ b/_pi/packages/pi-vcc/src/core/format.ts
@@ -7,6 +7,33 @@ const section = (title: string, items: string[]): string => {
 };
 
 const BRIEF_MAX_LINES = 120;
+const TUI_SAFE_LINE_CHARS = 120;
+
+const wrapLine = (line: string, maxChars: number): string[] => {
+  if (line.length <= maxChars) return [line];
+
+  const indent = line.match(/^\s*(?:[-*]\s+|\d+\.\s+)?/)?.[0] ?? "";
+  const continuationIndent = indent ? " ".repeat(Math.min(indent.length, 8)) : "";
+  const wrapped: string[] = [];
+  let remaining = line;
+  let prefix = "";
+
+  while (prefix.length + remaining.length > maxChars) {
+    const available = Math.max(20, maxChars - prefix.length);
+    let splitAt = remaining.lastIndexOf(" ", available);
+    if (splitAt < Math.floor(available * 0.5)) splitAt = available;
+
+    wrapped.push(prefix + remaining.slice(0, splitAt).trimEnd());
+    remaining = remaining.slice(splitAt).trimStart();
+    prefix = continuationIndent;
+  }
+
+  if (remaining) wrapped.push(prefix + remaining);
+  return wrapped;
+};
+
+export const wrapLongLines = (text: string, maxChars = TUI_SAFE_LINE_CHARS): string =>
+  text.split("\n").flatMap((line) => wrapLine(line, maxChars)).join("\n");
 
 export const capBrief = (text: string): string => {
   const lines = text.split("\n");

--- a/_pi/packages/pi-vcc/src/core/normalize.ts
+++ b/_pi/packages/pi-vcc/src/core/normalize.ts
@@ -1,9 +1,8 @@
-import type { Message } from "@earendil-works/pi-ai";
-import type { NormalizedBlock } from "../types";
+import { type NormalizedBlock, type PiMessage, isBashExecutionMessage } from "../types";
 import { textOf } from "./content";
 import { sanitize } from "./sanitize";
 
-const normalizeOne = (msg: Message, msgIndex: number): NormalizedBlock[] => {
+const normalizeOne = (msg: PiMessage, msgIndex: number): NormalizedBlock[] => {
   if (msg.role === "user") {
     const blocks: NormalizedBlock[] = [];
     const text = sanitize(textOf(msg.content));
@@ -16,6 +15,16 @@ const normalizeOne = (msg: Message, msgIndex: number): NormalizedBlock[] => {
       }
     }
     return blocks.length > 0 ? blocks : [{ kind: "user", text: "", sourceIndex: msgIndex }];
+  }
+
+  if (isBashExecutionMessage(msg)) {
+    return [{
+      kind: "bash",
+      command: msg.command ?? "",
+      output: msg.output ?? "",
+      exitCode: msg.exitCode,
+      sourceIndex: msgIndex,
+    }];
   }
 
   if (msg.role === "toolResult") {
@@ -60,7 +69,7 @@ const normalizeOne = (msg: Message, msgIndex: number): NormalizedBlock[] => {
   return [];
 };
 
-export const normalize = (messages: Message[]): NormalizedBlock[] =>
+export const normalize = (messages: PiMessage[]): NormalizedBlock[] =>
   messages.flatMap((msg, i) => normalizeOne(msg, i));
 
 

--- a/_pi/packages/pi-vcc/src/core/render-entries.ts
+++ b/_pi/packages/pi-vcc/src/core/render-entries.ts
@@ -1,4 +1,5 @@
 import type { Message } from "@earendil-works/pi-ai";
+import { type PiMessage, isBashExecutionMessage } from "../types";
 import { clip, textOf } from "./content";
 import { summarizeToolArgs } from "./tool-args";
 import { extractPath } from "./tool-args";
@@ -26,7 +27,7 @@ const extractFilesFromContent = (content: Message["content"]): string[] => {
     .filter((p): p is string => p !== null);
 };
 
-export const renderMessage = (msg: Message, index: number, full = false): RenderedEntry => {
+export const renderMessage = (msg: PiMessage, index: number, full = false): RenderedEntry => {
   if (msg.role === "user") {
     return { index, role: "user", summary: full ? textOf(msg.content) : clip(textOf(msg.content), 300) };
   }
@@ -38,10 +39,9 @@ export const renderMessage = (msg: Message, index: number, full = false): Render
       summary: `${prefix}[${msg.toolName}] ${text}`,
     };
   }
-  // bashExecution has command+output instead of content
-  if ((msg as any).role === "bashExecution") {
-    const cmd = (msg as any).command ?? "";
-    const out = (msg as any).output ?? "";
+  if (isBashExecutionMessage(msg)) {
+    const cmd = msg.command ?? "";
+    const out = msg.output ?? "";
     const text = full ? `$ ${cmd}\n${out}` : clip(`$ ${cmd}\n${out}`, 300);
     return { index, role: "bash", summary: text };
   }

--- a/_pi/packages/pi-vcc/src/core/report.ts
+++ b/_pi/packages/pi-vcc/src/core/report.ts
@@ -164,6 +164,9 @@ const matchesQuery = (text: string, query: string): boolean => {
     .every((term) => hay.includes(term));
 };
 
+const escapeRegexLiteral = (text: string): string =>
+  text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 const probesOf = (messages: PiMessage[], summary: string): RecallProbe[] => {
   const blocks = normalize(messages);
   const data = buildSections({ blocks });
@@ -192,12 +195,13 @@ const probesOf = (messages: PiMessage[], summary: string): RecallProbe[] => {
       const sourceText = text.trim();
       const query = queryOf(sourceText);
       if (!query) return null;
+      const recallQuery = label === "file" ? escapeRegexLiteral(query) : query;
       return {
         label,
         sourceText,
         query,
         summaryMentioned: matchesQuery(summary, query),
-        recallHits: searchEntries(rendered, messages, query).length,
+        recallHits: searchEntries(rendered, messages, recallQuery).length,
       };
     })
     .filter((probe): probe is RecallProbe => probe !== null);

--- a/_pi/packages/pi-vcc/src/core/report.ts
+++ b/_pi/packages/pi-vcc/src/core/report.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@earendil-works/pi-ai";
+import { type PiMessage, isBashExecutionMessage } from "../types";
 import { buildSections } from "./build-sections";
 import { clip } from "./content";
 import { normalize } from "./normalize";
@@ -12,6 +12,7 @@ interface RoleCounts {
   user: number;
   assistant: number;
   toolResult: number;
+  bashExecution: number;
 }
 
 interface BlockCounts {
@@ -19,6 +20,7 @@ interface BlockCounts {
   assistant: number;
   toolCalls: number;
   toolResults: number;
+  bash: number;
   thinking: number;
 }
 
@@ -64,22 +66,24 @@ export interface CompactReport {
 const estimateTokensFromChars = (chars: number): number =>
   Math.ceil(chars / 4);
 
-const countRoles = (messages: Message[]): RoleCounts => {
-  const counts: RoleCounts = { user: 0, assistant: 0, toolResult: 0 };
+const countRoles = (messages: PiMessage[]): RoleCounts => {
+  const counts: RoleCounts = { user: 0, assistant: 0, toolResult: 0, bashExecution: 0 };
   for (const msg of messages) {
-    if (msg.role === "user") counts.user += 1;
+    if (isBashExecutionMessage(msg)) counts.bashExecution += 1;
+    else if (msg.role === "user") counts.user += 1;
     else if (msg.role === "assistant") counts.assistant += 1;
     else if (msg.role === "toolResult") counts.toolResult += 1;
   }
   return counts;
 };
 
-const countBlocks = (messages: Message[]): BlockCounts => {
+const countBlocks = (messages: PiMessage[]): BlockCounts => {
   const counts: BlockCounts = {
     user: 0,
     assistant: 0,
     toolCalls: 0,
     toolResults: 0,
+    bash: 0,
     thinking: 0,
   };
 
@@ -88,18 +92,19 @@ const countBlocks = (messages: Message[]): BlockCounts => {
     else if (block.kind === "assistant") counts.assistant += 1;
     else if (block.kind === "tool_call") counts.toolCalls += 1;
     else if (block.kind === "tool_result") counts.toolResults += 1;
+    else if (block.kind === "bash") counts.bash += 1;
     else if (block.kind === "thinking") counts.thinking += 1;
   }
 
   return counts;
 };
 
-const inputCharsOf = (messages: Message[]): number =>
+const inputCharsOf = (messages: PiMessage[]): number =>
   messages
     .map((msg, index) => renderMessage(msg, index, true).summary.length)
     .reduce((sum, len) => sum + len, 0);
 
-const topFilesOf = (messages: Message[]): string[] => {
+const topFilesOf = (messages: PiMessage[]): string[] => {
   const files = new Set<string>();
   for (const block of normalize(messages)) {
     if (block.kind === "tool_call") {
@@ -112,7 +117,7 @@ const topFilesOf = (messages: Message[]): string[] => {
   return [...files].slice(0, 10);
 };
 
-const previewOf = (messages: Message[], edgeCount = 3): string => {
+const previewOf = (messages: PiMessage[], edgeCount = 3): string => {
   const rendered = messages.map((msg, index) => renderMessage(msg, index));
   if (rendered.length === 0) return "(empty)";
   if (rendered.length <= edgeCount * 2) {
@@ -159,7 +164,7 @@ const matchesQuery = (text: string, query: string): boolean => {
     .every((term) => hay.includes(term));
 };
 
-const probesOf = (messages: Message[], summary: string): RecallProbe[] => {
+const probesOf = (messages: PiMessage[], summary: string): RecallProbe[] => {
   const blocks = normalize(messages);
   const data = buildSections({ blocks });
 
@@ -192,7 +197,7 @@ const probesOf = (messages: Message[], summary: string): RecallProbe[] => {
         sourceText,
         query,
         summaryMentioned: matchesQuery(summary, query),
-        recallHits: searchEntries(rendered, query).length,
+        recallHits: searchEntries(rendered, messages, query).length,
       };
     })
     .filter((probe): probe is RecallProbe => probe !== null);

--- a/_pi/packages/pi-vcc/src/core/search-entries.ts
+++ b/_pi/packages/pi-vcc/src/core/search-entries.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@earendil-works/pi-ai";
+import { type PiMessage, isBashExecutionMessage } from "../types";
 import type { RenderedEntry } from "./render-entries";
 import { textOf } from "./content";
 
@@ -148,16 +148,16 @@ const lineSnippet = (text: string, regex: RegExp, contextLines = 2): string | un
 };
 
 /** Build full searchable text for a message. */
-const fullText = (msg: Message): string => {
-  if ((msg as any).role === "bashExecution") {
-    return `${(msg as any).command ?? ""} ${(msg as any).output ?? ""}`;
+const fullText = (msg: PiMessage): string => {
+  if (isBashExecutionMessage(msg)) {
+    return `${msg.command ?? ""} ${msg.output ?? ""}`;
   }
   return textOf(msg.content);
 };
 
 export const searchEntries = (
   entries: RenderedEntry[],
-  messages: Message[],
+  messages: PiMessage[],
   query?: string,
 ): SearchHit[] => {
   if (!query?.trim()) return entries;

--- a/_pi/packages/pi-vcc/src/core/summarize.ts
+++ b/_pi/packages/pi-vcc/src/core/summarize.ts
@@ -37,13 +37,25 @@ const briefOf = (text: string): string => {
   return text.slice(idx + SEPARATOR.length).trim();
 };
 
+const bulletLinesOf = (text: string): string[] => {
+  const lines: string[] = [];
+  for (const rawLine of text.split("\n")) {
+    if (rawLine.startsWith("- ")) {
+      lines.push(rawLine);
+    } else if (/^\s+\S/.test(rawLine) && lines.length > 0) {
+      lines[lines.length - 1] += ` ${rawLine.trim()}`;
+    }
+  }
+  return lines;
+};
+
 const mergeFileLines = (prev: string, fresh: string): string => {
   const categories = ["Modified", "Created", "Read"] as const;
   const merged: Record<string, Set<string>> = {};
   for (const cat of categories) merged[cat] = new Set();
 
   for (const text of [prev, fresh]) {
-    for (const line of text.split("\n")) {
+    for (const line of bulletLinesOf(text)) {
       for (const cat of categories) {
         const prefix = `- ${cat}: `;
         if (!line.startsWith(prefix)) continue;
@@ -82,9 +94,9 @@ const mergeHeaderSection = (header: string, prev: string, fresh: string): string
     return mergeFileLines(prev, fresh);
   }
 
-  const isClean = (l: string) => l.startsWith("- ") && !l.includes("<skill") && !l.includes("</skill");
-  const prevLines = prev.split("\n").filter(isClean);
-  const freshLines = fresh.split("\n").filter(isClean);
+  const isClean = (l: string) => !l.includes("<skill") && !l.includes("</skill");
+  const prevLines = bulletLinesOf(prev).filter(isClean);
+  const freshLines = bulletLinesOf(fresh).filter(isClean);
   const combined = [...new Set([...prevLines, ...freshLines])];
   const CAP = header === "Session Goal" ? 8 : 15;
   const capped = combined.length > CAP ? combined.slice(-CAP) : combined;

--- a/_pi/packages/pi-vcc/src/core/summarize.ts
+++ b/_pi/packages/pi-vcc/src/core/summarize.ts
@@ -1,14 +1,13 @@
-import type { Message } from "@earendil-works/pi-ai";
-import type { FileOps } from "../types";
+import type { FileOps, PiMessage } from "../types";
 import { normalize } from "./normalize";
 import { filterNoise } from "./filter-noise";
 import { buildSections } from "./build-sections";
-import { formatSummary, capBrief } from "./format";
+import { formatSummary, capBrief, wrapLongLines } from "./format";
 import { redact } from "./redact";
 import { collapseSkillLines } from "./skill-collapse";
 
 export interface CompileInput {
-  messages: Message[];
+  messages: PiMessage[];
   previousSummary?: string;
   fileOps?: FileOps;
 }
@@ -137,5 +136,6 @@ export const compile = (input: CompileInput): string => {
   const data = buildSections({ blocks });
   const fresh = formatSummary(data);
   const merged = input.previousSummary ? mergePrevious(input.previousSummary, fresh) : fresh;
-  return redact(merged);
+  if (!merged) return "";
+  return redact(wrapLongLines(redact(merged)));
 };

--- a/_pi/packages/pi-vcc/src/hooks/before-compact.ts
+++ b/_pi/packages/pi-vcc/src/hooks/before-compact.ts
@@ -124,23 +124,30 @@ function buildOwnCut(branchEntries: any[]): { messages: any[]; firstKeptEntryId:
 
 export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
   let agentTurnActive = false;
-  let continueAfterNextCompaction = false;
+  let activeAgentFinishedResponse = false;
   let continueTimer: ReturnType<typeof setTimeout> | undefined;
 
   pi.on("agent_start", () => {
     agentTurnActive = true;
+    activeAgentFinishedResponse = false;
+  });
+
+  pi.on("message_end", (event) => {
+    const message = event.message as { role?: string; stopReason?: string };
+    if (message.role === "assistant" && message.stopReason !== "toolUse") {
+      activeAgentFinishedResponse = true;
+    }
   });
 
   pi.on("agent_end", () => {
     agentTurnActive = false;
+    activeAgentFinishedResponse = false;
   });
 
   pi.on("session_compact", (event, ctx) => {
-    if (!continueAfterNextCompaction) return;
-    continueAfterNextCompaction = false;
-
     const details = event.compactionEntry.details as PiVccCompactionDetails | undefined;
     if (details?.compactor !== "pi-vcc") return;
+    if (!details.interruptedInFlightTurn) return;
     if (continueTimer) return;
 
     const startedAt = Date.now();
@@ -159,12 +166,11 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
 
   pi.on("session_before_compact", (event) => {
     const { preparation, branchEntries } = event;
-    const compactingActiveTurn = agentTurnActive;
+    const compactingActiveTurn = agentTurnActive && !activeAgentFinishedResponse;
     if (compactingActiveTurn) agentTurnActive = false;
 
     const ownCut = buildOwnCut(branchEntries as any[]);
     if (!ownCut) return { cancel: true };
-    if (compactingActiveTurn) continueAfterNextCompaction = true;
 
     const agentMessages = ownCut.messages;
     const firstKeptEntryId = ownCut.firstKeptEntryId;

--- a/_pi/packages/pi-vcc/src/types.ts
+++ b/_pi/packages/pi-vcc/src/types.ts
@@ -6,9 +6,22 @@ export interface FileOps {
   createdFiles?: string[];
 }
 
+export interface BashExecutionMessage {
+  role: "bashExecution";
+  command?: string;
+  output?: string;
+  exitCode?: number;
+}
+
+export type PiMessage = Message | BashExecutionMessage;
+
+export const isBashExecutionMessage = (msg: PiMessage): msg is BashExecutionMessage =>
+  msg.role === "bashExecution";
+
 export type NormalizedBlock =
   | { kind: "user"; text: string; sourceIndex?: number }
   | { kind: "assistant"; text: string; sourceIndex?: number }
   | { kind: "tool_call"; name: string; args: Record<string, unknown>; sourceIndex?: number }
   | { kind: "tool_result"; name: string; text: string; isError: boolean; sourceIndex?: number }
+  | { kind: "bash"; command: string; output: string; exitCode: number | undefined; sourceIndex?: number }
   | { kind: "thinking"; text: string; redacted: boolean; sourceIndex?: number };

--- a/_pi/packages/pi-vcc/tests/before-compact.test.ts
+++ b/_pi/packages/pi-vcc/tests/before-compact.test.ts
@@ -144,6 +144,29 @@ describe("active compaction continuation", () => {
     expect(sentUserMessages[0].options).toEqual({ deliverAs: "followUp" });
   });
 
+  it("does not prompt after the assistant has finished the turn", async () => {
+    const { handlers, sentUserMessages, ctx } = await getRegisteredHandlers();
+
+    handlers.agent_start[0]({ type: "agent_start" });
+    handlers.message_end[0]({ type: "message_end", message: assistantText("Done.") });
+
+    const result = handlers.session_before_compact[0]({
+      preparation: basePreparation,
+      branchEntries: compactableEntries(),
+    });
+
+    expect(result.compaction.details.interruptedInFlightTurn).toBe(false);
+
+    handlers.session_compact[0]({
+      type: "session_compact",
+      compactionEntry: { details: result.compaction.details },
+      fromExtension: true,
+    }, ctx);
+    await delay();
+
+    expect(sentUserMessages).toHaveLength(0);
+  });
+
   it("does not prompt after ordinary idle compaction", async () => {
     const { handlers, sentUserMessages, ctx } = await getRegisteredHandlers();
 

--- a/_pi/packages/pi-vcc/tests/brief.test.ts
+++ b/_pi/packages/pi-vcc/tests/brief.test.ts
@@ -37,6 +37,17 @@ describe("compileBrief", () => {
     expect(r).not.toContain("abcdefghi");
   });
 
+  it("does not split assistant sections for empty bash commands", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: "Checking files." },
+      { kind: "bash", command: "", output: "", exitCode: 0, sourceIndex: 2 },
+      { kind: "tool_call", name: "Read", args: { file_path: "auth.ts" } },
+    ];
+    const r = compileBrief(blocks);
+    expect(r.match(/\[assistant\]/g)?.length).toBe(1);
+    expect(r).toContain("Checking files.\n* Read \"auth.ts\"");
+  });
+
   it("collapses tool calls to one-liners under [assistant]", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "assistant", text: "Let me check." },

--- a/_pi/packages/pi-vcc/tests/brief.test.ts
+++ b/_pi/packages/pi-vcc/tests/brief.test.ts
@@ -19,6 +19,24 @@ describe("compileBrief", () => {
     expect(r).toContain("Let me look at the auth module.");
   });
 
+  it("renders bash commands as user actions", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "bash", command: "npm test", output: "FAIL noisy output", exitCode: 1, sourceIndex: 2 },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("[user]\n$ npm test (#2)");
+    expect(r).not.toContain("FAIL noisy output");
+  });
+
+  it("redacts bash commands when rendering user actions", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "bash", command: "curl https://example.test?token=abcdefghi", output: "", exitCode: 0, sourceIndex: 3 },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("token [REDACTED]");
+    expect(r).not.toContain("abcdefghi");
+  });
+
   it("collapses tool calls to one-liners under [assistant]", () => {
     const blocks: NormalizedBlock[] = [
       { kind: "assistant", text: "Let me check." },

--- a/_pi/packages/pi-vcc/tests/compile.test.ts
+++ b/_pi/packages/pi-vcc/tests/compile.test.ts
@@ -147,6 +147,46 @@ describe("compile", () => {
     expect(maxLineLength).toBeLessThanOrEqual(120);
   });
 
+  it("preserves wrapped header bullets across later merges", () => {
+    const previousSummary = [
+      "[Session Goal]",
+      "- Investigate a very long operator-facing compaction behavior where continuation prompts should remain",
+      "  silent after completed assistant turns but resume when interrupted mid-response",
+      "",
+      "---",
+      "",
+      "[user]",
+      "Original request",
+    ].join("\n");
+    const r = compile({
+      previousSummary,
+      messages: [userMsg("New follow-up")],
+    });
+    expect(r).toMatch(/silent after\s+completed assistant turns/);
+    expect(r).toContain("interrupted mid-response");
+    expect(r).toContain("- New follow-up");
+  });
+
+  it("preserves wrapped file bullets across later merges", () => {
+    const previousSummary = [
+      "[Files And Changes]",
+      "- Read: _pi/packages/pi-vcc/src/core/very-long-file-name-that-wrapped-before-the-next-compact.ts,",
+      "  _pi/packages/pi-vcc/src/core/continued-file.ts",
+      "",
+      "---",
+      "",
+      "[assistant]",
+      "* Read files",
+    ].join("\n");
+    const r = compile({
+      previousSummary,
+      messages: [assistantWithToolCall("Read", { path: "fresh.ts" })],
+    });
+    expect(r).toContain("very-long-file-name-that-wrapped-before-the-next-compact.ts");
+    expect(r).toContain("continued-file.ts");
+    expect(r).toContain("fresh.ts");
+  });
+
   it("redacts secrets after wrapping-sensitive assembly", () => {
     const secret = "token=" + "a".repeat(160);
     const r = compile({

--- a/_pi/packages/pi-vcc/tests/compile.test.ts
+++ b/_pi/packages/pi-vcc/tests/compile.test.ts
@@ -138,4 +138,22 @@ describe("compile", () => {
     expect(r).toContain("earlier lines omitted");
     expect(r).toContain("latest");
   });
+
+  it("wraps final compiled output", () => {
+    const r = compile({
+      messages: [userMsg("check final summary wrapping " + "word ".repeat(80))],
+    });
+    const maxLineLength = Math.max(...r.split("\n").map((line) => line.length));
+    expect(maxLineLength).toBeLessThanOrEqual(120);
+  });
+
+  it("redacts secrets after wrapping-sensitive assembly", () => {
+    const secret = "token=" + "a".repeat(160);
+    const r = compile({
+      messages: [userMsg(`run deploy with ${secret}`)],
+    });
+    expect(r).toContain("token [REDACTED]");
+    expect(r).not.toContain("a".repeat(80));
+    expect(Math.max(...r.split("\n").map((line) => line.length))).toBeLessThanOrEqual(120);
+  });
 });

--- a/_pi/packages/pi-vcc/tests/format.test.ts
+++ b/_pi/packages/pi-vcc/tests/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { formatSummary } from "../src/core/format";
+import { formatSummary, wrapLongLines } from "../src/core/format";
 import type { SectionData } from "../src/sections";
 
 const empty: SectionData = {
@@ -57,5 +57,10 @@ describe("formatSummary", () => {
     expect(r).toContain("[Session Goal]");
     expect(r).toContain("[Outstanding Context]");
     expect(r).toContain("\n\n");
+  });
+
+  it("wraps long lines so compaction TUI rendering stays bounded", () => {
+    const r = wrapLongLines(`[assistant]\n${"word ".repeat(80)}`);
+    expect(Math.max(...r.split("\n").map((line) => line.length))).toBeLessThanOrEqual(120);
   });
 });

--- a/_pi/packages/pi-vcc/tests/normalize.test.ts
+++ b/_pi/packages/pi-vcc/tests/normalize.test.ts
@@ -87,8 +87,16 @@ describe("normalize", () => {
     expect(blocks[1]).toEqual({ kind: "user", text: "[image: image/png]", sourceIndex: 0 });
   });
 
-  it("skips unknown message roles gracefully", () => {
-    const weird = { role: "bashExecution", command: "ls", output: "files", exitCode: 0 } as any;
+  it("normalizes bashExecution messages", () => {
+    const msg = { role: "bashExecution", command: "ls -la", output: "files", exitCode: 0 } as any;
+    const blocks = normalize([msg]);
+    expect(blocks).toEqual([
+      { kind: "bash", command: "ls -la", output: "files", exitCode: 0, sourceIndex: 0 },
+    ]);
+  });
+
+  it("skips truly unknown message roles gracefully", () => {
+    const weird = { role: "custom", content: "hello" } as any;
     const blocks = normalize([weird]);
     expect(blocks).toEqual([]);
   });

--- a/_pi/packages/pi-vcc/tests/report.test.ts
+++ b/_pi/packages/pi-vcc/tests/report.test.ts
@@ -56,6 +56,19 @@ describe("buildCompactReport", () => {
     expect(fileProbe?.recallHits).toBe(1);
   });
 
+  it("matches file probe recall hits literally", () => {
+    const report = buildCompactReport({
+      messages: [
+        userMsg("Handle unrelated setup"),
+        assistantWithToolCall("Read", { path: "unique-auth-file.ts" }),
+        assistantText("Mention unique-auth-fileXts as a separate token"),
+      ],
+    });
+    const fileProbe = report.recall.probes.find((p) => p.label === "file");
+    expect(fileProbe?.query).toBe("unique-auth-file.ts");
+    expect(fileProbe?.recallHits).toBe(1);
+  });
+
   it("counts and previews bashExecution messages", () => {
     const report = buildCompactReport({
       messages: [

--- a/_pi/packages/pi-vcc/tests/report.test.ts
+++ b/_pi/packages/pi-vcc/tests/report.test.ts
@@ -41,4 +41,31 @@ describe("buildCompactReport", () => {
     const goalProbe = report.recall.probes.find((p) => p.label === "goal");
     expect(goalProbe?.summaryMentioned).toBe(true);
   });
+
+  it("counts recall hits with the probe query", () => {
+    const report = buildCompactReport({
+      messages: [
+        userMsg("Handle unrelated setup"),
+        assistantWithToolCall("Read", { path: "unique-auth-file.ts" }),
+        toolResult("Read", "code content"),
+        assistantText("Done"),
+      ],
+    });
+    const fileProbe = report.recall.probes.find((p) => p.label === "file");
+    expect(fileProbe?.query).toBe("unique-auth-file.ts");
+    expect(fileProbe?.recallHits).toBe(1);
+  });
+
+  it("counts and previews bashExecution messages", () => {
+    const report = buildCompactReport({
+      messages: [
+        userMsg("Run the failing test"),
+        { role: "bashExecution", command: "bun test auth.test.ts", output: "rare_failure_marker", exitCode: 1 },
+      ],
+    });
+    expect(report.before.roleCounts.bashExecution).toBe(1);
+    expect(report.before.blockCounts.bash).toBe(1);
+    expect(report.before.preview).toContain("bun test auth.test.ts");
+    expect(report.before.preview).toContain("rare_failure_marker");
+  });
 });

--- a/_pi/packages/pi-vcc/tests/search-entries.test.ts
+++ b/_pi/packages/pi-vcc/tests/search-entries.test.ts
@@ -46,6 +46,18 @@ describe("searchEntries", () => {
     expect(r[0].snippet).toContain("hidden_keyword");
   });
 
+  it("searches bashExecution command and output text", () => {
+    const bashEntries: RenderedEntry[] = [
+      { index: 0, role: "bash", summary: "$ npm test\nclipped" },
+    ];
+    const bashMessages = [
+      { role: "bashExecution", command: "npm test", output: "rare_failure_marker", exitCode: 1 } as any,
+    ];
+    const r = searchEntries(bashEntries, bashMessages, "rare_failure_marker");
+    expect(r).toHaveLength(1);
+    expect(r[0].snippet).toContain("rare_failure_marker");
+  });
+
   it("returns snippet around matched term", () => {
     const r = searchEntries(entries, messages, "root");
     expect(r).toHaveLength(1);

--- a/install.sh
+++ b/install.sh
@@ -1829,21 +1829,21 @@ report_pi_vcc_upstream_status() {
     case "$status" in
         0)
             echo -e "    ${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-            echo -e "    ${BLUE}ℹ vendored pi-vcc matches the pinned upstream snapshot with the expected local patch set${NC}"
-            printf '%s\n' "$output" | sed -n '/^version status:/p;/^commit status:/p;/^drift status:/p' | sed 's/^/      /'
+            echo -e "    ${BLUE}ℹ vendored pi-vcc matches the reviewed upstream baseline with the intentional selective patch/skip manifest${NC}"
+            printf '%s\n' "$output" | sed -n '/^local package version:/p;/^version status:/p;/^commit status:/p;/^drift status:/p' | sed 's/^/      /'
             echo "      Review details with: ./scripts/check-pi-vcc-upstream.sh --verbose"
             echo -e "    ${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
             ;;
         1)
             echo -e "    ${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-            echo -e "    ${YELLOW}⚠ vendored pi-vcc has unexpected local drift${NC}"
-            printf '%s\n' "$output" | sed -n '/^version status:/p;/^commit status:/p;/^drift status:/p;/^unexpected diff count:/p;/^missing expected diff count:/p;/^review details with:/p' | sed 's/^/      /'
+            echo -e "    ${YELLOW}⚠ vendored pi-vcc has unexpected or stale manifest drift${NC}"
+            printf '%s\n' "$output" | sed -n '/^local package version:/p;/^version status:/p;/^commit status:/p;/^drift status:/p;/^unexpected diff count:/p;/^missing expected diff count:/p;/^review details with:/p' | sed 's/^/      /'
             echo -e "    ${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
             ;;
         2)
             echo -e "    ${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-            echo -e "    ${BLUE}ℹ vendored pi-vcc has upstream updates available${NC}"
-            printf '%s\n' "$output" | sed -n '/^version status:/p;/^commit status:/p;/^drift status:/p' | sed 's/^/      /'
+            echo -e "    ${BLUE}ℹ vendored pi-vcc reviewed-upstream metadata is stale; re-review upstream before changing local uptake${NC}"
+            printf '%s\n' "$output" | sed -n '/^local package version:/p;/^version status:/p;/^commit status:/p;/^drift status:/p' | sed 's/^/      /'
             echo "      Review details with: ./scripts/check-pi-vcc-upstream.sh --verbose"
             echo -e "    ${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
             ;;

--- a/scripts/check-pi-vcc-upstream.sh
+++ b/scripts/check-pi-vcc-upstream.sh
@@ -135,14 +135,18 @@ if [ -z "$REVIEWED_UPSTREAM_VERSION" ] || [ -z "$REVIEWED_UPSTREAM_COMMIT" ]; th
   printf 'commit status: reviewed upstream metadata missing\n'
   STALE=1
 else
-  if [ -n "$NPM_LATEST_VERSION" ] && [ "$NPM_LATEST_VERSION" != "$REVIEWED_UPSTREAM_VERSION" ]; then
+  if [ -z "$NPM_LATEST_VERSION" ]; then
+    printf 'version status: unknown (npm latest unavailable)\n'
+  elif [ "$NPM_LATEST_VERSION" != "$REVIEWED_UPSTREAM_VERSION" ]; then
     printf 'version status: RE-REVIEW REQUIRED (reviewed %s, npm latest %s)\n' "$REVIEWED_UPSTREAM_VERSION" "$NPM_LATEST_VERSION"
     STALE=1
   else
     printf 'version status: reviewed upstream version matches npm latest\n'
   fi
 
-  if [ -n "$UPSTREAM_HEAD" ] && [ "$UPSTREAM_HEAD" != "$REVIEWED_UPSTREAM_COMMIT" ]; then
+  if [ -z "$UPSTREAM_HEAD" ]; then
+    printf 'commit status: unknown (upstream head unavailable)\n'
+  elif [ "$UPSTREAM_HEAD" != "$REVIEWED_UPSTREAM_COMMIT" ]; then
     printf 'commit status: RE-REVIEW REQUIRED (reviewed %s, upstream %s)\n' "$REVIEWED_UPSTREAM_COMMIT" "$UPSTREAM_HEAD"
     STALE=1
   else

--- a/scripts/check-pi-vcc-upstream.sh
+++ b/scripts/check-pi-vcc-upstream.sh
@@ -10,18 +10,61 @@ README_PATH="$VENDORED_DIR/README.md"
 PACKAGE_JSON="$VENDORED_DIR/package.json"
 UPSTREAM_REPO_URL="https://github.com/sting8k/pi-vcc.git"
 VERBOSE=0
+
+# Path-level intentional manifest against the reviewed upstream commit recorded
+# in _pi/packages/pi-vcc/README.md. Entries include both local fork patches and
+# deliberately skipped upstream changes; any unlisted path drift fails.
 EXPECTED_LOCAL_DIFFS=(
-  "README.md"
-  "package.json"
-  "src/commands/pi-vcc.ts"
-  "src/core/format.ts"
-  "src/core/summarize.ts"
-  "src/hooks/before-compact.ts"
-  "tests/before-compact.test.ts"
-  "tests/compile.test.ts"
-  "tests/fixtures.ts"
-  "tests/format.test.ts"
-  "tests/support/load-session.ts"
+  ".gitignore|repo-local ignore set differs from upstream package repo"
+  "README.md|vendored README documents local fork contract and reviewed uptake"
+  "demo.gif|upstream demo asset intentionally not vendored"
+  "index.ts|preserve @earendil-works import/local registration behavior"
+  "package.json|preserve local package name/version and peer dependency ranges"
+  "src/commands/pi-vcc.ts|preserve __PI_VCC_MANUAL_BYPASS__ command marker"
+  "src/commands/vcc-recall.ts|preserve local recall command behavior"
+  "src/core/brief.ts|preserve redaction/tool-error policy plus bashExecution uptake"
+  "src/core/build-sections.ts|preserve local tool-error outstanding-context behavior"
+  "src/core/content.ts|preserve local content handling"
+  "src/core/filter-noise.ts|skip upstream broad noise-cleanup churn"
+  "src/core/format.ts|approved TUI wrapping uptake with local output contract"
+  "src/core/lineage.ts|skip upstream active-lineage recall feature"
+  "src/core/load-messages.ts|preserve local session loading behavior"
+  "src/core/normalize.ts|approved bashExecution uptake plus local thinking/tool-error handling"
+  "src/core/recall-scope.ts|skip upstream recall-scope feature"
+  "src/core/redact.ts|preserve local redaction despite upstream removal"
+  "src/core/render-entries.ts|approved explicit bashExecution typing/rendering"
+  "src/core/report.ts|approved report recall-hit searchEntries argument fix"
+  "src/core/search-entries.ts|approved explicit bashExecution search handling"
+  "src/core/settings.ts|skip upstream settings scaffold"
+  "src/core/summarize.ts|approved wrapping uptake while preserving final redaction/local continuation summary contract"
+  "src/details.ts|preserve local compaction details"
+  "src/extract/commits.ts|skip upstream commits section feature"
+  "src/extract/files.ts|preserve local file extraction behavior"
+  "src/extract/goals.ts|preserve local goal extraction behavior"
+  "src/extract/preferences.ts|preserve local preference extraction behavior"
+  "src/hooks/before-compact.ts|preserve local compaction cut, continuation, and marker behavior"
+  "src/sections.ts|preserve four-section local summary contract"
+  "src/tools/recall.ts|preserve local recall tool behavior"
+  "src/types.ts|approved bashExecution typing plus local block shape"
+  "tests/before-compact-hook.test.ts|skip upstream settings/hook test surface"
+  "tests/before-compact.test.ts|preserve local compaction invariant tests"
+  "tests/brief.test.ts|approved bashExecution test plus local redaction/tool-error tests"
+  "tests/build-sections.test.ts|preserve local section/tool-error tests"
+  "tests/compile.test.ts|approved wrapping tests plus local final redaction tests"
+  "tests/extract-goals.test.ts|preserve local extraction tests"
+  "tests/filter-noise.test.ts|skip upstream broad noise-cleanup churn"
+  "tests/fixtures.ts|preserve local test fixtures"
+  "tests/format.test.ts|approved wrapping tests plus local section contract"
+  "tests/lineage.test.ts|skip upstream active-lineage recall tests"
+  "tests/load-messages.test.ts|skip upstream load-message tests not in local package"
+  "tests/normalize.test.ts|approved bashExecution test plus local thinking/tool-error tests"
+  "tests/report.test.ts|approved report recall-hit and bashExecution report metrics tests"
+  "tests/recall-expand.test.ts|skip upstream recall expansion test surface"
+  "tests/recall-scope.test.ts|skip upstream recall-scope test surface"
+  "tests/recall-tool-scope.test.ts|skip upstream recall-scope test surface"
+  "tests/render-entries.test.ts|approved explicit bashExecution rendering tests"
+  "tests/search-entries.test.ts|approved bashExecution search tests plus local search behavior"
+  "tests/support/load-session.ts|preserve local real-session fixture loading"
 )
 
 for arg in "$@"; do
@@ -53,24 +96,64 @@ if ! command -v npm >/dev/null 2>&1; then
   exit 1
 fi
 
-UPSTREAM_VERSION="$(python3 - "$PACKAGE_JSON" <<'PY'
+LOCAL_PACKAGE_VERSION="$(python3 - "$PACKAGE_JSON" <<'PY'
 import json, sys
 with open(sys.argv[1], 'r', encoding='utf-8') as f:
-    version = json.load(f)['version']
-print(version.split('-ai-configs', 1)[0])
+    print(json.load(f)['version'])
 PY
 )"
 
-RECORDED_COMMIT="$(python3 - "$README_PATH" <<'PY'
+read_reviewed_metadata() {
+  python3 - "$README_PATH" <<'PY'
 import re, sys
 text = open(sys.argv[1], 'r', encoding='utf-8').read()
-m = re.search(r'^- Upstream commit snapshot: `([0-9a-f]{7,40})`$', text, re.M)
-print(m.group(1) if m else '')
+version = re.search(r'^- Reviewed upstream version: `([^`]+)`$', text, re.M)
+commit = re.search(r'^- Reviewed upstream commit: `([0-9a-f]{7,40})`$', text, re.M)
+print(version.group(1) if version else '')
+print(commit.group(1) if commit else '')
 PY
-)"
+}
+
+REVIEWED_METADATA="$(read_reviewed_metadata)"
+REVIEWED_UPSTREAM_VERSION="$(printf '%s\n' "$REVIEWED_METADATA" | sed -n '1p')"
+REVIEWED_UPSTREAM_COMMIT="$(printf '%s\n' "$REVIEWED_METADATA" | sed -n '2p')"
 
 NPM_LATEST_VERSION="$(npm view @sting8k/pi-vcc version 2>/dev/null || true)"
 UPSTREAM_HEAD="$(git ls-remote "$UPSTREAM_REPO_URL" refs/heads/master | awk '{print $1}')"
+
+printf 'pi-vcc upstream check\n'
+printf 'vendored path: %s\n' "$VENDORED_DIR_REL"
+printf 'local package version: %s\n' "$LOCAL_PACKAGE_VERSION"
+printf 'reviewed upstream version: %s\n' "${REVIEWED_UPSTREAM_VERSION:-<missing from README>}"
+printf 'reviewed upstream commit: %s\n' "${REVIEWED_UPSTREAM_COMMIT:-<missing from README>}"
+printf 'npm latest version: %s\n' "${NPM_LATEST_VERSION:-<unavailable>}"
+printf 'upstream master head: %s\n' "${UPSTREAM_HEAD:-<unavailable>}"
+
+STALE=0
+if [ -z "$REVIEWED_UPSTREAM_VERSION" ] || [ -z "$REVIEWED_UPSTREAM_COMMIT" ]; then
+  printf 'version status: reviewed upstream metadata missing\n'
+  printf 'commit status: reviewed upstream metadata missing\n'
+  STALE=1
+else
+  if [ -n "$NPM_LATEST_VERSION" ] && [ "$NPM_LATEST_VERSION" != "$REVIEWED_UPSTREAM_VERSION" ]; then
+    printf 'version status: RE-REVIEW REQUIRED (reviewed %s, npm latest %s)\n' "$REVIEWED_UPSTREAM_VERSION" "$NPM_LATEST_VERSION"
+    STALE=1
+  else
+    printf 'version status: reviewed upstream version matches npm latest\n'
+  fi
+
+  if [ -n "$UPSTREAM_HEAD" ] && [ "$UPSTREAM_HEAD" != "$REVIEWED_UPSTREAM_COMMIT" ]; then
+    printf 'commit status: RE-REVIEW REQUIRED (reviewed %s, upstream %s)\n' "$REVIEWED_UPSTREAM_COMMIT" "$UPSTREAM_HEAD"
+    STALE=1
+  else
+    printf 'commit status: reviewed upstream commit matches upstream head\n'
+  fi
+fi
+
+if [ "$STALE" -ne 0 ]; then
+  printf 'drift status: not checked because reviewed upstream metadata is stale or missing\n'
+  exit 2
+fi
 
 TMP_DIR="$(mktemp -d)"
 cleanup() {
@@ -78,7 +161,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
-git clone --depth 1 "$UPSTREAM_REPO_URL" "$TMP_DIR/upstream" >/dev/null 2>&1
+git init -q "$TMP_DIR/upstream"
+git -C "$TMP_DIR/upstream" remote add origin "$UPSTREAM_REPO_URL"
+git -C "$TMP_DIR/upstream" fetch --depth 1 origin "$REVIEWED_UPSTREAM_COMMIT" >/dev/null 2>&1
+git -C "$TMP_DIR/upstream" checkout -q --detach FETCH_HEAD
 
 NORMALIZED_DIFFS="$(python3 - "$TMP_DIR/upstream" "$VENDORED_DIR" <<'PY'
 from pathlib import Path
@@ -118,7 +204,7 @@ print('\n'.join(diffs))
 PY
 )"
 
-EXPECTED_DIFFS_TEXT="$(printf '%s\n' "${EXPECTED_LOCAL_DIFFS[@]}" | sort -u)"
+EXPECTED_DIFFS_TEXT="$(printf '%s\n' "${EXPECTED_LOCAL_DIFFS[@]}" | awk -F'|' '{print $1}' | sort -u)"
 UNEXPECTED_DIFFS="$({
   comm -23 \
     <(printf '%s\n' "$NORMALIZED_DIFFS" | sed '/^$/d' | sort -u) \
@@ -134,31 +220,14 @@ DRIFT_COUNT="$(printf '%s\n' "$NORMALIZED_DIFFS" | sed '/^$/d' | wc -l | tr -d '
 UNEXPECTED_COUNT="$(printf '%s\n' "$UNEXPECTED_DIFFS" | sed '/^$/d' | wc -l | tr -d ' ')"
 MISSING_COUNT="$(printf '%s\n' "$MISSING_EXPECTED_DIFFS" | sed '/^$/d' | wc -l | tr -d ' ')"
 
-printf 'pi-vcc upstream check\n'
-printf 'vendored path: %s\n' "$VENDORED_DIR_REL"
-printf 'vendored upstream version: %s\n' "$UPSTREAM_VERSION"
-printf 'recorded upstream commit: %s\n' "${RECORDED_COMMIT:-<missing from README>}"
-printf 'npm latest version: %s\n' "${NPM_LATEST_VERSION:-<unavailable>}"
-printf 'upstream master head: %s\n' "$UPSTREAM_HEAD"
-
-if [ -n "$NPM_LATEST_VERSION" ] && [ "$NPM_LATEST_VERSION" != "$UPSTREAM_VERSION" ]; then
-  printf 'version status: UPDATE AVAILABLE (vendored %s, npm latest %s)\n' "$UPSTREAM_VERSION" "$NPM_LATEST_VERSION"
-else
-  printf 'version status: up to date with npm latest\n'
-fi
-
-if [ -n "$RECORDED_COMMIT" ] && [ "$RECORDED_COMMIT" != "$UPSTREAM_HEAD" ]; then
-  printf 'commit status: UPDATE AVAILABLE (recorded %s, upstream %s)\n' "$RECORDED_COMMIT" "$UPSTREAM_HEAD"
-else
-  printf 'commit status: recorded commit matches upstream head\n'
-fi
-
 if [ -z "$NORMALIZED_DIFFS" ]; then
-  printf 'drift status: no local diffs vs upstream clone\n'
+  printf 'drift status: no local diffs vs reviewed upstream commit\n'
 elif [ -n "$UNEXPECTED_DIFFS" ]; then
   printf 'drift status: unexpected local diffs present\n'
+elif [ -n "$MISSING_EXPECTED_DIFFS" ]; then
+  printf 'drift status: intentional diff manifest contains stale paths\n'
 else
-  printf 'drift status: only expected local diffs present (%s paths)\n' "$DRIFT_COUNT"
+  printf 'drift status: only intentional diffs present (%s paths)\n' "$DRIFT_COUNT"
 fi
 
 if [ "$UNEXPECTED_COUNT" -gt 0 ]; then
@@ -170,7 +239,7 @@ if [ "$MISSING_COUNT" -gt 0 ]; then
 fi
 
 if [ "$VERBOSE" -eq 1 ]; then
-  printf '\nlocal drift vs upstream clone:\n'
+  printf '\nlocal drift vs reviewed upstream commit:\n'
   if [ -z "$NORMALIZED_DIFFS" ]; then
     printf '  none\n'
   else
@@ -182,12 +251,12 @@ $NORMALIZED_DIFFS
 EOF
   fi
 
-  printf '\nexpected local diffs:\n'
-  while IFS= read -r item; do
-    [ -n "$item" ] || continue
-    printf '  %s\n' "$item"
+  printf '\nintentional diff manifest:\n'
+  while IFS='|' read -r path reason; do
+    [ -n "$path" ] || continue
+    printf '  %s — %s\n' "$path" "$reason"
   done <<EOF
-$EXPECTED_DIFFS_TEXT
+$(printf '%s\n' "${EXPECTED_LOCAL_DIFFS[@]}" | sort -u)
 EOF
 
   if [ -n "$UNEXPECTED_DIFFS" ]; then
@@ -201,7 +270,7 @@ EOF
   fi
 
   if [ -n "$MISSING_EXPECTED_DIFFS" ]; then
-    printf '\nmissing expected local diffs:\n'
+    printf '\nmanifest entries without current diffs:\n'
     while IFS= read -r item; do
       [ -n "$item" ] || continue
       printf '  %s\n' "$item"
@@ -217,10 +286,6 @@ if [ -n "$UNEXPECTED_DIFFS" ]; then
   exit 1
 fi
 
-if [ -n "$RECORDED_COMMIT" ] && [ "$RECORDED_COMMIT" != "$UPSTREAM_HEAD" ]; then
-  exit 2
-fi
-
-if [ -n "$NPM_LATEST_VERSION" ] && [ "$NPM_LATEST_VERSION" != "$UPSTREAM_VERSION" ]; then
-  exit 2
+if [ -n "$MISSING_EXPECTED_DIFFS" ]; then
+  exit 1
 fi

--- a/thoughts/plans/pi-vcc-upstream-0-3-15-selective-uptake.html
+++ b/thoughts/plans/pi-vcc-upstream-0-3-15-selective-uptake.html
@@ -1,0 +1,457 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>pi-vcc High-Value Upstream Uptake</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #09111f;
+      --panel: #111827;
+      --panel-2: #172033;
+      --text: #e5e7eb;
+      --muted: #a7b0c0;
+      --accent: #7dd3fc;
+      --accent-2: #c084fc;
+      --good: #86efac;
+      --warn: #fbbf24;
+      --bad: #fca5a5;
+      --border: #2b364d;
+      --code: #0f172a;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: radial-gradient(circle at top left, rgba(125, 211, 252, 0.14), transparent 34rem), var(--bg);
+      color: var(--text);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.58;
+    }
+    main { max-width: 1160px; margin: 0 auto; padding: 48px 24px 88px; }
+    h1, h2, h3, h4 { line-height: 1.18; }
+    h1 { font-size: clamp(2rem, 4vw, 3.2rem); margin: 0 0 0.7rem; }
+    h2 { margin-top: 2.3rem; padding-top: 1.2rem; border-top: 1px solid var(--border); color: #f8fafc; }
+    h3 { margin-top: 1.45rem; color: var(--accent); }
+    h4 { margin: 1rem 0 0.35rem; color: #f8fafc; }
+    p, li { color: var(--text); }
+    a { color: var(--accent); }
+    code, pre { background: var(--code); color: #dbeafe; border-radius: 8px; }
+    code { padding: 0.12rem 0.3rem; }
+    pre { padding: 16px; overflow-x: auto; border: 1px solid var(--border); }
+    table { width: 100%; border-collapse: collapse; margin: 16px 0; }
+    th, td { border: 1px solid var(--border); padding: 10px 12px; vertical-align: top; }
+    th { background: var(--panel-2); color: #f8fafc; text-align: left; }
+    .badge { display: inline-block; padding: 0.22rem 0.6rem; border: 1px solid var(--border); border-radius: 999px; background: var(--panel-2); color: var(--accent); font-size: 0.86rem; }
+    .muted { color: var(--muted); }
+    .card { background: rgba(17,24,39,0.88); border: 1px solid var(--border); border-radius: 16px; padding: 18px 20px; margin: 18px 0; box-shadow: 0 18px 60px rgba(0,0,0,0.25); }
+    .decision { border-left: 4px solid var(--accent); }
+    .warn { border-left: 4px solid var(--warn); }
+    .bad { color: var(--bad); }
+    .good { color: var(--good); }
+    .phase { border-left: 4px solid var(--accent-2); }
+    input[type="checkbox"] { transform: translateY(1px); }
+  </style>
+</head>
+<body>
+<main>
+  <p class="badge">Status: implementation complete; scoped implementation reviews passed; final verification passed</p>
+  <h1 id="title">pi-vcc High-Value Upstream Uptake</h1>
+  <p class="muted">Narrow plan for taking only high-confidence upstream fixes into <code>_pi/packages/pi-vcc</code>. The default stance is skip unless the value is clear and regression risk is bounded.</p>
+
+  <section id="status">
+    <h2>Status</h2>
+    <p>This plan completed browser review plus independent Codex and Claude Code plan review. Both final reviewers reported execution-ready with no blockers. Implementation may start from the first unchecked Progress item.</p>
+  </section>
+
+  <section id="agent-review-gate">
+    <h2>Agent review gate</h2>
+    <p id="gate-rule"><strong>Rule:</strong> this plan is not execution-ready until both Codex and Claude Code have reviewed the latest saved plan file and any blocking findings have been integrated into the plan.</p>
+    <ul>
+      <li id="gate-codex"><strong>Codex review:</strong> final review completed on 2026-06-04 with verdict <code>execution-ready</code> and no blockers.</li>
+      <li id="gate-claude"><strong>Claude Code review:</strong> final review completed on 2026-06-04 with verdict <code>execution-ready</code> and no blockers.</li>
+      <li id="gate-final-status"><strong>Final promotion:</strong> completed; the status badge is <code>execution-ready</code> and the decision log records both final review outcomes.</li>
+    </ul>
+  </section>
+
+  <section id="goal">
+    <h2>Goal</h2>
+    <p>Preserve the currently working pi-vcc behavior and cherry-pick only upstream <code>0.3.15</code> deltas that have high, concrete value: provider-safe compaction invariants, TUI-safe summary wrapping, and bash/search/report correctness fixes. Skip upstream changes that are merely nice-to-have, uncertain, or mainly aesthetic.</p>
+  </section>
+
+  <section id="why-this-plan-exists">
+    <h2>Why this plan exists</h2>
+    <p><code>bash ./scripts/check-pi-vcc-upstream.sh --verbose</code> reports upstream drift: vendored upstream version <code>0.3.6</code>, npm latest <code>0.3.15</code>, upstream head <code>b4c9099c78863769bec8f6f3ee3861c1e094db9e</code>, and 37 unexpected local diffs against a fresh upstream clone.</p>
+    <p>The drift does not justify a broad uptake by itself. pi-vcc works well right now, and upstream removed or changed behaviors this repo relies on: local auto-compaction expectations, redaction, tool-error summary handling, and the in-flight continuation behavior we just repaired so pi-vcc does not send a continuation prompt after an assistant response has already completed.</p>
+  </section>
+
+  <section id="authority-and-inputs">
+    <h2>Authority and inputs</h2>
+    <ul>
+      <li id="input-user-request">User request: review upstream changes, decide what to pull, make a plan, post it for review, and do no coding yet.</li>
+      <li id="input-review-comment">Browser-review direction: “I don't want to adopt anything in this list that doesn't appear to have high value - pi-vcc works well right now. Anything that may help but isn't certain should be skipped.”</li>
+      <li id="input-root-agents"><code>AGENTS.md</code>: work directly in this repo by default; use checked plans and validate commands against real package paths.</li>
+      <li id="input-skills"><code>planning-workflow</code>, <code>html-plan-reviewer</code>, <code>reviewed-html-plan</code>, and <code>product-principles</code> guidance.</li>
+      <li id="input-current-pkg"><code>_pi/packages/pi-vcc</code> current vendored source and tests.</li>
+      <li id="input-upstream"><code>https://github.com/sting8k/pi-vcc</code> cloned at <code>b4c9099c78863769bec8f6f3ee3861c1e094db9e</code>.</li>
+      <li id="input-upstream-log">Upstream commits since <code>v0.3.6</code>: <code>v0.3.7</code> output quality and redaction removal, <code>v0.3.8</code> compact override docs/config, <code>v0.3.9</code> debug/cancel UX, <code>v0.3.10</code> compact-all sentinel, <code>v0.3.11</code> status wording, <code>v0.3.12</code> active-lineage recall, <code>v0.3.13</code>/<code>v0.3.14</code> TUI line wrapping, <code>v0.3.15</code> dependency and bash/search fixes.</li>
+    </ul>
+  </section>
+
+  <section id="current-implementation-reality">
+    <h2>Current implementation reality</h2>
+    <ul>
+      <li id="reality-vendored-install">This repo installs the local package from <code>./_pi/packages/pi-vcc</code>; it should not switch to direct upstream npm install.</li>
+      <li id="reality-current-hook"><code>src/hooks/before-compact.ts</code> currently handles compactions by default, has repo-local fallback-tail safety, and now tracks <code>interruptedInFlightTurn</code> so continuation prompts are only sent when compaction happened before the assistant finished its response.</li>
+      <li id="reality-current-marker"><code>src/commands/pi-vcc.ts</code> uses <code>__PI_VCC_MANUAL_BYPASS__</code>. <code>_pi/extensions/percentage-compaction.ts</code> also sends this marker for threshold compactions, so this marker is a cross-file local contract.</li>
+      <li id="reality-current-redaction"><code>src/core/summarize.ts</code> calls <code>redact()</code>, and <code>src/core/brief.ts</code> redacts compressed bash commands. Upstream <code>0.3.15</code> removed <code>src/core/redact.ts</code>.</li>
+      <li id="reality-current-errors">Current normalization keeps <code>tool_result.isError</code> and current summary logic includes tool errors in outstanding context. Upstream <code>0.3.15</code> omits tool result bodies entirely.</li>
+      <li id="reality-current-bash">Current code has partial <code>bashExecution</code> handling in rendering and search, but upstream adds normalization/report fixes that close correctness gaps.</li>
+      <li id="reality-upstream-import">Upstream <code>index.ts</code> imports <code>ExtensionAPI</code> from <code>@mariozechner/pi-coding-agent</code> while the rest of this repo and upstream package metadata use <code>@earendil-works/pi-coding-agent</code>. Do not copy that import unmodified.</li>
+    </ul>
+  </section>
+
+  <section id="upstream-delta-assessment">
+    <h2>Upstream delta assessment</h2>
+    <p id="delta-principle"><strong>Adoption rule:</strong> pull only deltas with a concrete correctness/display payoff and bounded blast radius. Skip anything whose value is speculative, cosmetic, or likely to destabilize the working compaction flow.</p>
+    <table>
+      <thead><tr><th>Upstream change</th><th>Decision</th><th>Reason</th></tr></thead>
+      <tbody>
+        <tr id="delta-wrap"><td>TUI-safe line wrapping for final compiled summaries</td><td class="good">Pull</td><td>High value and low risk: compacted summaries are user-visible and long lines are a known TUI/display failure mode. Pin to upstream commits <code>ad1fa01</code> (<code>src/core/format.ts</code>, <code>src/core/summarize.ts</code>, <code>tests/format.test.ts</code>) and <code>ab148ae</code> (<code>src/core/summarize.ts</code>, <code>tests/compile.test.ts</code>), but preserve local redaction as the final transform.</td></tr>
+        <tr id="delta-bash"><td><code>bashExecution</code> normalization and search/report argument-order fix</td><td class="good">Pull</td><td>High value correctness fix: current support is partial, and recall/reporting over bash entries should be reliable. Pin to upstream commits <code>fc21aa7</code> (<code>src/core/brief.ts</code>, <code>src/core/normalize.ts</code>, <code>src/core/report.ts</code>, <code>src/types.ts</code>, <code>tests/normalize.test.ts</code>) and <code>885825c</code> (<code>tests/brief.test.ts</code>, <code>tests/report.test.ts</code>). Do not pull unrelated noise-cleanup or recall-lineage changes.</td></tr>
+        <tr id="delta-deps"><td>Upstream peer dependency metadata ranges</td><td class="bad">Do not pull</td><td>The approved code changes do not require new runtime or peer dependencies. Keep current vendored peer dependency metadata unless implementation proves the package cannot install or test without changing it; that would be a new blocker, not planned uptake.</td></tr>
+        <tr id="delta-lineage"><td>Active-lineage recall with explicit <code>scope:"all"</code></td><td class="warn">Skip for now</td><td>Potentially useful, but no current high-value failure was identified. It changes recall semantics and adds enough surface area to defer.</td></tr>
+        <tr id="delta-commits"><td><code>[Commits]</code> section extraction</td><td class="warn">Skip for now</td><td>Nice context, but not essential to the current compaction workflow.</td></tr>
+        <tr id="delta-quality"><td>File path trimming, goal/preference extraction improvements, self-talk stripping, tool-call cap</td><td class="warn">Skip for now</td><td>Summary-quality improvements are plausible but not clearly high value for the current problem; avoid churn.</td></tr>
+        <tr id="delta-settings"><td><code>overrideDefaultCompaction</code> settings scaffold and upstream marker <code>__pi_vcc__</code></td><td class="bad">Do not pull</td><td>Could change working auto/threshold compaction behavior. Preserve current marker/defaults unless a later explicit task targets settings.</td></tr>
+        <tr id="delta-compact-all"><td>Compact-all sentinel and orphan recovery</td><td class="bad">Do not pull</td><td>May help edge cases, but it interacts with tool-call/result continuity and continuation-prompt semantics. Not worth destabilizing the current flow.</td></tr>
+        <tr id="delta-redaction"><td>Remove redaction</td><td class="bad">Do not pull</td><td>This repo should not make compaction summaries more likely to persist secrets without an explicit product decision.</td></tr>
+        <tr id="delta-tool-errors"><td>Hide all tool result bodies, including errors</td><td class="bad">Do not pull</td><td>Current outstanding-context extraction from tool errors is useful for resuming failed work.</td></tr>
+        <tr id="delta-demo"><td>Vendor <code>demo.gif</code></td><td class="bad">Do not pull</td><td>Large binary docs asset with no runtime value for this vendored package.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="progress">
+    <h2>Progress</h2>
+    <ul>
+      <li id="progress-p1"><input type="checkbox" checked disabled /> P1 — Lock local invariants with regression tests</li>
+      <li id="progress-p2"><input type="checkbox" checked disabled /> P2 — Uptake TUI wrapping and bash/search/report fixes</li>
+      <li id="progress-p3"><input type="checkbox" checked disabled /> P3 — Reconcile docs, checker, and install verification</li>
+    </ul>
+  </section>
+
+  <section id="resume-instructions">
+    <h2>Resume instructions (agent)</h2>
+    <p>Read this full plan, then execute the first unchecked Progress item only after review feedback is processed. Do not start with a wholesale upstream copy. Do not add active-lineage recall, commits, compact-all recovery, settings scaffolding, upstream peer dependency metadata changes, or broad summary-quality churn. Preserve the local continuation guard, redaction, tool-error context, manual/percentage compaction marker compatibility, and tool-call/result cut safety.</p>
+  </section>
+
+  <section id="product-intent-alignment">
+    <h2>Product intent alignment</h2>
+    <div class="card decision" id="intent-default-workflow">
+      <h3>Default workflow</h3>
+      <p>pi-vcc already works well. The safest product move is minimal high-value maintenance: fix clear correctness/display issues while keeping current compaction defaults stable.</p>
+    </div>
+    <div class="card decision" id="intent-safe-resume">
+      <h3>Safe resume context</h3>
+      <p>The compacted live window must remain valid for provider APIs: tool results may not outlive their matching assistant tool calls, and continuation prompts may not be injected after the assistant has already completed the turn.</p>
+    </div>
+    <div class="card warn" id="intent-fail-closed">
+      <h3>Fail-closed boundary</h3>
+      <p>When an upstream change is only plausibly useful rather than clearly valuable, skip it. Ambiguous compaction-trigger semantics, unknown marker inputs, and potential secret exposure are fail-closed areas.</p>
+    </div>
+  </section>
+
+  <section id="locked-decisions">
+    <h2>Locked decisions</h2>
+    <ol>
+      <li id="decision-vendored">Keep vendoring <code>_pi/packages/pi-vcc</code>; do not replace with direct upstream npm.</li>
+      <li id="decision-no-wholesale">Use selective cherry-picks/manual reconciliation, not a wholesale overwrite.</li>
+      <li id="decision-high-value">Only adopt upstream deltas with clear high value and bounded risk.</li>
+      <li id="decision-continuation">Preserve the local continuation contract: prompt only when compaction interrupted an unfinished assistant response; never prompt after a completed assistant response.</li>
+      <li id="decision-tool-pair">Preserve the local tool-call/result live-tail invariant.</li>
+      <li id="decision-marker">Preserve <code>__PI_VCC_MANUAL_BYPASS__</code> compatibility for <code>/pi-vcc</code> and <code>_pi/extensions/percentage-compaction.ts</code>. Do not add upstream settings/marker behavior in this plan.</li>
+      <li id="decision-default-compaction">Do not adopt upstream <code>overrideDefaultCompaction</code> behavior in this plan.</li>
+      <li id="decision-redaction">Keep redaction in compacted summaries and brief bash command rendering.</li>
+      <li id="decision-tool-errors">Keep tool-error evidence available in outstanding context.</li>
+      <li id="decision-imports">Keep <code>@earendil-works/pi-coding-agent</code> imports.</li>
+      <li id="decision-deps">Do not pull upstream peer dependency range changes in this pass; the approved code deltas do not require them.</li>
+      <li id="decision-version">Do not change <code>_pi/packages/pi-vcc/package.json</code> to claim upstream <code>0.3.15</code> parity. Keep the package version as a fork/local package version unless the entire vendored tree actually matches upstream plus documented local patches.</li>
+      <li id="decision-checker-metadata">Record reviewed upstream version/commit separately from package version, and make the upstream checker compare freshness against that reviewed-upstream metadata rather than treating package version as upstream parity.</li>
+      <li id="decision-checker-baseline">Use the pinned reviewed-upstream commit as the checker diff baseline, not the fork-base version and not live moving <code>master</code>. The intentional-diff manifest must therefore include both local fork patches and every deliberately skipped upstream-change path that differs from reviewed upstream.</li>
+      <li id="decision-checker-staleness">Check reviewed-upstream metadata freshness before diff classification. If npm latest or upstream head moves beyond the reviewed metadata, the checker should report stale/re-review required instead of classifying the resulting drift as unexpected local diffs.</li>
+      <li id="decision-redaction-order">Preserve redaction as the final transform in <code>compile()</code>: apply wrapping before the final <code>redact()</code> call or otherwise prove tests cannot split or expose redacted tokens.</li>
+      <li id="decision-demo">Do not vendor upstream <code>demo.gif</code>.</li>
+    </ol>
+  </section>
+
+  <section id="acceptance-criteria">
+    <h2>Acceptance criteria</h2>
+    <ol>
+      <li id="ac-local-continuation">Compaction during an unfinished assistant response sends one follow-up continuation prompt; compaction after a completed assistant response sends none.</li>
+      <li id="ac-tool-pair">Compaction never keeps a live <code>toolResult</code> whose matching assistant tool call was compacted away.</li>
+      <li id="ac-auto-marker"><code>/pi-vcc</code> and percentage-threshold compaction still route through pi-vcc without requiring users to edit config.</li>
+      <li id="ac-wrapping">Compiled summaries wrap long lines safely for Pi's TUI without changing section semantics; wrapping uses the upstream safe-width behavior from <code>ad1fa01</code>/<code>ab148ae</code> unless tests justify a narrower local adaptation.</li>
+      <li id="ac-bash">Bash execution entries normalize, search, and report consistently across summary and recall/report surfaces, including the upstream <code>searchEntries(rendered, messages, query)</code> argument-order fix and explicit <code>bashExecution</code> typing/normalization from <code>fc21aa7</code>.</li>
+      <li id="ac-redaction">Compacted summaries still redact known secret patterns.</li>
+      <li id="ac-tool-errors">Tool errors still appear in outstanding context or equivalent resume-critical section.</li>
+      <li id="ac-tests"><code>cd _pi/packages/pi-vcc &amp;&amp; bun test</code> passes.</li>
+      <li id="ac-drift"><code>bash ./scripts/check-pi-vcc-upstream.sh</code> diffs against the pinned reviewed-upstream commit, clearly distinguishes the intentionally narrow local patch set from intentionally skipped upstream changes, exits successfully when only the documented intentional diff manifest is present, exits stale/re-review when reviewed-upstream metadata no longer matches npm latest or upstream head, and exits unexpected-diff when an unmanifested file differs from the reviewed baseline.</li>
+      <li id="ac-install"><code>bash ./install.sh --pi</code> still installs the vendored package and reports pi-vcc status clearly.</li>
+    </ol>
+  </section>
+
+  <section id="bdd-scenarios">
+    <h2>BDD scenarios</h2>
+    <article class="card" id="bdd-continuation-inflight">
+      <h3>B1 — In-flight compaction resumes the agent</h3>
+      <p><strong>Given</strong> an assistant response is active and has not emitted a final non-tool-use assistant message<br />
+      <strong>When</strong> pi-vcc compacts the session<br />
+      <strong>Then</strong> the compaction details mark <code>interruptedInFlightTurn</code><br />
+      <strong>And</strong> <code>session_compact</code> sends exactly one follow-up continuation prompt.</p>
+    </article>
+    <article class="card" id="bdd-continuation-post-turn">
+      <h3>B2 — Completed-turn compaction stays silent</h3>
+      <p><strong>Given</strong> an assistant response has ended with a final non-<code>toolUse</code> assistant message<br />
+      <strong>When</strong> pi-vcc compacts at that boundary<br />
+      <strong>Then</strong> compaction details do not mark <code>interruptedInFlightTurn</code><br />
+      <strong>And</strong> no continuation prompt is sent.</p>
+    </article>
+    <article class="card" id="bdd-marker-compat">
+      <h3>B3 — Existing percentage compaction marker remains valid</h3>
+      <p><strong>Given</strong> <code>_pi/extensions/percentage-compaction.ts</code> triggers <code>ctx.compact()</code> with <code>__PI_VCC_MANUAL_BYPASS__</code><br />
+      <strong>When</strong> the pi-vcc hook receives <code>session_before_compact</code><br />
+      <strong>Then</strong> pi-vcc handles the compaction using current local behavior<br />
+      <strong>And</strong> the user is not required to set a new upstream config option.</p>
+    </article>
+    <article class="card" id="bdd-wrapping">
+      <h3>B4 — Long summary lines are TUI-safe</h3>
+      <p><strong>Given</strong> a summary section contains a very long line<br />
+      <strong>When</strong> <code>compile()</code> produces the final summary<br />
+      <strong>Then</strong> the line is wrapped at a safe width<br />
+      <strong>And</strong> section headings and bullet semantics remain intact.</p>
+    </article>
+    <article class="card" id="bdd-bash">
+      <h3>B5 — Bash execution is searchable and reportable</h3>
+      <p><strong>Given</strong> a session contains <code>bashExecution</code> entries<br />
+      <strong>When</strong> entries are normalized, searched, and reported<br />
+      <strong>Then</strong> bash commands and relevant output appear in the expected recall/report surfaces<br />
+      <strong>And</strong> no stale argument order causes missed hits or malformed excerpts.</p>
+    </article>
+    <article class="card" id="bdd-redaction">
+      <h3>B6 — Summary safety survives uptake</h3>
+      <p><strong>Given</strong> summarized messages contain password/API-key/token-like text in bash commands or message text<br />
+      <strong>When</strong> <code>compile()</code> produces the compacted summary<br />
+      <strong>Then</strong> known secret patterns are redacted by a final redaction transform after wrapping-sensitive summary assembly<br />
+      <strong>And</strong> wrapping does not unredact or split the secret into visible fragments.</p>
+    </article>
+    <article class="card" id="bdd-tool-errors">
+      <h3>B7 — Tool errors remain resumable context</h3>
+      <p><strong>Given</strong> a recent tool result is marked as an error<br />
+      <strong>When</strong> the summary sections are built<br />
+      <strong>Then</strong> the failure appears in <code>[Outstanding Context]</code> or an equivalent resume-critical section<br />
+      <strong>And</strong> non-error tool result bodies remain omitted from the brief transcript.</p>
+    </article>
+  </section>
+
+  <section id="test-coverage-matrix">
+    <h2>Test coverage matrix</h2>
+    <table>
+      <thead><tr><th>Acceptance / scenario</th><th>Planned test files</th><th>Verification</th></tr></thead>
+      <tbody>
+        <tr><td><code>AC1</code>, <code>B1</code>, <code>B2</code></td><td><code>tests/before-compact.test.ts</code></td><td><code>cd _pi/packages/pi-vcc &amp;&amp; bun test tests/before-compact.test.ts</code></td></tr>
+        <tr><td><code>AC2</code></td><td><code>tests/before-compact.test.ts</code></td><td><code>cd _pi/packages/pi-vcc &amp;&amp; bun test tests/before-compact.test.ts</code></td></tr>
+        <tr><td><code>AC3</code>, <code>B3</code></td><td><code>tests/before-compact.test.ts</code>; possibly <code>scripts/percentage-compaction.test.ts</code></td><td><code>cd _pi/packages/pi-vcc &amp;&amp; bun test tests/before-compact.test.ts</code> and <code>bun test scripts/percentage-compaction.test.ts</code> if touched</td></tr>
+        <tr><td><code>AC4</code>, <code>B4</code></td><td><code>tests/format.test.ts</code>, <code>tests/compile.test.ts</code></td><td><code>cd _pi/packages/pi-vcc &amp;&amp; bun test tests/format.test.ts tests/compile.test.ts</code></td></tr>
+        <tr><td><code>AC5</code>, <code>B5</code></td><td><code>tests/normalize.test.ts</code>, <code>tests/search-entries.test.ts</code>, <code>tests/report.test.ts</code>, <code>tests/render-entries.test.ts</code></td><td><code>cd _pi/packages/pi-vcc &amp;&amp; bun test tests/normalize.test.ts tests/search-entries.test.ts tests/report.test.ts tests/render-entries.test.ts</code></td></tr>
+        <tr><td><code>AC6</code>, <code>B6</code></td><td><code>tests/compile.test.ts</code>; add focused redaction tests if missing</td><td><code>cd _pi/packages/pi-vcc &amp;&amp; bun test tests/compile.test.ts</code></td></tr>
+        <tr><td><code>AC7</code>, <code>B7</code></td><td><code>tests/build-sections.test.ts</code>, <code>tests/normalize.test.ts</code></td><td><code>cd _pi/packages/pi-vcc &amp;&amp; bun test tests/build-sections.test.ts tests/normalize.test.ts</code></td></tr>
+        <tr><td><code>AC8</code>-<code>AC10</code></td><td>Package-wide tests, checker, installer</td><td><code>cd _pi/packages/pi-vcc &amp;&amp; bun test</code>; <code>bash ./scripts/check-pi-vcc-upstream.sh</code>; <code>bash ./install.sh --pi</code></td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="phase-plan">
+    <h2>Phase-by-phase execution plan</h2>
+
+    <article class="card phase" id="phase-p1-local-invariants">
+      <h3>P1 — Lock local invariants with regression tests</h3>
+      <h4>End State</h4>
+      <p>The local behaviors that upstream must not regress are covered by focused tests before any uptake.</p>
+      <h4>Tests first</h4>
+      <ul>
+        <li>Keep or add tests for in-flight continuation prompt and completed-turn no-prompt behavior.</li>
+        <li>Keep or add tests that fallback-tail compaction never starts at an orphaned <code>toolResult</code>.</li>
+        <li>Keep or add tests that <code>__PI_VCC_MANUAL_BYPASS__</code> still triggers pi-vcc compaction.</li>
+        <li>Add redaction and tool-error-context assertions if existing tests do not pin them tightly enough.</li>
+      </ul>
+      <h4>Work</h4>
+      <p>Only edit tests in this phase. P1 tests should pass against current HEAD; any failure is a real regression signal to investigate before upstream uptake, not an expected RED-phase failure.</p>
+      <h4>Expected files</h4>
+      <ul>
+        <li><code>_pi/packages/pi-vcc/tests/before-compact.test.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/tests/compile.test.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/tests/build-sections.test.ts</code></li>
+        <li><code>scripts/percentage-compaction.test.ts</code> only if marker compatibility crosses package boundary</li>
+      </ul>
+      <h4>Verify</h4>
+      <pre><code>cd _pi/packages/pi-vcc
+bun test tests/before-compact.test.ts tests/compile.test.ts tests/build-sections.test.ts
+cd ../../..
+bun test scripts/percentage-compaction.test.ts</code></pre>
+    </article>
+
+    <article class="card phase" id="phase-p2-high-value-fixes">
+      <h3>P2 — Uptake TUI wrapping and bash/search/report fixes</h3>
+      <h4>End State</h4>
+      <p>The vendored package includes only the two approved high-value upstream improvements: safe long-line wrapping and coherent bash execution normalization/search/report behavior. The search/report fix is localized to the defective report recall-hit caller: current <code>searchEntries(entries, messages, query?)</code> call sites in recall tools already pass three arguments correctly, while <code>src/core/report.ts</code> currently passes the query in the messages slot.</p>
+      <h4>Tests first</h4>
+      <ul>
+        <li>Add or adapt wrapping tests from upstream commits <code>ad1fa01</code> and <code>ab148ae</code> for long summary lines and final recall-note output.</li>
+        <li>Add or adapt bash execution normalization tests from upstream commit <code>fc21aa7</code>.</li>
+        <li>Add or adapt report recall-hit and bash command tests from upstream commit <code>885825c</code> so stale argument ordering or missed bash hits are caught.</li>
+        <li>Keep counter-tests proving redaction and tool-error outstanding context still work, including a test that final redaction occurs after wrapping-sensitive assembly.</li>
+      </ul>
+      <h4>Work</h4>
+      <ul>
+        <li>Update <code>src/core/format.ts</code> with upstream wrapping logic from <code>ad1fa01</code>.</li>
+        <li>Update <code>src/core/summarize.ts</code> with the compile-boundary wrapping from <code>ad1fa01</code>/<code>ab148ae</code>, but preserve local behavior where <code>redact()</code> is the final transform over the compiled output.</li>
+        <li>Update <code>src/types.ts</code> and <code>src/core/normalize.ts</code> for the explicit <code>bashExecution</code> shape from <code>fc21aa7</code>, then remove or reconcile existing <code>(msg as any).role === "bashExecution"</code> casts in touched rendering/search code.</li>
+        <li>Update <code>src/core/report.ts</code> for the upstream <code>searchEntries(rendered, messages, query)</code> argument-order fix from <code>fc21aa7</code>; do not churn already-correct three-argument recall call sites unless typing changes require a mechanical import/signature adjustment.</li>
+        <li>Update <code>src/core/brief.ts</code> only for the <code>bashExecution</code> handling from <code>fc21aa7</code>, while preserving local redaction of compressed bash commands.</li>
+        <li>Update <code>src/core/render-entries.ts</code> and <code>src/core/search-entries.ts</code> only as needed to align with the explicit bash type and avoid duplicate <code>as any</code> handling.</li>
+        <li>Do not add lineage recall, commits section, settings scaffold, compact-all sentinel, broad summary extraction changes, noise-filter changes, or demo assets.</li>
+        <li>Keep <code>src/core/redact.ts</code> and keep compile-time redaction as the final safety boundary.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <ul>
+        <li><code>_pi/packages/pi-vcc/src/core/format.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/src/core/summarize.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/src/core/brief.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/src/core/normalize.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/src/core/search-entries.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/src/core/report.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/src/core/render-entries.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/src/types.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/tests/format.test.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/tests/compile.test.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/tests/brief.test.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/tests/normalize.test.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/tests/search-entries.test.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/tests/report.test.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/tests/render-entries.test.ts</code></li>
+      </ul>
+      <h4>Verify</h4>
+      <pre><code>cd _pi/packages/pi-vcc
+bun test tests/format.test.ts tests/compile.test.ts tests/brief.test.ts tests/normalize.test.ts tests/search-entries.test.ts tests/report.test.ts tests/render-entries.test.ts</code></pre>
+    </article>
+
+    <article class="card phase" id="phase-p3-docs-drift-install">
+      <h3>P3 — Reconcile docs, checker, and install verification</h3>
+      <h4>End State</h4>
+      <p>The vendored package documents the deliberately narrow uptake and the deliberately skipped upstream changes. The checker and installer output are truthful without implying full <code>0.3.15</code> parity.</p>
+      <h4>Tests first</h4>
+      <ul>
+        <li>Run the package test suite before metadata/checker changes to catch semantic regressions.</li>
+        <li>Run the upstream checker before changing expected diffs and record the intentional final patch set.</li>
+        <li>Add or update checker tests if a test harness exists; otherwise validate the checker by captured before/after command output and document that evidence in the implementation notes.</li>
+      </ul>
+      <h4>Work</h4>
+      <ul>
+        <li>Update <code>_pi/packages/pi-vcc/README.md</code> with separate metadata fields for <code>Reviewed upstream version: 0.3.15</code>, <code>Reviewed upstream commit: b4c9099c78863769bec8f6f3ee3861c1e094db9e</code>, the narrow high-value uptake, and skipped-change rationale.</li>
+        <li>Update the checker metadata parser in the same commit as the README field rename so the regex names match exactly; a missing reviewed-commit parse must be a checker failure, not a silent no-op.</li>
+        <li>Do not use <code>_pi/packages/pi-vcc/package.json</code> as the upstream parity source. Keep the current fork package version unless a local suffix bump is required for install/cache semantics, and do not change peer dependency ranges.</li>
+        <li>Update <code>scripts/check-pi-vcc-upstream.sh</code> so it parses reviewed-upstream version/commit metadata from README (or another explicit metadata block), compares those values to npm latest/upstream head for freshness before diff classification, reports package version separately as the local fork package version, and clones/checks out the pinned reviewed commit for byte-diff comparison.</li>
+        <li>Extend or replace <code>EXPECTED_LOCAL_DIFFS</code> with a documented intentional-diff manifest for the exact final selective patch set against the reviewed-upstream baseline. This manifest must include every P2-touched source/test path that differs from reviewed upstream, such as <code>src/core/brief.ts</code>, <code>src/core/normalize.ts</code>, <code>src/core/search-entries.ts</code>, <code>src/core/report.ts</code>, <code>src/core/render-entries.ts</code>, <code>src/types.ts</code>, <code>tests/brief.test.ts</code>, <code>tests/normalize.test.ts</code>, <code>tests/search-entries.test.ts</code>, <code>tests/report.test.ts</code>, and <code>tests/render-entries.test.ts</code>.</li>
+        <li>The same manifest must also include every deliberately skipped upstream-change path that differs from reviewed upstream, with a reason label or adjacent documentation. Known examples include local-only <code>src/core/redact.ts</code>, upstream-only <code>demo.gif</code>, <code>package.json</code> peer dependency range differences, and any skipped lineage/commits/settings/compact-all/tool-error-omission files that remain different after the approved uptake.</li>
+        <li>The checker should pass only when every diff against the reviewed-upstream baseline is intentional, fail on unexpected diffs, and fail stale/re-review before diff classification when reviewed-upstream metadata is older than npm latest or upstream head.</li>
+        <li>Update <code>install.sh</code> only if current installer wording would mislead users into thinking the vendored copy fully matches upstream.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <ul>
+        <li><code>_pi/packages/pi-vcc/README.md</code></li>
+        <li><code>_pi/packages/pi-vcc/package.json</code> only for non-dependency fork/version/description metadata if justified</li>
+        <li><code>scripts/check-pi-vcc-upstream.sh</code></li>
+        <li><code>install.sh</code> only if installer messaging is misleading</li>
+      </ul>
+      <h4>Verify</h4>
+      <pre><code>cd _pi/packages/pi-vcc
+bun test
+cd ../../..
+bash ./scripts/check-pi-vcc-upstream.sh --verbose
+bash ./install.sh --pi
+git diff -- _pi/packages/pi-vcc scripts/check-pi-vcc-upstream.sh install.sh</code></pre>
+    </article>
+  </section>
+
+  <section id="verification-strategy">
+    <h2>Verification strategy</h2>
+    <ul>
+      <li id="verify-unit">Use focused <code>bun test</code> commands per phase for tight feedback.</li>
+      <li id="verify-package">Run full <code>cd _pi/packages/pi-vcc &amp;&amp; bun test</code> before declaring completion.</li>
+      <li id="verify-percentage">Run <code>bun test scripts/percentage-compaction.test.ts</code> in final verification because marker compatibility is a locked invariant, even if the implementation does not edit the percentage compaction extension.</li>
+      <li id="verify-drift">Run <code>bash ./scripts/check-pi-vcc-upstream.sh --verbose</code> before and after expected-diff reconciliation.</li>
+      <li id="verify-install">Run <code>bash ./install.sh --pi</code> only after code/tests/docs are consistent.</li>
+    </ul>
+  </section>
+
+  <section id="delivery-order">
+    <h2>Delivery order</h2>
+    <ol>
+      <li id="delivery-p1">Lock local safety and workflow invariants first.</li>
+      <li id="delivery-p2">Apply only the wrapping and bash/search/report fixes.</li>
+      <li id="delivery-p3">Update docs/checker/install metadata last, making partial uptake explicit.</li>
+    </ol>
+  </section>
+
+  <section id="non-goals">
+    <h2>Non-goals</h2>
+    <ul>
+      <li id="non-goal-direct-npm">Replacing the vendored package with upstream npm.</li>
+      <li id="non-goal-all-upstream">Blindly applying every upstream file.</li>
+      <li id="non-goal-lineage">Adding active-lineage recall in this pass.</li>
+      <li id="non-goal-commits">Adding a <code>[Commits]</code> summary section in this pass.</li>
+      <li id="non-goal-settings">Adding upstream settings/marker behavior in this pass.</li>
+      <li id="non-goal-compact-all">Adding compact-all sentinel/orphan recovery in this pass.</li>
+      <li id="non-goal-summary-churn">Applying broad summary extraction/cleanup changes without a concrete current problem.</li>
+      <li id="non-goal-deps">Changing upstream peer dependency metadata ranges.</li>
+      <li id="non-goal-remove-redaction">Removing redaction or weakening secret handling.</li>
+      <li id="non-goal-omp">Updating the separate <code>_omp/extensions/pi-vcc</code> copy unless review explicitly expands scope.</li>
+      <li id="non-goal-demo">Adding upstream binary demo assets.</li>
+    </ul>
+  </section>
+
+  <section id="decisions-deviations-log">
+    <h2>Decisions / Deviations log</h2>
+    <article class="card" id="log-2026-06-03-plan-created">
+      <h3>2026-06-03 — Plan created from upstream review</h3>
+      <p>Initial recommendation was selective uptake of lineage recall, wrapping, bash/search/report fixes, commits, and summary quality improvements while preserving local continuation guard, auto-compaction marker contract, redaction, and tool-error context.</p>
+    </article>
+    <article class="card" id="log-2026-06-03-review-narrowed">
+      <h3>2026-06-03 — Browser review narrowed adoption threshold</h3>
+      <p>Reviewer clarified that pi-vcc works well and anything not clearly high value should be skipped. Plan narrowed accordingly: keep only TUI-safe wrapping and bash/search/report correctness fixes, plus invariant tests and truthful docs/checker/install updates. Active-lineage recall, commits, settings, compact-all recovery, peer dependency range changes, and broad summary-quality churn are now non-goals for this pass.</p>
+    </article>
+    <article class="card" id="log-2026-06-03-deps-decision">
+      <h3>2026-06-03 — Dependency metadata decision fixed before implementation</h3>
+      <p>Reviewer asked that the plan identify in advance whether dependency metadata updates are included. Decision: they are not included. Upstream <code>0.3.15</code> only tightens peer dependency ranges, and the approved wrapping plus bash/search/report fixes do not require new dependencies.</p>
+    </article>
+    <article class="card" id="log-2026-06-04-agent-review-blockers">
+      <h3>2026-06-04 — Codex and Claude Code plan reviews found blockers</h3>
+      <p>Codex reported the plan was not execution-ready because checker/version metadata semantics were under-specified and both-reviewer agreement was not represented in the status gate. Claude Code reported the plan was not execution-ready because the approved upstream deltas were not pinned to concrete commits/files, wrapping/redaction ordering was ambiguous, and checker expected-diff reconciliation did not name <code>EXPECTED_LOCAL_DIFFS</code>. The first revision integrated those blockers and required both reviewers to re-review the latest saved plan before execution.</p>
+    </article>
+    <article class="card" id="log-2026-06-04-claude-rereview-baseline">
+      <h3>2026-06-04 — Claude rereview clarified checker baseline model</h3>
+      <p>Codex rereview found no blockers, but Claude Code rereview found one remaining checker blocker: the plan mixed a reviewed-upstream baseline with a local-patch-only diff manifest. This revision chooses the reviewed-upstream baseline explicitly, requires stale metadata to fail before diff classification, and requires the intentional manifest to include both adopted local patch paths and deliberately skipped upstream-change paths.</p>
+    </article>
+    <article class="card" id="log-2026-06-04-final-agent-review">
+      <h3>2026-06-04 — Final Codex and Claude Code reviews cleared execution</h3>
+      <p>Final Codex review reported <code>execution-ready</code> with no blockers. Final Claude Code review independently reported <code>execution-ready</code> with no blockers and verified the pinned upstream commits, localized <code>report.ts</code> search fix, redaction-as-final-transform requirement, and reviewed-upstream checker baseline model. The plan is promoted to execution-ready.</p>
+    </article>
+    <article class="card" id="log-2026-06-04-implementation-complete">
+      <h3>2026-06-04 — Scoped implementation completed phases P1-P3</h3>
+      <p>Implemented the approved wrapping and <code>bashExecution</code> fixes, preserved final redaction and local continuation/tool-error behavior, updated the reviewed-upstream checker contract and installer messaging, and completed the plan verification commands. Codex and Claude scoped implementation rereviews passed with no in-scope findings; PR monitoring remains pending under the scoped-plan-run workflow.</p>
+    </article>
+  </section>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Plan

`thoughts/plans/pi-vcc-upstream-0-3-15-selective-uptake.html`

## In-scope summary

- Preserves the local pi-vcc continuation guard so completed-turn compaction stays silent while in-flight compaction resumes the agent.
- Selectively uptakes only the approved upstream `0.3.15` fixes: TUI-safe wrapping and `bashExecution` normalization/search/report correctness.
- Keeps local redaction, tool-error outstanding context, manual bypass marker compatibility, and tool-call/result live-tail safety.
- Updates README/checker/install messaging so reviewed-upstream metadata is explicit and checker diffs against the pinned reviewed commit with an intentional patch/skip manifest.
- Addresses PR feedback for literal file-probe recall matching, empty bash-command brief state, unavailable upstream metadata reporting, and preserving wrapped header/file bullets across later merges.

## Verification

- `cd _pi/packages/pi-vcc && bun test` — 122 pass
- `bun test scripts/percentage-compaction.test.ts` — 5 pass
- `bash ./scripts/check-pi-vcc-upstream.sh --verbose` — pass, only intentional diffs present (50 paths)
- `bash ./install.sh --pi` — pass, vendored pi-vcc installed and upstream status reported correctly
- `git diff --check` — pass

## Scoped reviews

- Codex rereview: `VERDICT: PASS_WITH_DEFERRED_FOLLOW_UPS`; no in-scope findings.
- Claude rereview: `VERDICT: PASS_WITH_DEFERRED_FOLLOW_UPS`; no in-scope findings.

## Deferred out-of-scope follow-ups

- Checker intentionally exits stale/re-review before manifest validation when upstream advances; future enhancement could optionally validate manifest even when stale.
- Checker still assumes upstream branch `refs/heads/master`; branch discovery/default-branch support is deferred.

## Known residual risks

- The intentional-diff manifest is path-level, not hunk-level, so it catches unmanifested files but not unexpected edits inside already-manifested files.
