### PR TITLE
Update Pi plan mode for HTML reviews

### DIFF
--- a/_pi/README.md
+++ b/_pi/README.md
@@ -110,10 +110,13 @@ This repo now ships a maintained `pi-plan-mode` extension that:
 
 - powers `/plan` mode for `thoughts/` planning workflows,
 - keeps planning-mode file writes scoped to `thoughts/`,
-- surfaces `/review:plan` after plan edits as a non-blocking next step,
-- automatically follows a standard review with `/review:change-integrate` before any execution handoff,
-- keeps `/review:plan-adversarial` available as an optional second-pass challenge review after integration,
-- leaves execution handoff manual via `/skill:adn-dev-wf <plan> --target ...` so Pi can launch from a fresh session without popping a menu,
+- defaults active browser-reviewed plans to `thoughts/plans/<slug>.html` while still accepting explicit legacy Markdown plan paths,
+- displays the current registered plan-review URL in the plan-mode widget when available,
+- allows the narrow `plan-review` registration/comment commands and the `process` tool needed for queue-backed browser comment iteration,
+- steers HTML plan edits toward `/dev:reviewed-html-plan` for registration, browser feedback, PM review, and Claude/Codex plan review,
+- keeps `/review:plan` and `/review:plan-adversarial` available as explicit inline review paths, with HTML plans accepted as first-class inputs,
+- leaves execution handoff manual via `/cmd:execute-plan <plan> --target ...` so Pi can launch from a fresh session without popping a menu,
+- reminds the operator to stop the active plan-review comment listener before execution,
 - keeps alternate review commands such as `/review:change-claude-code` as explicit opt-ins rather than hidden plan-mode fallbacks,
 - disables `/plan` mode before dispatching into execution so implementation is not blocked by planning-only restrictions.
 
@@ -274,11 +277,17 @@ Prompt templates:
 
 Use `/skill:adn-dev-wf <plan>` after a reviewed plan is ready to continue. For browser-reviewed plans, the active artifact is `thoughts/plans/<slug>.html`, and `skills/html-plan-reviewer/SKILL.md` is the sole source for concrete `plan-review` commands, readiness metadata, canonical URL rules, and comment monitor mechanics.
 
-Canonical reviewed-plan flow:
+Canonical browser-reviewed HTML plan flow:
 
 ```text
 /dev:plan <plan>
-/dev:pm-review <plan> plan        # optional corrective PM reshaping pass before execution
+/dev:reviewed-html-plan <plan>    # register, monitor browser comments, PM-review, and run Claude/Codex plan reviews
+/cmd:execute-plan <plan>
+```
+
+Explicit inline review flow remains available when needed:
+
+```text
 /review:plan <plan>
 /review:change-integrate <plan>
 /review:plan-adversarial <plan>   # optional

--- a/_pi/agents/reviewer-plan-adversarial-gpt5.5.md
+++ b/_pi/agents/reviewer-plan-adversarial-gpt5.5.md
@@ -37,7 +37,7 @@ This command is review-only.
 
 Preferred input:
 
-- A single plan file: `thoughts/plans/<slug>.md`
+- A single plan file in the repo's active plan format. In this repo's browser-reviewed flow, that is `thoughts/plans/<slug>.html`.
 
 Accept legacy inputs for migration only:
 
@@ -47,9 +47,9 @@ Accept legacy inputs for migration only:
 Resolution rules:
 
 - If `$ARGUMENTS` starts with `@`, strip the leading `@` and treat as workspace-relative.
-- If a single argument is an existing `.md` file, treat as `plan_path`.
-- If a single argument is a slug, resolve to `thoughts/plans/<slug>.md`.
-- If the plan file does not exist but a legacy bundle exists for the slug, migrate to `thoughts/plans/<slug>.md` and review the migrated plan without modifying legacy files.
+- If a single argument is an existing plan file, including `.html` or legacy `.md`, treat as `plan_path`.
+- If a single argument is a slug, resolve it using repo-local active plan guidance. In this repo's browser-reviewed flow, resolve to `thoughts/plans/<slug>.html`; do not infer a Markdown path.
+- If the plan file does not exist but a legacy bundle exists for the slug, migrate only when repo-local guidance explicitly allows migration to the active plan format and review the migrated plan without modifying legacy files.
 
 If multiple candidates match or a required file is missing, ask for an explicit plan file path.
 

--- a/_pi/agents/reviewer-plan-adversarial-opus.md
+++ b/_pi/agents/reviewer-plan-adversarial-opus.md
@@ -36,7 +36,7 @@ This command is review-only.
 
 Preferred input:
 
-- A single plan file: `thoughts/plans/<slug>.md`
+- A single plan file in the repo's active plan format. In this repo's browser-reviewed flow, that is `thoughts/plans/<slug>.html`.
 
 Accept legacy inputs for migration only:
 
@@ -46,9 +46,9 @@ Accept legacy inputs for migration only:
 Resolution rules:
 
 - If `$ARGUMENTS` starts with `@`, strip the leading `@` and treat as workspace-relative.
-- If a single argument is an existing `.md` file, treat as `plan_path`.
-- If a single argument is a slug, resolve to `thoughts/plans/<slug>.md`.
-- If the plan file does not exist but a legacy bundle exists for the slug, migrate to `thoughts/plans/<slug>.md` and review the migrated plan without modifying legacy files.
+- If a single argument is an existing plan file, including `.html` or legacy `.md`, treat as `plan_path`.
+- If a single argument is a slug, resolve it using repo-local active plan guidance. In this repo's browser-reviewed flow, resolve to `thoughts/plans/<slug>.html`; do not infer a Markdown path.
+- If the plan file does not exist but a legacy bundle exists for the slug, migrate only when repo-local guidance explicitly allows migration to the active plan format and review the migrated plan without modifying legacy files.
 
 If multiple candidates match or a required file is missing, ask for an explicit plan file path.
 

--- a/_pi/agents/reviewer-plan-gpt5.5.md
+++ b/_pi/agents/reviewer-plan-gpt5.5.md
@@ -44,7 +44,7 @@ This command is review-only.
 
 Preferred input:
 
-- A single plan file: `thoughts/plans/<slug>.md`
+- A single plan file in the repo's active plan format. In this repo's browser-reviewed flow, that is `thoughts/plans/<slug>.html`.
 
 Accept legacy inputs for migration only:
 
@@ -54,9 +54,9 @@ Accept legacy inputs for migration only:
 Resolution rules:
 
 - If `$ARGUMENTS` starts with `@`, strip the leading `@` and treat as workspace-relative.
-- If a single argument is an existing `.md` file, treat as `plan_path`.
-- If a single argument is a slug, resolve to `thoughts/plans/<slug>.md`.
-- If the plan file does not exist but a legacy bundle exists for the slug, migrate to `thoughts/plans/<slug>.md` (do not modify legacy files) and review the migrated plan.
+- If a single argument is an existing plan file, including `.html` or legacy `.md`, treat as `plan_path`.
+- If a single argument is a slug, resolve it using repo-local active plan guidance. In this repo's browser-reviewed flow, resolve to `thoughts/plans/<slug>.html`; do not infer a Markdown path.
+- If the plan file does not exist but a legacy bundle exists for the slug, migrate only when repo-local guidance explicitly allows migration to the active plan format (do not modify legacy files) and review the migrated plan.
 
 If multiple candidates match or a required file is missing, ask for an explicit plan file path.
 

--- a/_pi/agents/reviewer-plan-kimi.md
+++ b/_pi/agents/reviewer-plan-kimi.md
@@ -43,7 +43,7 @@ This command is review-only.
 
 Preferred input:
 
-- A single plan file: `thoughts/plans/<slug>.md`
+- A single plan file in the repo's active plan format. In this repo's browser-reviewed flow, that is `thoughts/plans/<slug>.html`.
 
 Accept legacy inputs for migration only:
 
@@ -53,9 +53,9 @@ Accept legacy inputs for migration only:
 Resolution rules:
 
 - If `$ARGUMENTS` starts with `@`, strip the leading `@` and treat as workspace-relative.
-- If a single argument is an existing `.md` file, treat as `plan_path`.
-- If a single argument is a slug, resolve to `thoughts/plans/<slug>.md`.
-- If the plan file does not exist but a legacy bundle exists for the slug, migrate to `thoughts/plans/<slug>.md` (do not modify legacy files) and review the migrated plan.
+- If a single argument is an existing plan file, including `.html` or legacy `.md`, treat as `plan_path`.
+- If a single argument is a slug, resolve it using repo-local active plan guidance. In this repo's browser-reviewed flow, resolve to `thoughts/plans/<slug>.html`; do not infer a Markdown path.
+- If the plan file does not exist but a legacy bundle exists for the slug, migrate only when repo-local guidance explicitly allows migration to the active plan format (do not modify legacy files) and review the migrated plan.
 
 If multiple candidates match or a required file is missing, ask for an explicit plan file path.
 

--- a/_pi/agents/reviewer-plan-opus.md
+++ b/_pi/agents/reviewer-plan-opus.md
@@ -43,7 +43,7 @@ This command is review-only.
 
 Preferred input:
 
-- A single plan file: `thoughts/plans/<slug>.md`
+- A single plan file in the repo's active plan format. In this repo's browser-reviewed flow, that is `thoughts/plans/<slug>.html`.
 
 Accept legacy inputs for migration only:
 
@@ -53,9 +53,9 @@ Accept legacy inputs for migration only:
 Resolution rules:
 
 - If `$ARGUMENTS` starts with `@`, strip the leading `@` and treat as workspace-relative.
-- If a single argument is an existing `.md` file, treat as `plan_path`.
-- If a single argument is a slug, resolve to `thoughts/plans/<slug>.md`.
-- If the plan file does not exist but a legacy bundle exists for the slug, migrate to `thoughts/plans/<slug>.md` (do not modify legacy files) and review the migrated plan.
+- If a single argument is an existing plan file, including `.html` or legacy `.md`, treat as `plan_path`.
+- If a single argument is a slug, resolve it using repo-local active plan guidance. In this repo's browser-reviewed flow, resolve to `thoughts/plans/<slug>.html`; do not infer a Markdown path.
+- If the plan file does not exist but a legacy bundle exists for the slug, migrate only when repo-local guidance explicitly allows migration to the active plan format (do not modify legacy files) and review the migrated plan.
 
 If multiple candidates match or a required file is missing, ask for an explicit plan file path.
 

--- a/_pi/agents/reviewer-plan-synthesis.md
+++ b/_pi/agents/reviewer-plan-synthesis.md
@@ -36,13 +36,13 @@ This command is review-only.
 
 Preferred input:
 
-- A single plan file: `thoughts/plans/<slug>.md`
+- A single plan file in the repo's active plan format. In this repo's browser-reviewed flow, that is `thoughts/plans/<slug>.html`.
 
 Resolution rules:
 
 - If `$ARGUMENTS` starts with `@`, strip the leading `@` and treat as workspace-relative.
-- If a single argument is an existing `.md` file, treat as `plan_path`.
-- If a single argument is a slug, resolve to `thoughts/plans/<slug>.md`.
+- If a single argument is an existing plan file, including `.html` or legacy `.md`, treat as `plan_path`.
+- If a single argument is a slug, resolve it using repo-local active plan guidance. In this repo's browser-reviewed flow, resolve to `thoughts/plans/<slug>.html`; do not infer a Markdown path.
 - If the plan file is missing or ambiguous, ask for an explicit plan file path.
 
 ### 1) Read Existing Review Comments

--- a/_pi/extensions/pi-plan-mode/index.ts
+++ b/_pi/extensions/pi-plan-mode/index.ts
@@ -357,7 +357,13 @@ async function resolveExecutePlanRequest(
 	}
 
 	const planDispatchArgument = stripPathSigil(planArgument);
-	const planPath = /\.(html|md)$/i.test(planDispatchArgument)
+	const isExplicitPlanPath = /\.(html|md)$/i.test(planDispatchArgument);
+	if (!isExplicitPlanPath && !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(planDispatchArgument)) {
+		return {
+			error: `Invalid plan slug "${planDispatchArgument}". Slugs may only contain letters, numbers, dots, underscores, and hyphens, and must start with a letter or number.`,
+		};
+	}
+	const planPath = isExplicitPlanPath
 		? resolveFromCwd(cwd, planDispatchArgument)
 		: resolve(cwd, PLAN_DIRECTORY, `${planDispatchArgument}.html`);
 

--- a/_pi/extensions/pi-plan-mode/index.ts
+++ b/_pi/extensions/pi-plan-mode/index.ts
@@ -961,7 +961,28 @@ ${currentPlanInstruction}`,
 	});
 
 	pi.on("tool_result", async (event, ctx) => {
-		if (!planModeEnabled || event.isError) return;
+		if (!planModeEnabled) return;
+
+		if (event.toolName === "process") {
+			const action = String(event.input.action ?? "");
+			const command = String(event.input.command ?? "");
+			if (action === "kill" && event.input.id === currentPlanListenerProcessId) {
+				currentPlanListenerProcessId = undefined;
+				updateUi(ctx);
+				persistState();
+				return;
+			}
+			if (event.isError) return;
+			if (action === "start" && /^\s*plan-review\s+agent\s+next\b/i.test(command)) {
+				const match = toolResultToText(event.content).match(/\b(proc_\w+)/);
+				currentPlanListenerProcessId = match?.[1] ?? currentPlanListenerProcessId;
+				updateUi(ctx);
+				persistState();
+			}
+			return;
+		}
+
+		if (event.isError) return;
 
 		if (event.toolName === "bash") {
 			const command = String(event.input.command ?? "");
@@ -980,22 +1001,6 @@ ${currentPlanInstruction}`,
 			return;
 		}
 
-		if (event.toolName === "process") {
-			const action = String(event.input.action ?? "");
-			const command = String(event.input.command ?? "");
-			if (action === "start" && /^\s*plan-review\s+agent\s+next\b/i.test(command)) {
-				const match = toolResultToText(event.content).match(/\b(proc_\w+)/);
-				currentPlanListenerProcessId = match?.[1] ?? currentPlanListenerProcessId;
-				updateUi(ctx);
-				persistState();
-			}
-			if (action === "kill" && event.input.id === currentPlanListenerProcessId) {
-				currentPlanListenerProcessId = undefined;
-				updateUi(ctx);
-				persistState();
-			}
-			return;
-		}
 
 		if (event.toolName !== "edit" && event.toolName !== "write") return;
 

--- a/_pi/extensions/pi-plan-mode/index.ts
+++ b/_pi/extensions/pi-plan-mode/index.ts
@@ -191,6 +191,15 @@ function isAllowedPlanReviewCommand(command: string): boolean {
 	);
 }
 
+function isPlanReviewListenerCommand(command: string): boolean {
+	const tokens = parseCommandArgs(command.trim());
+	return tokens[0] === "plan-review"
+		&& tokens[1] === "agent"
+		&& tokens[2] === "next"
+		&& tokens.includes("--wait")
+		&& !tokens.includes("--no-wait");
+}
+
 function isSafeCommand(command: string): boolean {
 	if (isAllowedPlanReviewCommand(command)) return true;
 	const destructive = DESTRUCTIVE_PATTERNS.some((pattern) => pattern.test(command));
@@ -973,7 +982,7 @@ ${currentPlanInstruction}`,
 				return;
 			}
 			if (event.isError) return;
-			if (action === "start" && /^\s*plan-review\s+agent\s+next\b/i.test(command)) {
+			if (action === "start" && isPlanReviewListenerCommand(command)) {
 				const match = toolResultToText(event.content).match(/\b(proc_\w+)/);
 				currentPlanListenerProcessId = match?.[1] ?? currentPlanListenerProcessId;
 				updateUi(ctx);

--- a/_pi/extensions/pi-plan-mode/index.ts
+++ b/_pi/extensions/pi-plan-mode/index.ts
@@ -8,6 +8,7 @@ const PLAN_STATE_TYPE = "plan-mode-state";
 const PRD_STATE_TYPE = "prd-mode-state";
 const PLAN_ROOT = "thoughts";
 const PLAN_DIRECTORY = "thoughts/plans";
+const PLAN_REVIEW_SERVICE_URL = "http://mbp.braid-python.ts.net:4317";
 const PLAN_PROMPTS_DIRECTORIES = ["_pi/prompts", ".pi/prompts"] as const;
 const GLOBAL_PROMPTS_DIRECTORY = resolve(homedir(), ".pi/agent/prompts");
 const EXECUTE_PLAN_COMMAND = "cmd:execute-plan";
@@ -123,6 +124,7 @@ const DEFAULT_PLAN_TOOLS = [
 	"get_search_content",
 	"question",
 	"questionnaire",
+	"process",
 ] as const;
 
 const REVIEW_ORCHESTRATION_TOOLS = [
@@ -137,6 +139,9 @@ const REVIEW_ORCHESTRATION_TOOLS = [
 interface PlanModeState {
 	enabled: boolean;
 	currentPlanPath?: string;
+	currentPlanReviewUrl?: string;
+	currentPlanId?: string;
+	currentPlanListenerProcessId?: string;
 	savedActiveTools?: string[];
 	reviewCycles: number;
 	lastReviewCommand?: string;
@@ -171,7 +176,23 @@ function relativeToCwd(cwd: string, inputPath: string): string {
 	return relative(cwd, resolveFromCwd(cwd, inputPath));
 }
 
+function isAllowedPlanReviewCommand(command: string): boolean {
+	const normalized = command.trim();
+	if (/^plan-review\s+watch\b/i.test(normalized)) return false;
+	if (/[\r\n;&|`<>]/.test(normalized) || /\$\(/.test(normalized) || />>/.test(normalized)) return false;
+	return (
+		/^plan-review\s+register\b/i.test(normalized)
+		|| /^plan-review\s+index\b/i.test(normalized)
+		|| /^plan-review\s+agent\s+next\b/i.test(normalized)
+		|| /^plan-review\s+queue\s+(list|claim)\b/i.test(normalized)
+		|| /^plan-review\s+(ack|resolve|release)\b/i.test(normalized)
+		|| /^open\s+http:\/\/mbp\.braid-python\.ts\.net:4317(?:\/\S*)?\s*$/i.test(normalized)
+		|| /^brew\s+services\s+start\s+plan-reviewer\b/i.test(normalized)
+	);
+}
+
 function isSafeCommand(command: string): boolean {
+	if (isAllowedPlanReviewCommand(command)) return true;
 	const destructive = DESTRUCTIVE_PATTERNS.some((pattern) => pattern.test(command));
 	const safe = SAFE_BASH_PATTERNS.some((pattern) => pattern.test(command));
 	return !destructive && safe;
@@ -287,7 +308,7 @@ function isStandardReviewCommand(command: string | undefined): command is typeof
 }
 
 function getExecutePlanUsage(): string {
-	return `Usage: /${EXECUTE_PLAN_COMMAND} <plan slug | thoughts/plans/<slug>.md | path/to/plan.md> [--target dev:run|skill:adn-dev-wf]`;
+	return `Usage: /${EXECUTE_PLAN_COMMAND} <plan slug | thoughts/plans/<slug>.html | path/to/plan.html | legacy path/to/plan.md> [--target dev:run|skill:adn-dev-wf]`;
 }
 
 async function resolveExecutePlanRequest(
@@ -327,9 +348,9 @@ async function resolveExecutePlanRequest(
 	}
 
 	const planDispatchArgument = stripPathSigil(planArgument);
-	const planPath = planDispatchArgument.endsWith(".md")
+	const planPath = /\.(html|md)$/i.test(planDispatchArgument)
 		? resolveFromCwd(cwd, planDispatchArgument)
-		: resolve(cwd, PLAN_DIRECTORY, `${planDispatchArgument}.md`);
+		: resolve(cwd, PLAN_DIRECTORY, `${planDispatchArgument}.html`);
 
 	try {
 		await access(planPath);
@@ -356,7 +377,70 @@ function isThoughtsPath(cwd: string, inputPath: string): boolean {
 
 function isPlanFilePath(cwd: string, inputPath: string): boolean {
 	const resolved = resolveFromCwd(cwd, inputPath);
-	return isWithin(getPlansRoot(cwd), resolved) && resolved.endsWith(".md");
+	return isWithin(getPlansRoot(cwd), resolved) && /\.(html|md)$/i.test(resolved);
+}
+
+function toolResultToText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (Array.isArray(content)) {
+		return content.map((item) => {
+			if (typeof item === "string") return item;
+			if (item && typeof item === "object" && "text" in item) {
+				return String((item as { text?: unknown }).text ?? "");
+			}
+			return JSON.stringify(item);
+		}).join("\n");
+	}
+	return content === undefined ? "" : JSON.stringify(content);
+}
+
+function parseJsonObject(text: string): Record<string, unknown> | undefined {
+	try {
+		return JSON.parse(text) as Record<string, unknown>;
+	} catch {
+		const match = text.match(/\{[\s\S]*\}/);
+		if (!match) return undefined;
+		try {
+			return JSON.parse(match[0]) as Record<string, unknown>;
+		} catch {
+			return undefined;
+		}
+	}
+}
+
+function canonicalPlanReviewUrl(rawUrl: unknown): string | undefined {
+	if (typeof rawUrl !== "string" || rawUrl.length === 0) return undefined;
+	if (/^https?:\/\//i.test(rawUrl)) {
+		try {
+			const url = new URL(rawUrl);
+			if (["localhost", "127.0.0.1", "::1", "[::1]"].includes(url.hostname) && url.port === "4317") {
+				return `${PLAN_REVIEW_SERVICE_URL}${url.pathname}${url.search}${url.hash}`;
+			}
+		} catch {
+			return undefined;
+		}
+		return rawUrl;
+	}
+	return rawUrl.startsWith("/") ? `${PLAN_REVIEW_SERVICE_URL}${rawUrl}` : `${PLAN_REVIEW_SERVICE_URL}/${rawUrl}`;
+}
+
+function parsePlanReviewRegistrationOutput(text: string): { planId?: string; reviewUrl?: string; sourcePath?: string } {
+	const payload = parseJsonObject(text);
+	if (payload) {
+		const sourceSync = payload.sourceSync as { sourcePath?: unknown } | undefined;
+		return {
+			planId: typeof payload.planId === "string" ? payload.planId : undefined,
+			reviewUrl: canonicalPlanReviewUrl(payload.reviewUrl),
+			sourcePath: typeof sourceSync?.sourcePath === "string" ? sourceSync.sourcePath : undefined,
+		};
+	}
+
+	const reviewUrl = text.match(/^\s*Review URL\s*:?\s*(\S+)\s*$/im)?.[1];
+	const planId = text.match(/^\s*Plan ID\s*:?\s*(\S+)\s*$/im)?.[1];
+	return {
+		planId,
+		reviewUrl: canonicalPlanReviewUrl(reviewUrl),
+	};
 }
 
 function derivePlanTools(allTools: string[], normalTools: string[] | undefined, includeReviewTools: boolean): string[] {
@@ -382,6 +466,9 @@ function derivePlanTools(allTools: string[], normalTools: string[] | undefined, 
 export default function planModeExtension(pi: ExtensionAPI): void {
 	let planModeEnabled = false;
 	let currentPlanPath: string | undefined;
+	let currentPlanReviewUrl: string | undefined;
+	let currentPlanId: string | undefined;
+	let currentPlanListenerProcessId: string | undefined;
 	let savedActiveTools: string[] | undefined;
 	let reviewCycles = 0;
 	let reviewInFlight = false;
@@ -402,6 +489,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		pi.appendEntry(PLAN_STATE_TYPE, {
 			enabled: planModeEnabled,
 			currentPlanPath,
+			currentPlanReviewUrl,
+			currentPlanId,
+			currentPlanListenerProcessId,
 			savedActiveTools,
 			reviewCycles,
 			lastReviewCommand,
@@ -417,6 +507,8 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		}
 
 		const planLabel = currentPlanPath ?? "no plan file yet";
+		const urlLabel = currentPlanReviewUrl ?? "not registered yet";
+		const listenerLabel = currentPlanListenerProcessId ?? "not running/unknown";
 		const displayedCycles = Math.min(reviewCycles, MAX_REVIEW_CYCLES);
 		const cycleLabel = reviewCycles > 0 ? ` • review ${displayedCycles}/${MAX_REVIEW_CYCLES}` : "";
 		const status = reviewInFlight ? `🧪 plan review${cycleLabel}` : `📝 plan${cycleLabel}`;
@@ -424,6 +516,8 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		ctx.ui.setWidget("plan-mode", [
 			ctx.ui.theme.fg("accent", "Plan mode active"),
 			ctx.ui.theme.fg("muted", `Current plan: ${planLabel}`),
+			ctx.ui.theme.fg("muted", `Plan URL: ${urlLabel}`),
+			ctx.ui.theme.fg("muted", `Comment listener: ${listenerLabel}`),
 			ctx.ui.theme.fg("muted", `Writes allowed only under ${PLAN_ROOT}/`),
 		]);
 	}
@@ -455,6 +549,12 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		ctx.ui.notify(`Plan mode enabled.${planNote}`, "info");
 	}
 
+	function getListenerCleanupMessage(): string | undefined {
+		return currentPlanListenerProcessId
+			? `Stop the active plan-review comment listener before execution: process kill ${currentPlanListenerProcessId}.`
+			: undefined;
+	}
+
 	function disablePlanMode(ctx: ExtensionContext): void {
 		planModeEnabled = false;
 		reviewInFlight = false;
@@ -467,7 +567,8 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		updateUi(ctx);
 		persistState();
 		const planNote = currentPlanPath ? ` Current plan preserved: ${currentPlanPath}` : "";
-		ctx.ui.notify(`Plan mode disabled.${planNote}`, "info");
+		const listenerNote = getListenerCleanupMessage();
+		ctx.ui.notify(`Plan mode disabled.${planNote}${listenerNote ? ` ${listenerNote}` : ""}`, "info");
 	}
 
 	function togglePlanMode(ctx: ExtensionContext): void {
@@ -486,6 +587,12 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 	}
 
 	async function handleExecutePlanCommand(args: string, ctx: ExtensionCommandContext): Promise<void> {
+		const listenerCleanupMessage = getListenerCleanupMessage();
+		if (listenerCleanupMessage) {
+			ctx.ui.notify(listenerCleanupMessage, "warning");
+			return;
+		}
+
 		const request = await resolveExecutePlanRequest(ctx.cwd, args);
 		if ("error" in request) {
 			ctx.ui.notify(request.error, "warning");
@@ -518,6 +625,7 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 			return;
 		}
 
+		disablePlanMode(ctx);
 		await ctx.waitForIdle();
 		const result = await ctx.newSession({ parentSession: ctx.sessionManager.getSessionFile() });
 		if (result.cancelled) {
@@ -549,6 +657,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		reviewInFlight = false;
 		pendingAutoReviewCommand = false;
 		currentPlanPath = undefined;
+		currentPlanReviewUrl = undefined;
+		currentPlanId = undefined;
+		currentPlanListenerProcessId = undefined;
 		savedActiveTools = undefined;
 		reviewCycles = 0;
 		lastReviewCommand = undefined;
@@ -563,6 +674,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		if (stateEntry?.data) {
 			planModeEnabled = stateEntry.data.enabled;
 			currentPlanPath = stateEntry.data.currentPlanPath;
+			currentPlanReviewUrl = stateEntry.data.currentPlanReviewUrl;
+			currentPlanId = stateEntry.data.currentPlanId;
+			currentPlanListenerProcessId = stateEntry.data.currentPlanListenerProcessId;
 			savedActiveTools = stateEntry.data.savedActiveTools;
 			reviewCycles = stateEntry.data.reviewCycles ?? 0;
 			lastReviewCommand = stateEntry.data.lastReviewCommand;
@@ -580,6 +694,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 				await access(resolve(ctx.cwd, currentPlanPath));
 			} catch {
 				currentPlanPath = undefined;
+				currentPlanReviewUrl = undefined;
+				currentPlanId = undefined;
+				currentPlanListenerProcessId = undefined;
 				reviewCycles = 0;
 				lastReviewCommand = undefined;
 				preferredStandardReviewCommand = undefined;
@@ -621,6 +738,14 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		}
 
 		const standardReviewCommand = getPreferredStandardReviewCommand();
+		if (/\.html$/i.test(currentPlanPath)) {
+			ctx.ui.notify(
+				`HTML plan updated (${reason}). Run /dev:reviewed-html-plan ${formatCommandArg(currentPlanPath)} to register/iterate browser feedback; /${standardReviewCommand} ${formatCommandArg(currentPlanPath)} remains available for explicit inline review.`,
+				"info",
+			);
+			return;
+		}
+
 		ctx.ui.notify(
 			`Plan updated (${reason}). Run /${standardReviewCommand} ${formatCommandArg(currentPlanPath)} when ready.`,
 			"info",
@@ -706,6 +831,11 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		if (!planModeEnabled) return { action: "continue" };
 
 		if (text.startsWith(`/${EXECUTE_PLAN_COMMAND}`) || text.startsWith("/dev:run") || text.startsWith("/skill:adn-dev-wf") || text.startsWith("/ralph:run")) {
+			const listenerCleanupMessage = getListenerCleanupMessage();
+			if (listenerCleanupMessage) {
+				ctx.ui.notify(listenerCleanupMessage, "warning");
+				return { action: "block" };
+			}
 			disablePlanMode(ctx);
 			return { action: "continue" };
 		}
@@ -757,8 +887,8 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		if (!planModeEnabled) return;
 
 		const currentPlanInstruction = currentPlanPath
-			? `Current plan file: ${currentPlanPath}. Continue evolving that file unless the user explicitly asks for a different one.`
-			: `If you create a new plan, write it to ${PLAN_DIRECTORY}/<slug>.md.`;
+			? `Current plan file: ${currentPlanPath}. Continue evolving that file unless the user explicitly asks for a different one. Current browser review URL: ${currentPlanReviewUrl ?? "not registered yet"}.`
+			: `If you create a new plan, write it to ${PLAN_DIRECTORY}/<slug>.html.`;
 
 		return {
 			message: {
@@ -772,13 +902,17 @@ Constraints:
 - Keep plan files in ${PLAN_DIRECTORY}/.
 - Do not make implementation changes outside ${PLAN_ROOT}/.
 - Use read-only bash commands for exploration; file mutations must go through edit/write inside ${PLAN_ROOT}/.
+- Load and follow the planning skills needed for deterministic HTML planning: planning-workflow, html-plan-reviewer, reviewed-html-plan, product-principles for workflow-impacting plans, plus relevant domain skills.
 - Plans should align with thoughts/specs/product_intent.md and thoughts/plans/AGENTS.md when relevant.
-- After creating or materially updating a plan, /review:plan <path> is available when you want review.
-- After a standard review completes with inline comments, /review:change-integrate <path> runs automatically so review feedback is resolved back into the same plan file before any manual execution handoff.
-- After standard review integration, you may optionally run /review:plan-adversarial <path> for a second-pass challenge review.
-- After an integrated review completes, you may manually run /cmd:execute-plan <path> --target dev:run or --target skill:adn-dev-wf to start a fresh execution session.
+- New active plans should be semantic HTML under ${PLAN_DIRECTORY}/<slug>.html unless the user explicitly supplies an existing legacy Markdown plan.
+- Register HTML plans with plan-review using truthful --execution-ready metadata; preserve and display the canonical browser review URL.
+- Use only the queue-backed plan-review agent next flow for browser comments: drain with --no-wait, listen with --wait via the process tool, process one claimed comment, ack/resolve it, then restart the listener. Do not use or recommend the watch subcommand in /plan mode.
+- After creating or materially updating an HTML plan, /dev:reviewed-html-plan <path> is the deterministic registration, browser-feedback, PM-review, and Claude/Codex plan-review path. /review:plan <path> remains available only as an explicit inline review.
+- After a standard inline review completes with comments, /review:change-integrate <path> runs automatically so review feedback is resolved back into the same plan file before any manual execution handoff.
+- After standard inline review integration, you may optionally run /review:plan-adversarial <path> for a second-pass challenge review.
+- Before execution, stop any active plan-review comment listener, then run /cmd:execute-plan <path> --target dev:run or --target skill:adn-dev-wf to start a fresh execution session.
 - Review feedback should be integrated back into the same plan file.
-- Automatic review looping is capped at ${MAX_REVIEW_CYCLES} cycles before stopping.
+- Automatic inline review looping is capped at ${MAX_REVIEW_CYCLES} cycles before stopping.
 
 ${currentPlanInstruction}`,
 				display: false,
@@ -799,6 +933,22 @@ ${currentPlanInstruction}`,
 			}
 		}
 
+		if (event.toolName === "process") {
+			const action = String(event.input.action ?? "");
+			const command = String(event.input.command ?? "");
+			const id = typeof event.input.id === "string" ? event.input.id : undefined;
+			const readOnlyActions = new Set(["list", "output", "logs"]);
+			const allowedStart = action === "start" && /^\s*plan-review\s+agent\s+next\b/i.test(command) && isAllowedPlanReviewCommand(command);
+			const allowedKill = action === "kill" && id !== undefined && id === currentPlanListenerProcessId;
+
+			if (!readOnlyActions.has(action) && !allowedStart && !allowedKill) {
+				return {
+					block: true,
+					reason: "Plan mode only allows process list/output/logs, starting the plan-review agent next listener, or killing the tracked listener.",
+				};
+			}
+		}
+
 		if (event.toolName === "edit" || event.toolName === "write") {
 			const inputPath = typeof event.input.path === "string" ? event.input.path : "";
 			if (!inputPath || !isThoughtsPath(ctx.cwd, inputPath)) {
@@ -812,13 +962,53 @@ ${currentPlanInstruction}`,
 
 	pi.on("tool_result", async (event, ctx) => {
 		if (!planModeEnabled || event.isError) return;
+
+		if (event.toolName === "bash") {
+			const command = String(event.input.command ?? "");
+			if (/^\s*plan-review\s+register\b/i.test(command)) {
+				const registration = parsePlanReviewRegistrationOutput(toolResultToText(event.content));
+				if (registration.reviewUrl) {
+					currentPlanReviewUrl = registration.reviewUrl;
+					currentPlanId = registration.planId ?? currentPlanId;
+					if (registration.sourcePath) {
+						currentPlanPath = relativeToCwd(ctx.cwd, registration.sourcePath);
+					}
+					updateUi(ctx);
+					persistState();
+				}
+			}
+			return;
+		}
+
+		if (event.toolName === "process") {
+			const action = String(event.input.action ?? "");
+			const command = String(event.input.command ?? "");
+			if (action === "start" && /^\s*plan-review\s+agent\s+next\b/i.test(command)) {
+				const match = toolResultToText(event.content).match(/\b(proc_\w+)/);
+				currentPlanListenerProcessId = match?.[1] ?? currentPlanListenerProcessId;
+				updateUi(ctx);
+				persistState();
+			}
+			if (action === "kill" && event.input.id === currentPlanListenerProcessId) {
+				currentPlanListenerProcessId = undefined;
+				updateUi(ctx);
+				persistState();
+			}
+			return;
+		}
+
 		if (event.toolName !== "edit" && event.toolName !== "write") return;
 
 		const inputPath = typeof event.input.path === "string" ? event.input.path : undefined;
 		if (!inputPath || !isPlanFilePath(ctx.cwd, inputPath)) return;
 
 		turnTouchedPlan = true;
-		currentPlanPath = relativeToCwd(ctx.cwd, inputPath);
+		const nextPlanPath = relativeToCwd(ctx.cwd, inputPath);
+		if (nextPlanPath !== currentPlanPath) {
+			currentPlanReviewUrl = undefined;
+			currentPlanId = undefined;
+		}
+		currentPlanPath = nextPlanPath;
 		if (!reviewInFlight) {
 			reviewCycles = 0;
 			lastReviewCommand = undefined;

--- a/_pi/prompts/cmd:execute-plan.md
+++ b/_pi/prompts/cmd:execute-plan.md
@@ -53,7 +53,8 @@ Do not infer “the current plan” from conversation state.
 7. Preserve that normalized string as `PLAN_DISPATCH_ARGUMENT`.
 8. Resolve `PLAN_PATH` for validation only:
    - If `PLAN_DISPATCH_ARGUMENT` is an existing plan file path, use it as `PLAN_PATH`.
-   - Otherwise treat it as a slug and resolve it using repo-local active plan guidance. Do not infer a markdown path.
+   - Otherwise treat it as a slug and resolve it using repo-local active plan guidance. In this repo's active browser-reviewed flow, slugs resolve to `thoughts/plans/<slug>.html`.
+   - Do not infer a markdown path for slugs.
    - If repo guidance does not define slug-to-plan-path resolution, stop and ask for the explicit existing plan path.
 9. Read `PLAN_PATH` to confirm the reviewed plan exists.
 10. If `PLAN_PATH` does not exist, stop and tell the user that `/cmd:execute-plan` requires an explicit existing reviewed plan file or a slug resolvable by repo-local guidance.

--- a/_pi/prompts/dev:plan.md
+++ b/_pi/prompts/dev:plan.md
@@ -161,7 +161,10 @@ Before finishing:
 
 ## Next Steps
 
-- If the written plan is `execution-ready`, suggest:
+- If the written plan is an HTML plan, suggest:
+  - `/dev:reviewed-html-plan <plan_path>` to register it, process browser comments, run PM plus Claude/Codex plan reviews, and iterate to execution-ready.
+  - `/cmd:execute-plan <plan_path>` only after browser-review metadata and readiness gates are complete.
+- If the written plan is a legacy Markdown plan and is `execution-ready`, suggest:
   - `/review:change <plan_path>`
   - `/cmd:execute-plan <plan_path>`
 - If the written plan is `research-ready`, suggest reviewing the plan and then doing the exact next research action recorded in it instead of executing.

--- a/_pi/prompts/review:change-claude-code.md
+++ b/_pi/prompts/review:change-claude-code.md
@@ -54,6 +54,7 @@ Documents to review: $ARGUMENTS
 This command is review-only.
 
 - Only modify the plan by inserting inline `[REVIEW:...] ... [/REVIEW]` comments.
+- HTML plans are first-class inputs; keep them as valid semantic HTML and insert review comments visibly without converting the plan to Markdown.
 - Do not change any other plan content (do not fix, rewrite, or reorganize anything).
 - Do not remove or resolve review comments.
 - Do not run follow-up commands (including `/review:change-integrate`).

--- a/_pi/prompts/review:change-gpt.md
+++ b/_pi/prompts/review:change-gpt.md
@@ -33,6 +33,7 @@ Documents to review: $ARGUMENTS
 This command is review-only.
 
 - Only modify the plan by inserting inline `[REVIEW:...] ... [/REVIEW]` comments.
+- HTML plans are first-class inputs; keep them as valid semantic HTML and insert review comments visibly without converting the plan to Markdown.
 - Do not change any other plan content (do not fix, rewrite, or reorganize anything).
 - Do not remove or resolve review comments.
 - Do not run follow-up commands (including `/review:change-integrate`).

--- a/_pi/prompts/review:change-integrate.md
+++ b/_pi/prompts/review:change-integrate.md
@@ -79,6 +79,7 @@ Use the available repo exploration tools in this session.
 
 - Classify each review comment as material or optional before editing the plan.
 - Apply edits directly to the plan with `edit` unless a deliberate full-file rewrite is required.
+- HTML plans are first-class inputs; preserve valid semantic HTML while integrating and removing review comments.
 - Remove each resolved inline review comment.
 - Integrate only material findings that affect readiness for the stated scope.
 - If feedback implies adding or changing requirements, do so only when the plan's stated goal, non-goals, acceptance criteria, or validated source scope require it. Then update:

--- a/_pi/prompts/review:change-k2.5.md
+++ b/_pi/prompts/review:change-k2.5.md
@@ -33,6 +33,7 @@ Documents to review: $ARGUMENTS
 This command is review-only.
 
 - Only modify the plan by inserting inline `[REVIEW:...] ... [/REVIEW]` comments.
+- HTML plans are first-class inputs; keep them as valid semantic HTML and insert review comments visibly without converting the plan to Markdown.
 - Do not change any other plan content (do not fix, rewrite, or reorganize anything).
 - Do not remove or resolve review comments.
 - Do not run follow-up commands (including `/review:change-integrate`).

--- a/_pi/prompts/review:change-opus.md
+++ b/_pi/prompts/review:change-opus.md
@@ -33,6 +33,7 @@ Documents to review: $ARGUMENTS
 This command is review-only.
 
 - Only modify the plan by inserting inline `[REVIEW:...] ... [/REVIEW]` comments.
+- HTML plans are first-class inputs; keep them as valid semantic HTML and insert review comments visibly without converting the plan to Markdown.
 - Do not change any other plan content (do not fix, rewrite, or reorganize anything).
 - Do not remove or resolve review comments.
 - Do not run follow-up commands (including `/review:change-integrate`).

--- a/_pi/prompts/review:change.md
+++ b/_pi/prompts/review:change.md
@@ -14,6 +14,7 @@ Documents to review: $ARGUMENTS
 This command is review-only.
 
 - Only modify the plan by inserting inline `[REVIEW:...] ... [/REVIEW]` comments.
+- HTML plans are first-class inputs; keep them as valid semantic HTML and insert review comments visibly without converting the plan to Markdown.
 - Do not change any other plan content (do not fix, rewrite, or reorganize anything).
 - Do not remove or resolve review comments.
 - Do not run follow-up commands (including `/review:change-integrate`).

--- a/_pi/prompts/review:plan.md
+++ b/_pi/prompts/review:plan.md
@@ -8,6 +8,8 @@ This command orchestrates a blocker-focused review-only plan review using two in
 
 Documents to review: $ARGUMENTS
 
+HTML plans are first-class inputs. If the argument is a slug, resolve it through repo-local active plan guidance; in this repo's browser-reviewed flow that means `thoughts/plans/<slug>.html`, not a Markdown fallback.
+
 ## Execution Mode
 
 - Use the actual Pi subagent tool surface: launch two background agents with `Agent`.
@@ -29,14 +31,14 @@ Launch both reviews before waiting for either of them to finish.
 - **Model:** `openai-codex/gpt-5.5`
 - **Reasoning:** High
 - **Task:** Perform blocker-only plan review per reviewer-plan-gpt5.5 instructions
-- **Output:** Plan file with `[REVIEW:GPT]` comments + summary
+- **Output:** Same plan file with `[REVIEW:GPT]` comments + summary. For HTML plans, insert comments into the semantic HTML in a visible, valid way without converting the plan to Markdown.
 
 ### Subagent 2: Kimi K2.5 Review
 - **Agent:** `reviewer-plan-kimi`
 - **Model:** `opencode/kimi-k2.5`
 - **Reasoning:** High
 - **Task:** Perform blocker-only plan review per reviewer-plan-kimi instructions
-- **Output:** Plan file with `[REVIEW:Kimi K2.5]` comments + summary
+- **Output:** Same plan file with `[REVIEW:Kimi K2.5]` comments + summary. For HTML plans, insert comments into the semantic HTML in a visible, valid way without converting the plan to Markdown.
 
 ### Parallel Execution
 
@@ -46,14 +48,14 @@ Launch two background `Agent` calls so Pi actually runs both reviewers concurren
 const gpt54 = Agent({
   subagent_type: "reviewer-plan-gpt5.5",
   description: "Review plan with GPT",
-  prompt: "Review the plan at $ARGUMENTS. Follow your reviewer-plan-gpt5.5 instructions exactly. Add [REVIEW:GPT] comments only for blockers, materially risky gaps, or missing decisions required to execute the stated goal within the validated source scope, then provide a readiness summary.",
+  prompt: "Review the plan at $ARGUMENTS. Follow your reviewer-plan-gpt5.5 instructions exactly. Treat HTML plan files as first-class plan inputs and do not convert them to Markdown. Add [REVIEW:GPT] comments only for blockers, materially risky gaps, or missing decisions required to execute the stated goal within the validated source scope, then provide a readiness summary.",
   run_in_background: true,
 });
 
 const kimi = Agent({
   subagent_type: "reviewer-plan-kimi",
   description: "Review plan with Kimi K2.5",
-  prompt: "Review the plan at $ARGUMENTS. Follow your reviewer-plan-kimi instructions exactly. Add [REVIEW:Kimi K2.5] comments only for blockers, materially risky gaps, or missing decisions required to execute the stated goal within the validated source scope, then provide a readiness summary.",
+  prompt: "Review the plan at $ARGUMENTS. Follow your reviewer-plan-kimi instructions exactly. Treat HTML plan files as first-class plan inputs and do not convert them to Markdown. Add [REVIEW:Kimi K2.5] comments only for blockers, materially risky gaps, or missing decisions required to execute the stated goal within the validated source scope, then provide a readiness summary.",
   run_in_background: true,
 });
 
@@ -65,7 +67,7 @@ Wait for both `get_subagent_result(..., wait: true)` calls to complete before pr
 
 ## Review Output
 
-The final plan file should be an annotated plan containing any `[REVIEW:...]` comments left by GPT and Kimi K2.5.
+The final plan file should be the same annotated plan file, in its original format, containing any `[REVIEW:...]` comments left by GPT and Kimi K2.5. For HTML plans, keep the document valid semantic HTML.
 
 ## Summary Format
 

--- a/skills/claude-code-review/SKILL.md
+++ b/skills/claude-code-review/SKILL.md
@@ -49,6 +49,7 @@ window=claude-plan-review
 
 cat > "$prompt" <<'PROMPT'
 Review <plan_path> against AGENTS.md and thoughts/specs/product_intent.md.
+If <plan_path> is HTML, treat that HTML file as the authoritative plan artifact and do not require Markdown conversion.
 This is read-only. Do not edit files. Return a concise review with Verdict, Findings, Required Changes, Residual Risks.
 PROMPT
 
@@ -97,6 +98,7 @@ window=claude-plan-review
 
 cat > "$prompt" <<'PROMPT'
 Review <plan_path> against thoughts/plans/AGENTS.md and thoughts/specs/product_intent.md.
+If <plan_path> is HTML, treat that HTML file as the authoritative plan artifact and do not require Markdown conversion.
 This is a read-only plan review. Do not edit files.
 Return concise sections: Verdict, Strengths, Issues, Required Changes.
 PROMPT

--- a/skills/codex-review-partner/references/prompt-templates.md
+++ b/skills/codex-review-partner/references/prompt-templates.md
@@ -44,6 +44,8 @@ Constraints:
 Plan:
 <paste the plan here>
 
+If the plan is HTML, treat the HTML file as the authoritative plan artifact. Do not require Markdown conversion.
+
 Review for:
 - missing steps
 - unsafe assumptions

--- a/thoughts/plans/pi-plan-mode-html-review-flow.html
+++ b/thoughts/plans/pi-plan-mode-html-review-flow.html
@@ -332,6 +332,7 @@ rg -n "&lt;slug&gt;\.html|plan-review register|agent next --wait|listener" _pi/e
       <li id="log-2026-06-08-p1-p4-complete">2026-06-08 — Implemented P1-P4: HTML plan tracking/defaults, plan-review command/tool support, deterministic plan-mode instructions, execution handoff cleanup guidance, URL visibility, and HTML compatibility for review prompts/agents.</li>
       <li id="log-2026-06-08-p5-complete">2026-06-08 — Completed P5 verification: esbuild syntax check and <code>git diff --check</code> passed; scoped Codex review returned <code>VERDICT: PASS_SCOPED</code> after safety-boundary fixes.</li>
       <li id="log-2026-06-08-pr-feedback-listener-clear">2026-06-08 — Addressed PR feedback: a tracked listener kill attempt now clears the listener id even when the process already exited and the kill result is an error, preventing stale listener state from blocking execution.</li>
+      <li id="log-2026-06-08-pr-feedback-wait-only">2026-06-08 — Addressed PR feedback: only <code>plan-review agent next</code> process starts that include <code>--wait</code> and omit <code>--no-wait</code> are tracked as active comment listeners.</li>
     </ul>
   </section>
 </main>

--- a/thoughts/plans/pi-plan-mode-html-review-flow.html
+++ b/thoughts/plans/pi-plan-mode-html-review-flow.html
@@ -1,0 +1,338 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Pi Plan Mode HTML Review Flow</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #08111f;
+      --panel: #101a2b;
+      --panel-2: #17243a;
+      --text: #e6edf7;
+      --muted: #aab7c8;
+      --accent: #7dd3fc;
+      --accent-2: #c4b5fd;
+      --good: #86efac;
+      --warn: #fbbf24;
+      --bad: #fca5a5;
+      --border: #2d3c55;
+      --code: #0b1220;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: radial-gradient(circle at 15% 0%, rgba(125, 211, 252, 0.14), transparent 34rem), var(--bg);
+      color: var(--text);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+    }
+    main { max-width: 1120px; margin: 0 auto; padding: 48px 24px 80px; }
+    h1, h2, h3, h4 { line-height: 1.2; }
+    h1 { margin: 0 0 0.65rem; font-size: clamp(2rem, 5vw, 3.4rem); }
+    h2 { margin-top: 2.4rem; padding-top: 1.2rem; border-top: 1px solid var(--border); color: #f8fafc; }
+    h3 { margin-top: 1.6rem; color: var(--accent); }
+    h4 { margin-bottom: 0.3rem; color: var(--accent-2); }
+    a { color: var(--accent); }
+    code, pre { background: var(--code); color: #dbeafe; border-radius: 8px; }
+    code { padding: 0.12rem 0.32rem; }
+    pre { padding: 16px; overflow-x: auto; border: 1px solid var(--border); }
+    table { width: 100%; border-collapse: collapse; margin: 16px 0; }
+    th, td { border: 1px solid var(--border); padding: 10px 12px; vertical-align: top; }
+    th { background: var(--panel-2); color: #f8fafc; text-align: left; }
+    ul, ol { padding-left: 1.35rem; }
+    .badge { display: inline-block; padding: 0.22rem 0.65rem; border: 1px solid var(--border); border-radius: 999px; background: var(--panel-2); color: var(--accent); font-size: 0.86rem; }
+    .muted { color: var(--muted); }
+    .card { background: rgba(16, 26, 43, 0.9); border: 1px solid var(--border); border-radius: 16px; padding: 18px 20px; margin: 18px 0; box-shadow: 0 18px 60px rgba(0,0,0,0.24); }
+    .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+    .grid > div { background: rgba(23, 36, 58, 0.72); border: 1px solid var(--border); border-radius: 12px; padding: 14px; }
+    .good { color: var(--good); }
+    .warn { color: var(--warn); }
+    .bad { color: var(--bad); }
+    @media (max-width: 860px) { .grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+<main>
+  <p class="badge" id="status">Status: execution-ready</p>
+  <h1 id="title">Pi Plan Mode HTML Review Flow</h1>
+  <p class="muted" id="summary">Shift Pi <code>/plan</code> mode from Markdown-review assumptions to the current HTML plan-review workflow: create semantic HTML plans, register them in <code>plan-review</code>, keep the queue-backed comment listener running during iteration, and stop the listener before handing the reviewed plan to execution.</p>
+
+  <section id="goal">
+    <h2>Goal</h2>
+    <p>Make <code>_pi/extensions/pi-plan-mode/index.ts</code> and the Pi planning prompt steer agents toward the deterministic reviewed HTML process documented in <code>skills/planning-workflow/SKILL.md</code>, <code>skills/html-plan-reviewer/SKILL.md</code>, and <code>skills/reviewed-html-plan/SKILL.md</code>.</p>
+  </section>
+
+  <section id="why-this-plan-exists">
+    <h2>Why this plan exists</h2>
+    <p>The repo already has a reviewed HTML workflow, but <code>/plan</code> mode still defaults new plans and slug execution to <code>.md</code>, only tracks plan edits for Markdown files, nudges users toward inline Markdown plan reviews, blocks the <code>plan-review</code> commands needed to register HTML plans, and does not explicitly coordinate the <code>plan-review agent next --wait</code> listener lifecycle. This creates dissonance between the current process and the mode that should make planning deterministic.</p>
+  </section>
+
+  <section id="authority-and-inputs">
+    <h2>Authority and inputs</h2>
+    <ul>
+      <li id="input-agents"><code>AGENTS.md</code>: active browser-reviewed plans are semantic HTML files under <code>thoughts/plans/&lt;slug&gt;.html</code>; <code>skills/html-plan-reviewer/SKILL.md</code> is the sole source for concrete <code>plan-review</code> commands.</li>
+      <li id="input-extension"><code>_pi/extensions/pi-plan-mode/index.ts</code>: current mode implementation, write guardrails, plan tracking, review prompts, and execution handoff.</li>
+      <li id="input-dev-plan"><code>_pi/prompts/dev:plan.md</code>: plan materialization prompt already supports repo-local HTML guidance but still suggests Markdown-era next steps.</li>
+      <li id="input-reviewed-html"><code>_pi/prompts/dev:reviewed-html-plan.md</code> and <code>skills/reviewed-html-plan/SKILL.md</code>: authoritative gate for registration, browser comments, PM review, and AI plan reviews.</li>
+      <li id="input-pi-docs">Pi extension docs: plan mode can inject context, constrain tools, track tool results, register commands, and restore tools on mode exit.</li>
+    </ul>
+  </section>
+
+  <section id="current-implementation-reality">
+    <h2>Current implementation reality</h2>
+    <table>
+      <thead><tr><th>Area</th><th>Observed reality</th><th>Required shift</th></tr></thead>
+      <tbody>
+        <tr id="reality-md-default"><td>Plan path default</td><td><code>resolveExecutePlanRequest</code> and plan-mode injected context resolve slugs/new plans to <code>thoughts/plans/&lt;slug&gt;.md</code>.</td><td>Default to <code>.html</code> while still accepting explicit existing paths.</td></tr>
+        <tr id="reality-md-tracking"><td>Plan tracking</td><td><code>isPlanFilePath</code> only recognizes <code>.md</code>, so HTML edits do not update current-plan state.</td><td>Track <code>thoughts/plans/*.html</code> as first-class plan files.</td></tr>
+        <tr id="reality-tools"><td>Tools</td><td><code>process</code> is only enabled during review orchestration, and <code>plan-review</code>/<code>open</code> commands are blocked by the safe-bash gate.</td><td>Allow the tools and narrow commands needed for HTML registration and the listener.</td></tr>
+        <tr id="reality-review-nudges"><td>Review nudges</td><td>After edits, the mode suggests <code>/review:plan</code> and Markdown inline integration flows.</td><td>Suggest <code>/dev:reviewed-html-plan</code> / <code>/skill:reviewed-html-plan</code> and browser-comment processing first for HTML plans.</td></tr>
+        <tr id="reality-review-command-html"><td>Review command compatibility</td><td>Several review prompts and plan-reviewer agents still describe <code>thoughts/plans/&lt;slug&gt;.md</code> as the single plan file shape.</td><td>Update <code>/review:plan</code>, Claude Code review, Codex review, and plan-reviewer agent prompts as needed so HTML plans are accepted first-class inputs.</td></tr>
+        <tr id="reality-listener"><td>Listener lifecycle</td><td>No state exists for a plan-review listener. Execution disables plan mode but does not tell the agent to stop any running listener.</td><td>Record listener context when available and make mode-exit/execution handoff explicitly terminate or prompt listener cleanup.</td></tr>
+        <tr id="reality-review-url"><td>Plan URL visibility</td><td>The plan-mode widget only shows the current plan path, so developers cannot always see the browser review URL while planning.</td><td>Persist and display the canonical review URL whenever the current HTML plan has been registered.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="progress">
+    <h2>Progress</h2>
+    <ul>
+      <li id="progress-p1"><label><input type="checkbox" checked /> P1 — HTML plan identity and tracking</label></li>
+      <li id="progress-p2"><label><input type="checkbox" checked /> P2 — Registration and listener tool support</label></li>
+      <li id="progress-p3"><label><input type="checkbox" checked /> P3 — Deterministic plan-mode instructions</label></li>
+      <li id="progress-p4"><label><input type="checkbox" checked /> P4 — Execution handoff and docs alignment</label></li>
+      <li id="progress-p5"><label><input type="checkbox" checked /> P5 — Verification and review</label></li>
+    </ul>
+  </section>
+
+  <section id="resume-instructions-agent">
+    <h2>Resume instructions (agent)</h2>
+    <ol>
+      <li id="resume-read">Read this HTML plan fully plus <code>_pi/extensions/pi-plan-mode/index.ts</code>, <code>_pi/prompts/dev:plan.md</code>, and <code>skills/html-plan-reviewer/SKILL.md</code>.</li>
+      <li id="resume-first-unchecked">Find the first unchecked item in <a href="#progress">Progress</a> and execute phases in order.</li>
+      <li id="resume-update-progress">Update only the matching progress checkbox when its phase is complete; preserve the append-only decisions/deviations log.</li>
+      <li id="resume-ask">Ask the user only if Pi extension APIs cannot support listener termination beyond prompting/tool instructions.</li>
+    </ol>
+  </section>
+
+  <section id="product-intent-alignment">
+    <h2>Product intent alignment</h2>
+    <div class="grid" id="product-grid">
+      <div id="product-golden-path"><strong>Golden path</strong><br />Typing <code>/plan</code> should make the next planning turn naturally produce/register an HTML plan and tell the user where to annotate it.</div>
+      <div id="product-safe-default"><strong>Safe default</strong><br />Slug inputs should resolve to HTML plans; explicit legacy Markdown paths remain accepted only when the user supplies them.</div>
+      <div id="product-recovery"><strong>Recovery</strong><br />If registration or listener setup is missing, plan-mode instructions should provide exact <code>plan-review</code> remediation steps instead of relying on tribal knowledge. The current plan's browser review URL should stay visible in plan mode so developers can return to the active review without searching logs.</div>
+    </div>
+  </section>
+
+  <section id="locked-decisions">
+    <h2>Locked decisions</h2>
+    <ul>
+      <li id="decision-html-default">New plan-mode plans and slug execution resolve to <code>thoughts/plans/&lt;slug&gt;.html</code>.</li>
+      <li id="decision-explicit-md">Explicit existing <code>.md</code> paths remain accepted for legacy compatibility, but no new Markdown companion is created.</li>
+      <li id="decision-reviewer-skill">Plan-review service command details stay delegated to <code>skills/html-plan-reviewer/SKILL.md</code>; prompts reference it instead of duplicating long recipes.</li>
+      <li id="decision-listener-process">The queue-backed <code>agent next --wait</code> listener is the only plan-mode listener. Do not surface <code>plan-review watch</code> from <code>/plan</code>; treat it as legacy/debug-only service tooling outside the deterministic planning path.</li>
+      <li id="decision-exit-cleanup">Leaving plan mode for execution must make listener cleanup explicit before execution begins.</li>
+      <li id="decision-url-visible">Plan mode must persist and display the canonical current plan URL after HTML registration.</li>
+    </ul>
+  </section>
+
+  <section id="acceptance-criteria">
+    <h2>Acceptance criteria</h2>
+    <ol>
+      <li id="ac-1">When <code>/plan</code> mode is active and no current plan exists, the injected context tells the agent to write <code>thoughts/plans/&lt;slug&gt;.html</code> and load <code>planning-workflow</code>, <code>html-plan-reviewer</code>, <code>reviewed-html-plan</code>, and relevant domain skills.</li>
+      <li id="ac-2">HTML plan writes under <code>thoughts/plans/</code> update <code>currentPlanPath</code> and trigger the post-edit planning nudge.</li>
+      <li id="ac-3">Slug-based <code>/cmd:execute-plan</code> resolves to <code>thoughts/plans/&lt;slug&gt;.html</code>; explicit existing <code>.html</code> and <code>.md</code> paths still validate.</li>
+      <li id="ac-4">Plan mode enables the <code>process</code> tool and permits narrow <code>plan-review</code> registration/comment commands needed by the HTML workflow.</li>
+      <li id="ac-5">Plan-mode instructions require registration with truthful <code>--execution-ready</code> metadata, queue-backed comment draining/listening, claim/ack/resolve processing, and listener restart after each processed claim.</li>
+      <li id="ac-6">Before execution handoff, plan mode disables planning restrictions and explicitly terminates or requires termination of the active plan-review comment listener.</li>
+      <li id="ac-7">README and prompt text no longer present Markdown review as the default plan-mode path.</li>
+      <li id="ac-8">After an HTML plan is registered, the plan-mode status/widget always shows the canonical current plan review URL until a different plan is selected or plan mode is disabled.</li>
+      <li id="ac-9"><code>/review:plan</code>, Claude Code review, Codex review, and plan-reviewer agent prompts accept reviewed HTML plan paths without assuming Markdown-only input.</li>
+    </ol>
+  </section>
+
+  <section id="bdd-scenarios">
+    <h2>BDD scenarios</h2>
+    <article id="bdd-new-plan-html">
+      <h3>New plan defaults to HTML</h3>
+      <p><strong>Given</strong> <code>/plan</code> mode is enabled with no current plan, <strong>when</strong> the next agent turn creates a plan, <strong>then</strong> the injected instruction says to write <code>thoughts/plans/&lt;slug&gt;.html</code> and follow the HTML reviewer workflow.</p>
+    </article>
+    <article id="bdd-track-html-edit">
+      <h3>HTML edit tracks current plan</h3>
+      <p><strong>Given</strong> plan mode is active, <strong>when</strong> the agent writes <code>thoughts/plans/foo.html</code>, <strong>then</strong> the mode records <code>foo.html</code> as the current plan and offers HTML-review next steps.</p>
+    </article>
+    <article id="bdd-execute-slug-html">
+      <h3>Execution slug resolves to reviewed HTML</h3>
+      <p><strong>Given</strong> <code>thoughts/plans/foo.html</code> exists, <strong>when</strong> the user runs <code>/cmd:execute-plan foo --target dev:run</code>, <strong>then</strong> validation uses the HTML file and dispatches the normalized slug to <code>/dev:run</code>.</p>
+    </article>
+    <article id="bdd-listener-cleanup">
+      <h3>Listener cleanup on exit</h3>
+      <p><strong>Given</strong> browser review monitoring is active, <strong>when</strong> the user exits plan mode or starts execution, <strong>then</strong> the mode surfaces cleanup for the active listener before implementation begins.</p>
+    </article>
+    <article id="bdd-legacy-explicit-md">
+      <h3>Explicit Markdown legacy path</h3>
+      <p><strong>Given</strong> a user passes <code>thoughts/plans/legacy.md</code>, <strong>when</strong> the file exists, <strong>then</strong> validation accepts the explicit path without creating or implying a same-slug HTML companion.</p>
+    </article>
+    <article id="bdd-plan-url-visible">
+      <h3>Current plan URL is visible</h3>
+      <p><strong>Given</strong> an HTML plan has been registered, <strong>when</strong> the developer is in <code>/plan</code> mode, <strong>then</strong> the plan-mode widget shows the canonical browser review URL for the current plan.</p>
+    </article>
+    <article id="bdd-review-commands-accept-html">
+      <h3>Review commands accept HTML plans</h3>
+      <p><strong>Given</strong> a reviewed HTML plan path, <strong>when</strong> a developer invokes <code>/review:plan</code>, Claude Code review, or Codex review, <strong>then</strong> the review flow treats the HTML file as the plan authority and does not require a Markdown conversion.</p>
+    </article>
+  </section>
+
+  <section id="phase-by-phase-execution-plan">
+    <h2>Phase-by-phase execution plan</h2>
+
+    <article class="card" id="phase-p1-html-plan-identity">
+      <h3>P1 — HTML plan identity and tracking</h3>
+      <h4>End State</h4>
+      <p>Plan mode treats <code>thoughts/plans/*.html</code> as the primary active plan format while preserving explicit existing paths.</p>
+      <h4>Tests first</h4>
+      <p>Add or perform targeted TypeScript/static checks for slug resolution and <code>isPlanFilePath</code> behavior if an extension test harness exists; otherwise use a syntax check plus grep-based assertions.</p>
+      <h4>Work</h4>
+      <ul>
+        <li id="p1-work-default">Change plan usage/help text and slug resolution to default to <code>.html</code>.</li>
+        <li id="p1-work-explicit">Accept explicit existing <code>.html</code> and legacy <code>.md</code> file paths.</li>
+        <li id="p1-work-track">Update plan-file detection so HTML edits update <code>currentPlanPath</code>.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <p><code>_pi/extensions/pi-plan-mode/index.ts</code></p>
+      <h4>Verify</h4>
+      <pre><code>rg -n "&lt;slug&gt;\.html|endsWith\(\"\.html\"\)|cmd:execute-plan" _pi/extensions/pi-plan-mode/index.ts
+npx tsc --noEmit --allowJs false _pi/extensions/pi-plan-mode/index.ts</code></pre>
+    </article>
+
+    <article class="card" id="phase-p2-registration-listener-support">
+      <h3>P2 — Registration and listener tool support</h3>
+      <h4>End State</h4>
+      <p>An agent in plan mode can register the HTML plan, drain comments, and start the queue-backed listener without the mode blocking required tools.</p>
+      <h4>Tests first</h4>
+      <p>Define the allowed command set before editing: <code>plan-review register</code>, <code>plan-review agent next</code>, <code>plan-review queue</code>, <code>plan-review ack</code>, <code>plan-review resolve</code>, <code>plan-review release</code>, <code>plan-review index</code>, canonical <code>open</code>, and narrow <code>brew services start plan-reviewer</code>.</p>
+      <h4>Work</h4>
+      <ul>
+        <li id="p2-work-process">Enable the <code>process</code> tool during normal plan mode because the listener is part of planning, not execution.</li>
+        <li id="p2-work-bash">Allow narrow <code>plan-review</code> and canonical URL <code>open</code> commands through the read-only bash gate.</li>
+        <li id="p2-work-state">Record plan-review listener/process identity when observable from process tool calls, or document the supported cleanup prompt when the extension cannot directly manage the process tool registry.</li>
+        <li id="p2-work-url">Capture the canonical review URL from registration output and show it in the plan-mode widget/status alongside the current plan path.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <p><code>_pi/extensions/pi-plan-mode/index.ts</code></p>
+      <h4>Verify</h4>
+      <pre><code>rg -n "plan-review|agent next|process|listener|brew services start plan-reviewer" _pi/extensions/pi-plan-mode/index.ts</code></pre>
+    </article>
+
+    <article class="card" id="phase-p3-deterministic-instructions">
+      <h3>P3 — Deterministic plan-mode instructions</h3>
+      <h4>End State</h4>
+      <p>Injected plan-mode context tells agents exactly which skills to load and which gates to run for HTML planning.</p>
+      <h4>Tests first</h4>
+      <p>Compare injected instructions against the required skills and HTML plan-review lifecycle before editing.</p>
+      <h4>Work</h4>
+      <ul>
+        <li id="p3-work-skills">Name required skills: <code>planning-workflow</code>, <code>html-plan-reviewer</code>, <code>reviewed-html-plan</code>, <code>product-principles</code> for workflow changes, plus domain skills.</li>
+        <li id="p3-work-lifecycle">Encode create/register/share/drain/listen/process/ack/resolve/reregister-ready behavior using only <code>plan-review agent next</code>, not <code>plan-review watch</code>.</li>
+        <li id="p3-work-next-steps">Replace Markdown-review nudges with reviewed HTML plan next steps while keeping explicit review commands opt-in.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <p><code>_pi/extensions/pi-plan-mode/index.ts</code>, <code>_pi/prompts/dev:plan.md</code></p>
+      <h4>Verify</h4>
+      <pre><code>rg -n "html-plan-reviewer|reviewed-html-plan|execution-ready|plan-review agent next|/dev:reviewed-html-plan" _pi/extensions/pi-plan-mode/index.ts _pi/prompts/dev:plan.md</code></pre>
+    </article>
+
+    <article class="card" id="phase-p4-execution-handoff-docs">
+      <h3>P4 — Execution handoff and docs alignment</h3>
+      <h4>End State</h4>
+      <p>Exiting plan mode for execution restores normal tools, makes listener cleanup explicit, and docs describe HTML as the default active plan artifact.</p>
+      <h4>Tests first</h4>
+      <p>Inventory user-facing text that still says <code>.md</code> or Markdown review is default.</p>
+      <h4>Work</h4>
+      <ul>
+        <li id="p4-work-disable">Update disable/execution notifications to mention listener cleanup when a reviewed HTML plan is current.</li>
+        <li id="p4-work-readme">Update <code>_pi/README.md</code> plan-mode bullets and examples.</li>
+        <li id="p4-work-execute-prompt">Keep <code>_pi/prompts/cmd:execute-plan.md</code> aligned with slug-to-HTML resolution.</li>
+        <li id="p4-work-review-html">Update <code>/review:plan</code>, Claude Code review, Codex review, and plan-reviewer agent prompts so HTML plans are valid first-class inputs where those surfaces are used in the planning process.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <p><code>_pi/extensions/pi-plan-mode/index.ts</code>, <code>_pi/README.md</code>, <code>_pi/prompts/cmd:execute-plan.md</code>, <code>_pi/prompts/review:plan*.md</code>, <code>_pi/prompts/review:change*.md</code>, <code>_pi/agents/reviewer-plan*.md</code>, and Codex/Claude review-partner skill prompt references as needed.</p>
+      <h4>Verify</h4>
+      <pre><code>rg -n "thoughts/plans/&lt;slug&gt;\.md|Markdown review|/review:plan after plan edits" _pi/README.md _pi/prompts _pi/extensions/pi-plan-mode/index.ts</code></pre>
+    </article>
+
+    <article class="card" id="phase-p5-verification-review">
+      <h3>P5 — Verification and review</h3>
+      <h4>End State</h4>
+      <p>The scoped changes are verified with syntax/static checks and a focused review against this plan.</p>
+      <h4>Tests first</h4>
+      <p>No product test harness is present for the extension; verification relies on TypeScript syntax/import checks and grep-backed contract checks.</p>
+      <h4>Work</h4>
+      <ul>
+        <li id="p5-work-syntax">Run the narrowest available TypeScript/syntax check for the extension.</li>
+        <li id="p5-work-contract">Run grep checks for default HTML paths, allowed plan-review commands, listener cleanup text, and prompt/docs alignment.</li>
+        <li id="p5-work-review">Perform a focused self-review or quality-reviewer pass for regressions in plan-mode safety boundaries.</li>
+      </ul>
+      <h4>Expected files</h4>
+      <p>No additional files beyond the touched extension, prompts/docs, and this plan.</p>
+      <h4>Verify</h4>
+      <pre><code>npx tsc --noEmit --allowJs false _pi/extensions/pi-plan-mode/index.ts
+rg -n "&lt;slug&gt;\.html|plan-review register|agent next --wait|listener" _pi/extensions/pi-plan-mode/index.ts _pi/prompts/dev:plan.md _pi/prompts/cmd:execute-plan.md _pi/README.md</code></pre>
+    </article>
+  </section>
+
+  <section id="verification-strategy">
+    <h2>Verification strategy</h2>
+    <table>
+      <thead><tr><th>Acceptance</th><th>Evidence</th><th>Command or check</th></tr></thead>
+      <tbody>
+        <tr id="verify-ac1"><td>AC1</td><td>Injected context mentions HTML default and skills.</td><td><code>rg -n "&lt;slug&gt;\.html|html-plan-reviewer|reviewed-html-plan" _pi/extensions/pi-plan-mode/index.ts</code></td></tr>
+        <tr id="verify-ac2"><td>AC2</td><td>Plan-file predicate accepts <code>.html</code>.</td><td><code>rg -n "endsWith\(\"\.html\"\)" _pi/extensions/pi-plan-mode/index.ts</code></td></tr>
+        <tr id="verify-ac3"><td>AC3</td><td>Execute usage and resolver default to HTML.</td><td><code>rg -n "cmd:execute-plan.*html|PLAN_DIRECTORY.*html" _pi/extensions/pi-plan-mode/index.ts _pi/prompts/cmd:execute-plan.md</code></td></tr>
+        <tr id="verify-ac4"><td>AC4</td><td><code>process</code> and narrow <code>plan-review</code> commands are available.</td><td><code>rg -n "process|plan-review" _pi/extensions/pi-plan-mode/index.ts</code></td></tr>
+        <tr id="verify-ac5"><td>AC5</td><td>Lifecycle instructions contain registration/listener/ack/resolve steps and do not recommend <code>watch</code>.</td><td><code>rg -n -- "--execution-ready|agent next|ack|resolve" _pi/extensions/pi-plan-mode/index.ts _pi/prompts/dev:plan.md &amp;&amp; ! rg -n "plan-review watch" _pi/extensions/pi-plan-mode/index.ts _pi/prompts/dev:plan.md</code></td></tr>
+        <tr id="verify-ac6"><td>AC6</td><td>Execution exit text mentions terminating listener.</td><td><code>rg -n "terminate.*listener|listener.*execution" _pi/extensions/pi-plan-mode/index.ts</code></td></tr>
+        <tr id="verify-ac7"><td>AC7</td><td>Docs/prompt no longer advertise Markdown review as default.</td><td><code>rg -n "Markdown review|/review:plan after plan edits|&lt;slug&gt;\.md" _pi/README.md _pi/prompts/dev:plan.md</code></td></tr>
+        <tr id="verify-ac8"><td>AC8</td><td>Plan-mode UI persists and displays the canonical review URL.</td><td><code>rg -n "reviewUrl|currentPlan.*URL|Plan URL" _pi/extensions/pi-plan-mode/index.ts</code></td></tr>
+        <tr id="verify-ac9"><td>AC9</td><td>Review prompts and agents accept HTML plan inputs.</td><td><code>rg -n "\.html|HTML plan|reviewed HTML" _pi/prompts/review:plan*.md _pi/prompts/review:change*.md _pi/agents/reviewer-plan*.md skills/codex-review-partner skills/claude-code-review</code></td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="delivery-order">
+    <h2>Delivery order</h2>
+    <ol>
+      <li id="delivery-1">Patch the extension path and predicate logic first so HTML plan files are observable.</li>
+      <li id="delivery-2">Add narrow command/tool allowance for registration and listener setup.</li>
+      <li id="delivery-3">Update injected instructions, prompts, and docs so agents consistently choose reviewed HTML planning.</li>
+      <li id="delivery-4">Run syntax/static checks and a focused safety review.</li>
+    </ol>
+  </section>
+
+  <section id="non-goals">
+    <h2>Non-goals</h2>
+    <ul>
+      <li id="non-goal-service">Do not modify the standalone <code>plan-reviewer</code> service or CLI.</li>
+      <li id="non-goal-md-delete">Do not delete legacy Markdown plans or PRD-mode Markdown behavior.</li>
+      <li id="non-goal-review-rewrite">Do not redesign review semantics beyond the minimum needed for HTML-plan compatibility; do update <code>/review:plan</code>, Claude Code review, and Codex review surfaces when they would otherwise force Markdown-only planning.</li>
+      <li id="non-goal-auto-impl">Do not start implementing product-code plans automatically when browser feedback arrives.</li>
+    </ul>
+  </section>
+
+  <section id="decisions-deviations-log">
+    <h2>Decisions / Deviations log</h2>
+    <ul>
+      <li id="log-2026-06-08-initial">2026-06-08 — Initial plan created from user request to move Pi <code>/plan</code> mode from Markdown review toward HTML plan registration and full browser-comment iteration.</li>
+      <li id="log-2026-06-08-browser-comment-1">2026-06-08 — Browser comment noted that current plan mode also prevents agents from registering the plan; clarified this blocker in the plan rationale.</li>
+      <li id="log-2026-06-08-browser-comment-3">2026-06-08 — Browser comment challenged whether <code>plan-review watch</code> should remain in the plan-mode workflow; clarified that <code>/plan</code> should expose only the queue-backed <code>agent next</code> path and not recommend <code>watch</code>.</li>
+      <li id="log-2026-06-08-browser-comment-4">2026-06-08 — Browser comment added that developers should always see the current plan URL in plan mode; added URL persistence/display requirements, acceptance coverage, and a BDD scenario.</li>
+      <li id="log-2026-06-08-browser-comment-5">2026-06-08 — Browser comment clarified that review surfaces should be reworked as needed for HTML plans; moved <code>/review:plan</code>, Claude Code review, Codex review, and plan-reviewer agent prompt compatibility into scope.</li>
+      <li id="log-2026-06-08-p1-p4-complete">2026-06-08 — Implemented P1-P4: HTML plan tracking/defaults, plan-review command/tool support, deterministic plan-mode instructions, execution handoff cleanup guidance, URL visibility, and HTML compatibility for review prompts/agents.</li>
+      <li id="log-2026-06-08-p5-complete">2026-06-08 — Completed P5 verification: esbuild syntax check and <code>git diff --check</code> passed; scoped Codex review returned <code>VERDICT: PASS_SCOPED</code> after safety-boundary fixes.</li>
+    </ul>
+  </section>
+</main>
+</body>
+</html>

--- a/thoughts/plans/pi-plan-mode-html-review-flow.html
+++ b/thoughts/plans/pi-plan-mode-html-review-flow.html
@@ -333,6 +333,7 @@ rg -n "&lt;slug&gt;\.html|plan-review register|agent next --wait|listener" _pi/e
       <li id="log-2026-06-08-p5-complete">2026-06-08 — Completed P5 verification: esbuild syntax check and <code>git diff --check</code> passed; scoped Codex review returned <code>VERDICT: PASS_SCOPED</code> after safety-boundary fixes.</li>
       <li id="log-2026-06-08-pr-feedback-listener-clear">2026-06-08 — Addressed PR feedback: a tracked listener kill attempt now clears the listener id even when the process already exited and the kill result is an error, preventing stale listener state from blocking execution.</li>
       <li id="log-2026-06-08-pr-feedback-wait-only">2026-06-08 — Addressed PR feedback: only <code>plan-review agent next</code> process starts that include <code>--wait</code> and omit <code>--no-wait</code> are tracked as active comment listeners.</li>
+      <li id="log-2026-06-08-pr-feedback-slug-validation">2026-06-08 — Addressed PR feedback: extensionless execute-plan slugs are now validated before resolving to <code>thoughts/plans/&lt;slug&gt;.html</code>, preventing traversal-shaped slug inputs.</li>
     </ul>
   </section>
 </main>

--- a/thoughts/plans/pi-plan-mode-html-review-flow.html
+++ b/thoughts/plans/pi-plan-mode-html-review-flow.html
@@ -331,6 +331,7 @@ rg -n "&lt;slug&gt;\.html|plan-review register|agent next --wait|listener" _pi/e
       <li id="log-2026-06-08-browser-comment-5">2026-06-08 — Browser comment clarified that review surfaces should be reworked as needed for HTML plans; moved <code>/review:plan</code>, Claude Code review, Codex review, and plan-reviewer agent prompt compatibility into scope.</li>
       <li id="log-2026-06-08-p1-p4-complete">2026-06-08 — Implemented P1-P4: HTML plan tracking/defaults, plan-review command/tool support, deterministic plan-mode instructions, execution handoff cleanup guidance, URL visibility, and HTML compatibility for review prompts/agents.</li>
       <li id="log-2026-06-08-p5-complete">2026-06-08 — Completed P5 verification: esbuild syntax check and <code>git diff --check</code> passed; scoped Codex review returned <code>VERDICT: PASS_SCOPED</code> after safety-boundary fixes.</li>
+      <li id="log-2026-06-08-pr-feedback-listener-clear">2026-06-08 — Addressed PR feedback: a tracked listener kill attempt now clears the listener id even when the process already exited and the kill result is an error, preventing stale listener state from blocking execution.</li>
     </ul>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- default Pi plan-mode slugs/new plans to reviewed HTML plans while preserving explicit legacy Markdown paths
- allow narrow plan-review/process workflows for registration, queue listener handling, URL display, and execution cleanup blocking
- align Pi docs, plan/review prompts, review agents, and review-partner skills with HTML-first planning

## Verification
- npx esbuild _pi/extensions/pi-plan-mode/index.ts --bundle=false --format=esm --platform=node --outfile=/tmp/pi-plan-mode-final-check.mjs
- git diff --check
- contract rg checks for HTML defaults, plan-review listener handling, canonical URL display, and HTML review prompt support
- scoped Codex review: VERDICT: PASS_SCOPED
- scoped Claude review: VERDICT: PASS_WITH_DEFERRED_FOLLOW_UPS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTML plan format support with integrated browser-review workflow
  * Introduced plan registration and comment-iteration capabilities for reviewed plans
  * Added execution safety checks to prevent runs while review listeners are active

* **Documentation**
  * Updated plan workflow guidance to reflect HTML-based planning and review processes
  * Clarified execution handoff instructions and review-flow sequences
  * Added comprehensive HTML plan review flow documentation and acceptance criteria

<!-- end of auto-generated comment: release notes by coderabbit.ai -->