### PR TITLE
Make Claude reviews use interactive tmux launcher

### DIFF
--- a/_omp/commands/review:plan-adversarial.md
+++ b/_omp/commands/review:plan-adversarial.md
@@ -39,6 +39,7 @@ Use this after the standard multi-model review when you want an explicit challen
 - **Model:** `opencode-zen/claude-opus-4-6`
 - **Reasoning:** High
 - **Output:** Plan file with `[REVIEW:Adversarial Opus 4.6]` comments + summary
+- **Gate classification:** optional model-provider review, not a required Claude Code CLI review gate.
 
 ### Parallel Execution
 

--- a/_opencode/commands/cmd:linear-build-workspace.md
+++ b/_opencode/commands/cmd:linear-build-workspace.md
@@ -226,7 +226,7 @@ python3 "$HOME/.config/opencode/scripts/linear_build_orchestrator.py" block \
 
 ## Stage 4: Plan Gates
 
-Run bounded Codex and Claude Code review gates through the required review runner. Do not substitute OpenCode `research`, `quality-reviewer`, `reviewer-*`, or generic subagents for these two required reviews.
+Run bounded Codex and Claude Code review gates through the required review runner. Do not substitute OpenCode `research`, `quality-reviewer`, `reviewer-*`, or generic subagents for these two required reviews. The Claude reviewer path delegates transport to the canonical private-tmux interactive launcher; do not invoke Claude Code directly from this command.
 
 ```bash
 REVIEW_RUN_ID="${ISSUE_KEY}-$(date -u +%Y%m%dT%H%M%SZ)"

--- a/_opencode/scripts/linear_build_review.py
+++ b/_opencode/scripts/linear_build_review.py
@@ -4,7 +4,9 @@
 The linear build workflow requires two implementation reviewers: Codex and
 Claude Code. This helper makes that requirement mechanical by invoking the
 approved review paths and writing artifacts whose first line is the exact
-ledger verdict.
+ledger verdict. Claude Code transport is delegated to the canonical interactive
+private-tmux launcher; this script only owns prompt construction and verdict
+parsing.
 """
 
 from __future__ import annotations
@@ -13,10 +15,8 @@ import argparse
 import hashlib
 import os
 import re
-import shlex
 import subprocess
 import sys
-import tempfile
 import time
 from pathlib import Path
 
@@ -167,40 +167,77 @@ def run_codex(prompt: str, cwd: str, output_path: Path, kind: str) -> str:
     return raw_path.read_text(errors="replace")
 
 
-def ensure_codex_tmux() -> None:
-    if subprocess.run(["tmux", "has-session", "-t", "codex"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0:
-        return
-    subprocess.run(
-        ["zellij", "--session", "main", "run", "--name", "codex-tmux-bootstrap", "--close-on-exit", "--", "/bin/zsh", "-ilc", "tmux new-session -d -s codex"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=True,
+def resolve_claude_review_launcher() -> Path:
+    candidates: list[Path] = []
+    if os.environ.get("CLAUDE_REVIEW_LAUNCHER"):
+        candidates.append(Path(os.environ["CLAUDE_REVIEW_LAUNCHER"]).expanduser())
+    candidates.append(Path.home() / ".agents/skills/claude-code-review/scripts/claude_interactive_review.py")
+    try:
+        repo_candidate = Path(__file__).resolve().parents[2] / "skills/claude-code-review/scripts/claude_interactive_review.py"
+        if repo_candidate.is_file():
+            candidates.append(repo_candidate)
+    except IndexError:
+        pass
+    candidates.append(Path.home() / ".config/opencode/skills/claude-code-review/scripts/claude_interactive_review.py")
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(
+        "Claude review launcher not found. Run ./install.sh --opencode, or set "
+        "CLAUDE_REVIEW_LAUNCHER to the repo or installed claude_interactive_review.py path. "
+        "Checked: " + ", ".join(str(path) for path in candidates)
     )
 
 
 def run_claude(prompt: str, cwd: str, output_path: Path, issue_key: str, kind: str) -> str:
-    ensure_codex_tmux()
     prompt_path = output_path.with_suffix(".prompt.md")
     raw_path = output_path.with_suffix(".raw.md")
-    prompt_path.write_text(prompt)
+    prompt_path.write_text(prompt, encoding="utf-8")
     raw_path.unlink(missing_ok=True)
-    window = f"claude-{kind.lower()}-{issue_key.lower()}"[:32]
-    inner = f"claude -p \"$(< {shlex.quote(str(prompt_path))})\" > {shlex.quote(str(raw_path))} 2>&1; echo EXIT=$? >> {shlex.quote(str(raw_path))}"
-    command = (
-        f"cd {shlex.quote(cwd)} && "
-        f"zsh -ilc {shlex.quote(inner)}"
-    )
-    run(["tmux", "new-window", "-t", "codex", "-n", window, command])
-    for _ in range(900):
-        if raw_path.exists() and raw_path.read_text(errors="replace").splitlines()[-1:].count("EXIT=0"):
-            break
-        if raw_path.exists() and raw_path.read_text(errors="replace").splitlines()[-1:] and raw_path.read_text(errors="replace").splitlines()[-1].startswith("EXIT="):
-            break
-        time.sleep(1)
-    else:
-        raise SystemExit(f"Claude review timed out; inspect tmux window codex:{window}")
-    output = raw_path.read_text(errors="replace")
-    return re.sub(r"\nEXIT=\d+\s*$", "", output).strip()
+    safe_issue = re.sub(r"[^A-Za-z0-9_-]+", "-", issue_key.upper()).strip("-") or "ISSUE"
+    sentinel = f"CLAUDE_REVIEW_DONE_{safe_issue}_{kind.upper()}_{int(time.time())}"
+    review_name = f"claude-{kind.lower()}-{issue_key.lower()}"
+    launcher = resolve_claude_review_launcher()
+    proc = subprocess.run([
+        sys.executable,
+        str(launcher),
+        "--cwd",
+        cwd,
+        "--prompt-file",
+        str(prompt_path),
+        "--output",
+        str(raw_path),
+        "--review-name",
+        review_name,
+        "--timeout-seconds",
+        "900",
+        "--sentinel",
+        sentinel,
+    ], text=True, capture_output=True)
+    if proc.returncode != 0:
+        details = raw_path.read_text(errors="replace") if raw_path.exists() else (proc.stderr or proc.stdout)
+        raise SystemExit(f"Claude review launcher failed with exit {proc.returncode}\n{details}")
+    return raw_path.read_text(errors="replace")
+
+
+def run_claude_smoke(cwd: str, output_path: Path) -> str:
+    launcher = resolve_claude_review_launcher()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run([
+        sys.executable,
+        str(launcher),
+        "--smoke",
+        "--cwd",
+        cwd,
+        "--review-name",
+        "opencode-linear-build-smoke",
+        "--output",
+        str(output_path),
+    ], text=True, capture_output=True)
+    text = output_path.read_text(errors="replace") if output_path.exists() else (proc.stderr or proc.stdout)
+    if proc.returncode != 0 or "CLAUDE_REVIEW_SMOKE_READY" not in text:
+        raise SystemExit(f"Claude review smoke failed with exit {proc.returncode}\n{text}")
+    return text
 
 
 def main() -> int:
@@ -211,13 +248,22 @@ def main() -> int:
     parser.add_argument("--plan", required=True)
     parser.add_argument("--base-ref", default="origin/develop")
     parser.add_argument("--output", required=True)
+    parser.add_argument("--claude-smoke", action="store_true")
     args = parser.parse_args()
 
     cwd = os.getcwd()
-    allowed = PLAN_ALLOWED if args.kind == "plan" else CODE_ALLOWED if args.kind == "code" else PM_ALLOWED
-    prompt = build_prompt(args.kind, args.plan, args.issue_key.upper(), args.base_ref)
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    if args.claude_smoke:
+        if args.reviewer != "claude":
+            raise SystemExit("--claude-smoke requires --reviewer claude")
+        text = run_claude_smoke(cwd, output_path)
+        print(f"claude:smoke:CLAUDE_REVIEW_SMOKE_READY:{output_path}")
+        print(text.strip())
+        return 0
+
+    allowed = PLAN_ALLOWED if args.kind == "plan" else CODE_ALLOWED if args.kind == "code" else PM_ALLOWED
+    prompt = build_prompt(args.kind, args.plan, args.issue_key.upper(), args.base_ref)
     raw_output = run_codex(prompt, cwd, output_path, args.kind) if args.reviewer == "codex" else run_claude(prompt, cwd, output_path, args.issue_key, args.kind)
     verdict = extract_verdict(raw_output, allowed)
     write_artifact(output_path, verdict, raw_output, args.reviewer)

--- a/_pi/README.md
+++ b/_pi/README.md
@@ -256,7 +256,7 @@ Example installed agents:
 - `review-change-integrate`
 - `review-change-kimi`
 - `review-change-opus`
-- `review-change-claude-code` — direct Claude Code review-only pass via pi-interactive-shell hands-free launch, then backgrounded
+- `review-change-claude-code` — Claude Code review-only pass through the shared private-tmux interactive launcher
 
 ## Usage
 

--- a/_pi/extensions/pi-plan-mode/index.ts
+++ b/_pi/extensions/pi-plan-mode/index.ts
@@ -574,7 +574,10 @@ function isAllowedQueueLifecycle(cwd: string, tokens: string[], state: Partial<P
 	if (!commentId || !changedFilesAreThoughts(cwd, tokens) || !allPlanReviewUrlsAllowed(tokens)) return false;
 	if (!validateRemainingTokens(tokens, 3, { valueFlags: new Set(["--url", "--claim", "--note", "--summary", "--changed-files", "--reason"]), booleanFlags: new Set(["--json"]) })) return false;
 	if (subcommand === "ack") return commentId === state.activeCommentId && getOptionValue(tokens, "--claim") === state.activeClaimId;
-	if (subcommand === "release") return commentId === state.activeCommentId && getOptionValue(tokens, "--claim") === state.activeClaimId;
+	if (subcommand === "release") {
+		const claim = getOptionValue(tokens, "--claim");
+		return commentId === state.activeCommentId && (claim === undefined || claim === state.activeClaimId);
+	}
 	if (subcommand === "resolve") return commentId === state.acknowledgedCommentId;
 	return false;
 }
@@ -658,8 +661,11 @@ function transitionClaimLifecycle(state: Partial<PlanModeState>, command: string
 	if (subcommand === "resolve" && commentId === state.acknowledgedCommentId) {
 		return { ...state, activeCommentId: undefined, activeClaimId: undefined, acknowledgedCommentId: undefined };
 	}
-	if (subcommand === "release" && commentId === state.activeCommentId && getOptionValue(tokens, "--claim") === state.activeClaimId) {
-		return { ...state, activeCommentId: undefined, activeClaimId: undefined, acknowledgedCommentId: undefined };
+	if (subcommand === "release" && commentId === state.activeCommentId) {
+		const claim = getOptionValue(tokens, "--claim");
+		if (claim === undefined || claim === state.activeClaimId) {
+			return { ...state, activeCommentId: undefined, activeClaimId: undefined, acknowledgedCommentId: undefined };
+		}
 	}
 	return state;
 }

--- a/_pi/extensions/pi-plan-mode/index.ts
+++ b/_pi/extensions/pi-plan-mode/index.ts
@@ -593,12 +593,19 @@ function isAllowedPlanReviewCommand(cwd: string, tokens: string[], state: Partia
 }
 
 function isAllowedClaudeReviewLauncherCommand(cwd: string, tokens: string[]): boolean {
-	if (tokens[0] !== "python3" || tokens.length !== 12) return false;
+	if (tokens[0] !== "python3") return false;
 	const launcherPaths = new Set([
 		"$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py",
 		resolve(homedir(), ".agents/skills/claude-code-review/scripts/claude_interactive_review.py"),
 	]);
 	if (!launcherPaths.has(tokens[1])) return false;
+	if (tokens[2] === "--smoke") {
+		if (tokens.length !== 9) return false;
+		if (tokens[3] !== "--cwd" || (tokens[4] !== "$PWD" && tokens[4] !== cwd)) return false;
+		if (tokens[5] !== "--review-name" || !/^[A-Za-z0-9._-]+$/.test(tokens[6])) return false;
+		return tokens[7] === "--output" && isClaudeReviewTempPath(tokens[8], ".txt");
+	}
+	if (tokens.length !== 12) return false;
 	const expectedFlags = ["--cwd", "--prompt-file", "--output", "--review-name", "--timeout-seconds"];
 	for (let index = 2; index < tokens.length; index += 2) {
 		if (tokens[index] !== expectedFlags[(index - 2) / 2]) return false;

--- a/_pi/extensions/pi-plan-mode/index.ts
+++ b/_pi/extensions/pi-plan-mode/index.ts
@@ -1,6 +1,7 @@
+import { existsSync, readFileSync } from "node:fs";
 import { access, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { isAbsolute, relative, resolve } from "node:path";
+import { basename, isAbsolute, relative, resolve } from "node:path";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Key } from "@mariozechner/pi-tui";
 
@@ -142,6 +143,9 @@ interface PlanModeState {
 	currentPlanReviewUrl?: string;
 	currentPlanId?: string;
 	currentPlanListenerProcessId?: string;
+	activeCommentId?: string;
+	activeClaimId?: string;
+	acknowledgedCommentId?: string;
 	savedActiveTools?: string[];
 	reviewCycles: number;
 	lastReviewCommand?: string;
@@ -174,37 +178,6 @@ function isWithin(parent: string, child: string): boolean {
 
 function relativeToCwd(cwd: string, inputPath: string): string {
 	return relative(cwd, resolveFromCwd(cwd, inputPath));
-}
-
-function isAllowedPlanReviewCommand(command: string): boolean {
-	const normalized = command.trim();
-	if (/^plan-review\s+watch\b/i.test(normalized)) return false;
-	if (/[\r\n;&|`<>]/.test(normalized) || /\$\(/.test(normalized) || />>/.test(normalized)) return false;
-	return (
-		/^plan-review\s+register\b/i.test(normalized)
-		|| /^plan-review\s+index\b/i.test(normalized)
-		|| /^plan-review\s+agent\s+next\b/i.test(normalized)
-		|| /^plan-review\s+queue\s+(list|claim)\b/i.test(normalized)
-		|| /^plan-review\s+(ack|resolve|release)\b/i.test(normalized)
-		|| /^open\s+http:\/\/mbp\.braid-python\.ts\.net:4317(?:\/\S*)?\s*$/i.test(normalized)
-		|| /^brew\s+services\s+start\s+plan-reviewer\b/i.test(normalized)
-	);
-}
-
-function isPlanReviewListenerCommand(command: string): boolean {
-	const tokens = parseCommandArgs(command.trim());
-	return tokens[0] === "plan-review"
-		&& tokens[1] === "agent"
-		&& tokens[2] === "next"
-		&& tokens.includes("--wait")
-		&& !tokens.includes("--no-wait");
-}
-
-function isSafeCommand(command: string): boolean {
-	if (isAllowedPlanReviewCommand(command)) return true;
-	const destructive = DESTRUCTIVE_PATTERNS.some((pattern) => pattern.test(command));
-	const safe = SAFE_BASH_PATTERNS.some((pattern) => pattern.test(command));
-	return !destructive && safe;
 }
 
 function stripFrontmatter(content: string): string {
@@ -395,6 +368,280 @@ function isPlanFilePath(cwd: string, inputPath: string): boolean {
 	return isWithin(getPlansRoot(cwd), resolved) && /\.(html|md)$/i.test(resolved);
 }
 
+function isHtmlPlanFilePath(cwd: string, inputPath: string): boolean {
+	const resolved = resolveFromCwd(cwd, inputPath);
+	return isWithin(getPlansRoot(cwd), resolved) && /\.html$/i.test(resolved);
+}
+
+function hasShellHazards(command: string): boolean {
+	return /[\r\n;&|`<>]/.test(command) || /\$\(/.test(command) || />>/.test(command);
+}
+
+function getOptionValues(tokens: string[], option: string): string[] {
+	const values: string[] = [];
+	const equalsPrefix = `${option}=`;
+	for (let i = 0; i < tokens.length; i += 1) {
+		if (tokens[i] === option && i < tokens.length - 1) values.push(tokens[i + 1]);
+		else if (tokens[i].startsWith(equalsPrefix)) values.push(tokens[i].slice(equalsPrefix.length));
+	}
+	return values;
+}
+
+function getOptionValue(tokens: string[], option: string): string | undefined {
+	return getOptionValues(tokens, option)[0];
+}
+
+function hasFlag(tokens: string[], flag: string): boolean {
+	return tokens.includes(flag);
+}
+
+function validateRemainingTokens(tokens: string[], startIndex: number, options: { valueFlags?: Set<string>; booleanFlags?: Set<string>; positional?: (token: string) => boolean } = {}): boolean {
+	const valueFlags = options.valueFlags ?? new Set<string>();
+	const booleanFlags = options.booleanFlags ?? new Set<string>();
+	const positional = options.positional ?? (() => false);
+	for (let i = startIndex; i < tokens.length; i += 1) {
+		const token = tokens[i];
+		const equalsIndex = token.indexOf("=");
+		if (equalsIndex > 0) {
+			const flag = token.slice(0, equalsIndex);
+			if (!valueFlags.has(flag)) return false;
+			if (token.slice(equalsIndex + 1).length === 0) return false;
+			continue;
+		}
+		if (valueFlags.has(token)) {
+			if (i === tokens.length - 1 || tokens[i + 1].startsWith("-")) return false;
+			i += 1;
+			continue;
+		}
+		if (booleanFlags.has(token)) continue;
+		if (token.startsWith("-")) return false;
+		if (!positional(token)) return false;
+	}
+	return true;
+}
+
+function serviceUrlAllowed(rawUrl: string | undefined, path?: string): boolean {
+	if (typeof rawUrl !== "string") return false;
+	try {
+		const url = new URL(rawUrl);
+		const hostOk = (url.hostname === "mbp.braid-python.ts.net" || url.hostname === "127.0.0.1" || url.hostname === "localhost") && url.port === "4317";
+		return hostOk && (path === undefined || url.pathname === path);
+	} catch {
+		return false;
+	}
+}
+
+function allPlanReviewUrlsAllowed(tokens: string[]): boolean {
+	return getOptionValues(tokens, "--url").every((url) => serviceUrlAllowed(url));
+}
+
+function changedFilesAreThoughts(cwd: string, tokens: string[]): boolean {
+	return getOptionValues(tokens, "--changed-files")
+		.flatMap((value) => value.split(",").map((file) => file.trim()).filter(Boolean))
+		.every((file) => isThoughtsPath(cwd, file));
+}
+
+function commandPlanId(tokens: string[]): string | undefined {
+	if (tokens[0] === "plan-review" && tokens[1] === "agent" && tokens[2] === "next" && tokens[3] && !tokens[3].startsWith("-")) return tokens[3];
+	if (tokens[0] === "plan-review" && tokens[1] === "queue" && tokens[2] === "list") return getOptionValue(tokens, "--plan-id");
+	if (tokens[0] === "plan-review" && tokens[1] === "queue" && tokens[2] === "claim") return tokens[3] && !tokens[3].startsWith("-") ? tokens[3] : undefined;
+	return undefined;
+}
+
+function planIdMatches(tokens: string[], state: Partial<PlanModeState> = {}): boolean {
+	if (!state.currentPlanId) return Boolean(commandPlanId(tokens));
+	return commandPlanId(tokens) === state.currentPlanId;
+}
+
+function isAllowedHealthCommand(tokens: string[]): boolean {
+	if (tokens[0] !== "curl") return false;
+	const urls = tokens.filter((token) => /^https?:\/\//i.test(token));
+	if (urls.length !== 1 || !serviceUrlAllowed(urls[0], "/health")) return false;
+	const harmlessFlags = new Set(["-f", "-s", "-S", "-L", "-i", "--fail", "--silent", "--show-error", "--location", "--include"]);
+	return tokens.every((token) => token === "curl" || token === urls[0] || /^-[fsSLi]+$/.test(token) || harmlessFlags.has(token));
+}
+
+function hasPackageScript(cwd: string, scriptName: string): boolean {
+	try {
+		const packageJson = JSON.parse(readFileSync(resolve(cwd, "package.json"), "utf8")) as { scripts?: Record<string, unknown> };
+		return typeof packageJson.scripts?.[scriptName] === "string";
+	} catch {
+		return false;
+	}
+}
+
+function isAllowedPlanNodeCommand(cwd: string, tokens: string[]): boolean {
+	if (tokens[0] !== "node" || tokens.length < 3) return false;
+	const resolvedScript = resolveFromCwd(cwd, tokens[1]);
+	if (!existsSync(resolvedScript)) return false;
+	if (!isWithin(resolve(cwd, "scripts/plans"), resolvedScript)) return false;
+	const scriptName = basename(resolvedScript);
+	if (scriptName !== "validate-html-plan.mjs" && scriptName !== "check-plan-authority.mjs" && !/^(validate|check)-[A-Za-z0-9._-]+\.mjs$/.test(scriptName)) return false;
+	let sawPlan = false;
+	for (const token of tokens.slice(2)) {
+		if (token.startsWith("-")) return false;
+		sawPlan = true;
+		if (!isHtmlPlanFilePath(cwd, token)) return false;
+	}
+	return sawPlan;
+}
+
+function isAllowedPlanServerCommand(cwd: string, tokens: string[]): boolean {
+	if (tokens[0] !== "npm" || tokens[1] !== "run" || tokens[2] !== "plans:serve") return false;
+	if (!hasPackageScript(cwd, "plans:serve")) return false;
+	if (!hasFlag(tokens, "--check")) return false;
+	const planValues = getOptionValues(tokens, "--plan");
+	return planValues.length > 0
+		&& planValues.every((planPath) => isHtmlPlanFilePath(cwd, planPath))
+		&& validateRemainingTokens(tokens, 3, { valueFlags: new Set(["--plan"]), booleanFlags: new Set(["--", "--check"]) });
+}
+
+function isAllowedServiceStartupOrOpen(tokens: string[]): boolean {
+	if (tokens[0] === "brew") return tokens[1] === "services" && tokens[2] === "start" && tokens[3] === "plan-reviewer" && tokens.length === 4;
+	if (tokens[0] === "open") return tokens.length === 2 && /^http:\/\/mbp\.braid-python\.ts\.net:4317(?:\/\S*)?$/i.test(tokens[1]);
+	return false;
+}
+
+function isAllowedRegister(cwd: string, tokens: string[]): boolean {
+	if (tokens[1] !== "register") return false;
+	const executionReadyValues = getOptionValues(tokens, "--execution-ready");
+	if (executionReadyValues.length !== 1 || !["true", "false"].includes(executionReadyValues[0])) return false;
+	const flagsWithValues = new Set(["--repo", "--branch", "--commit", "--execution-ready", "--url"]);
+	const booleanFlags = new Set(["--json", "--snapshot", "--new-thread"]);
+	const planFiles: string[] = [];
+	for (let i = 2; i < tokens.length; i += 1) {
+		const token = tokens[i];
+		if (token.includes("=")) {
+			const flag = token.slice(0, token.indexOf("="));
+			if (flagsWithValues.has(flag)) continue;
+		}
+		if (flagsWithValues.has(token)) {
+			i += 1;
+			continue;
+		}
+		if (booleanFlags.has(token)) continue;
+		if (token.startsWith("-")) return false;
+		planFiles.push(token);
+	}
+	return planFiles.length === 1 && isHtmlPlanFilePath(cwd, planFiles[0]) && allPlanReviewUrlsAllowed(tokens);
+}
+
+function isAgentNextDrain(tokens: string[], state: Partial<PlanModeState> = {}): boolean {
+	return tokens[1] === "agent"
+		&& tokens[2] === "next"
+		&& Boolean(commandPlanId(tokens))
+		&& planIdMatches(tokens, state)
+		&& hasFlag(tokens, "--no-wait")
+		&& hasFlag(tokens, "--json")
+		&& !hasFlag(tokens, "--wait")
+		&& allPlanReviewUrlsAllowed(tokens)
+		&& validateRemainingTokens(tokens, 4, { valueFlags: new Set(["--url", "--timeout", "--lease-seconds"]), booleanFlags: new Set(["--no-wait", "--json"]) });
+}
+
+function isAllowedPlanReviewListenerCommand(command: string, state: Partial<PlanModeState> = {}): boolean {
+	const tokens = parseCommandArgs(command.trim());
+	return tokens[0] === "plan-review"
+		&& tokens[1] === "agent"
+		&& tokens[2] === "next"
+		&& Boolean(commandPlanId(tokens))
+		&& planIdMatches(tokens, state)
+		&& hasFlag(tokens, "--wait")
+		&& hasFlag(tokens, "--json")
+		&& !hasFlag(tokens, "--no-wait")
+		&& allPlanReviewUrlsAllowed(tokens)
+		&& validateRemainingTokens(tokens, 4, { valueFlags: new Set(["--url", "--timeout", "--lease-seconds"]), booleanFlags: new Set(["--wait", "--json"]) });
+}
+
+function isAllowedQueueLifecycle(cwd: string, tokens: string[], state: Partial<PlanModeState> = {}): boolean {
+	const subcommand = tokens[1];
+	if (subcommand === "queue") {
+		if (tokens[2] !== "list" && tokens[2] !== "claim") return false;
+		if (!commandPlanId(tokens)) return false;
+		const startIndex = tokens[2] === "claim" ? 4 : 3;
+		return planIdMatches(tokens, state)
+			&& changedFilesAreThoughts(cwd, tokens)
+			&& allPlanReviewUrlsAllowed(tokens)
+			&& validateRemainingTokens(tokens, startIndex, { valueFlags: new Set(["--url", "--plan-id", "--ids", "--limit", "--lease-seconds", "--changed-files"]), booleanFlags: new Set(["--json", "--all", "--one"]) });
+	}
+	const commentId = tokens[2];
+	if (!commentId || !changedFilesAreThoughts(cwd, tokens) || !allPlanReviewUrlsAllowed(tokens)) return false;
+	if (!validateRemainingTokens(tokens, 3, { valueFlags: new Set(["--url", "--claim", "--note", "--summary", "--changed-files", "--reason"]), booleanFlags: new Set(["--json"]) })) return false;
+	if (subcommand === "ack") return commentId === state.activeCommentId && getOptionValue(tokens, "--claim") === state.activeClaimId;
+	if (subcommand === "release") return commentId === state.activeCommentId && getOptionValue(tokens, "--claim") === state.activeClaimId;
+	if (subcommand === "resolve") return commentId === state.acknowledgedCommentId;
+	return false;
+}
+
+function isAllowedPlanReviewCommand(cwd: string, tokens: string[], state: Partial<PlanModeState> = {}): boolean {
+	if (tokens[0] !== "plan-review") return false;
+	if (tokens[1] === "watch") return false;
+	if (tokens[1] === "index") return tokens.length === 2;
+	if (tokens[1] === "register") return isAllowedRegister(cwd, tokens);
+	if (tokens[1] === "agent" && tokens[2] === "next") return isAgentNextDrain(tokens, state);
+	if (tokens[1] === "queue" || tokens[1] === "ack" || tokens[1] === "resolve" || tokens[1] === "release") return isAllowedQueueLifecycle(cwd, tokens, state);
+	return false;
+}
+
+function isSafeCommand(cwd: string, command: string, state: Partial<PlanModeState> = {}): boolean {
+	const normalized = command.trim();
+	if (hasShellHazards(normalized)) return false;
+	const tokens = parseCommandArgs(normalized);
+	if (tokens.length === 0) return false;
+	if (isAllowedPlanReviewCommand(cwd, tokens, state)) return true;
+	if (isAllowedHealthCommand(tokens)) return true;
+	if (tokens[0] === "curl") return false;
+	if (isAllowedPlanNodeCommand(cwd, tokens)) return true;
+	if (isAllowedPlanServerCommand(cwd, tokens)) return true;
+	if (isAllowedServiceStartupOrOpen(tokens)) return true;
+	const destructive = DESTRUCTIVE_PATTERNS.some((pattern) => pattern.test(normalized));
+	const safe = SAFE_BASH_PATTERNS.some((pattern) => pattern.test(normalized));
+	return !destructive && safe;
+}
+
+function noteClaimFromText(previousState: Partial<PlanModeState>, text: string): Partial<PlanModeState> {
+	let payload: Record<string, unknown> | undefined;
+	try {
+		payload = JSON.parse(text) as Record<string, unknown>;
+	} catch {
+		const match = text.match(/\{[\s\S]*\}/);
+		if (!match) return {};
+		try {
+			payload = JSON.parse(match[0]) as Record<string, unknown>;
+		} catch {
+			return {};
+		}
+	}
+	const directClaim = payload?.status === "claimed" ? payload : undefined;
+	const listedClaim = Array.isArray(payload?.claimed) ? payload.claimed[0] as Record<string, unknown> | undefined : undefined;
+	const listedNestedClaim = listedClaim?.claim as Record<string, unknown> | undefined;
+	const directNestedClaim = directClaim?.claim as Record<string, unknown> | undefined;
+	const commentId = directClaim?.commentId ?? directClaim?.id ?? listedClaim?.commentId ?? listedClaim?.id;
+	const claimId = directClaim?.claimId ?? directNestedClaim?.id ?? listedClaim?.claimId ?? listedNestedClaim?.id;
+	if (typeof commentId !== "string" || typeof claimId !== "string") return {};
+	return { ...previousState, activeCommentId: commentId, activeClaimId: claimId, acknowledgedCommentId: undefined };
+}
+
+function transitionClaimLifecycle(state: Partial<PlanModeState>, command: string): Partial<PlanModeState> {
+	const tokens = parseCommandArgs(command.trim());
+	if (tokens[0] !== "plan-review") return state;
+	const subcommand = tokens[1];
+	const commentId = tokens[2];
+	if (subcommand === "ack" && commentId === state.activeCommentId && getOptionValue(tokens, "--claim") === state.activeClaimId) {
+		return { ...state, activeCommentId: undefined, activeClaimId: undefined, acknowledgedCommentId: commentId };
+	}
+	if (subcommand === "resolve" && commentId === state.acknowledgedCommentId) {
+		return { ...state, activeCommentId: undefined, activeClaimId: undefined, acknowledgedCommentId: undefined };
+	}
+	if (subcommand === "release" && commentId === state.activeCommentId && getOptionValue(tokens, "--claim") === state.activeClaimId) {
+		return { ...state, activeCommentId: undefined, activeClaimId: undefined, acknowledgedCommentId: undefined };
+	}
+	return state;
+}
+
+function isFinishedProcessOutput(text: string): boolean {
+	return /\[(?:exit\(\d+\)|killed|failed|crashed)\]/i.test(text) || /\b(exit|completed|terminated)\b/i.test(text);
+}
+
 function toolResultToText(content: unknown): string {
 	if (typeof content === "string") return content;
 	if (Array.isArray(content)) {
@@ -484,6 +731,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 	let currentPlanReviewUrl: string | undefined;
 	let currentPlanId: string | undefined;
 	let currentPlanListenerProcessId: string | undefined;
+	let activeCommentId: string | undefined;
+	let activeClaimId: string | undefined;
+	let acknowledgedCommentId: string | undefined;
 	let savedActiveTools: string[] | undefined;
 	let reviewCycles = 0;
 	let reviewInFlight = false;
@@ -500,6 +750,23 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		return pi.getAllTools().map((tool) => tool.name);
 	}
 
+	function getCommandState(): PlanModeState {
+		return {
+			enabled: planModeEnabled,
+			currentPlanPath,
+			currentPlanReviewUrl,
+			currentPlanId,
+			currentPlanListenerProcessId,
+			activeCommentId,
+			activeClaimId,
+			acknowledgedCommentId,
+			savedActiveTools,
+			reviewCycles,
+			lastReviewCommand,
+			preferredStandardReviewCommand,
+		};
+	}
+
 	function persistState(): void {
 		pi.appendEntry(PLAN_STATE_TYPE, {
 			enabled: planModeEnabled,
@@ -507,6 +774,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 			currentPlanReviewUrl,
 			currentPlanId,
 			currentPlanListenerProcessId,
+			activeCommentId,
+			activeClaimId,
+			acknowledgedCommentId,
 			savedActiveTools,
 			reviewCycles,
 			lastReviewCommand,
@@ -524,6 +794,11 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		const planLabel = currentPlanPath ?? "no plan file yet";
 		const urlLabel = currentPlanReviewUrl ?? "not registered yet";
 		const listenerLabel = currentPlanListenerProcessId ?? "not running/unknown";
+		const claimLabel = activeCommentId && activeClaimId
+			? acknowledgedCommentId === activeCommentId
+				? `acknowledged ${activeCommentId} (${activeClaimId})`
+				: `active ${activeCommentId} (${activeClaimId})`
+			: "none";
 		const displayedCycles = Math.min(reviewCycles, MAX_REVIEW_CYCLES);
 		const cycleLabel = reviewCycles > 0 ? ` • review ${displayedCycles}/${MAX_REVIEW_CYCLES}` : "";
 		const status = reviewInFlight ? `🧪 plan review${cycleLabel}` : `📝 plan${cycleLabel}`;
@@ -533,6 +808,7 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 			ctx.ui.theme.fg("muted", `Current plan: ${planLabel}`),
 			ctx.ui.theme.fg("muted", `Plan URL: ${urlLabel}`),
 			ctx.ui.theme.fg("muted", `Comment listener: ${listenerLabel}`),
+			ctx.ui.theme.fg("muted", `Active claim: ${claimLabel}`),
 			ctx.ui.theme.fg("muted", `Writes allowed only under ${PLAN_ROOT}/`),
 		]);
 	}
@@ -564,10 +840,19 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		ctx.ui.notify(`Plan mode enabled.${planNote}`, "info");
 	}
 
+	function getExecutionBlockReason(): string | undefined {
+		const blockers: string[] = [];
+		if (currentPlanListenerProcessId) {
+			blockers.push(`Stop the active plan-review comment listener before execution: process kill ${currentPlanListenerProcessId}.`);
+		}
+		if (activeCommentId && activeClaimId && !acknowledgedCommentId) {
+			blockers.push(`Resolve or release the active browser comment claim before execution: ${activeCommentId} (${activeClaimId}).`);
+		}
+		return blockers.length > 0 ? blockers.join(" ") : undefined;
+	}
+
 	function getListenerCleanupMessage(): string | undefined {
-		return currentPlanListenerProcessId
-			? `Stop the active plan-review comment listener before execution: process kill ${currentPlanListenerProcessId}.`
-			: undefined;
+		return getExecutionBlockReason();
 	}
 
 	function disablePlanMode(ctx: ExtensionContext): void {
@@ -675,6 +960,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		currentPlanReviewUrl = undefined;
 		currentPlanId = undefined;
 		currentPlanListenerProcessId = undefined;
+		activeCommentId = undefined;
+		activeClaimId = undefined;
+		acknowledgedCommentId = undefined;
 		savedActiveTools = undefined;
 		reviewCycles = 0;
 		lastReviewCommand = undefined;
@@ -692,6 +980,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 			currentPlanReviewUrl = stateEntry.data.currentPlanReviewUrl;
 			currentPlanId = stateEntry.data.currentPlanId;
 			currentPlanListenerProcessId = stateEntry.data.currentPlanListenerProcessId;
+			activeCommentId = stateEntry.data.activeCommentId;
+			activeClaimId = stateEntry.data.activeClaimId;
+			acknowledgedCommentId = stateEntry.data.acknowledgedCommentId;
 			savedActiveTools = stateEntry.data.savedActiveTools;
 			reviewCycles = stateEntry.data.reviewCycles ?? 0;
 			lastReviewCommand = stateEntry.data.lastReviewCommand;
@@ -712,6 +1003,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 				currentPlanReviewUrl = undefined;
 				currentPlanId = undefined;
 				currentPlanListenerProcessId = undefined;
+				activeCommentId = undefined;
+				activeClaimId = undefined;
+				acknowledgedCommentId = undefined;
 				reviewCycles = 0;
 				lastReviewCommand = undefined;
 				preferredStandardReviewCommand = undefined;
@@ -846,9 +1140,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		if (!planModeEnabled) return { action: "continue" };
 
 		if (text.startsWith(`/${EXECUTE_PLAN_COMMAND}`) || text.startsWith("/dev:run") || text.startsWith("/skill:adn-dev-wf") || text.startsWith("/ralph:run")) {
-			const listenerCleanupMessage = getListenerCleanupMessage();
-			if (listenerCleanupMessage) {
-				ctx.ui.notify(listenerCleanupMessage, "warning");
+			const executionBlockReason = getExecutionBlockReason();
+			if (executionBlockReason) {
+				ctx.ui.notify(executionBlockReason, "warning");
 				return { action: "block" };
 			}
 			disablePlanMode(ctx);
@@ -901,9 +1195,12 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 	pi.on("before_agent_start", async (_event) => {
 		if (!planModeEnabled) return;
 
+		const activeClaimInstruction = activeCommentId && activeClaimId
+			? ` Active browser comment claim: ${activeCommentId} (${activeClaimId})${acknowledgedCommentId === activeCommentId ? " is acknowledged; resolve it before restarting the listener." : " is unacknowledged; ack, release, or resolve it before execution."}`
+			: " No active browser comment claim.";
 		const currentPlanInstruction = currentPlanPath
-			? `Current plan file: ${currentPlanPath}. Continue evolving that file unless the user explicitly asks for a different one. Current browser review URL: ${currentPlanReviewUrl ?? "not registered yet"}.`
-			: `If you create a new plan, write it to ${PLAN_DIRECTORY}/<slug>.html.`;
+			? `Current plan file: ${currentPlanPath}. Continue evolving that file unless the user explicitly asks for a different one. Current browser review URL: ${currentPlanReviewUrl ?? "not registered yet"}.${activeClaimInstruction}`
+			: `If you create a new plan, write it to ${PLAN_DIRECTORY}/<slug>.html.${activeClaimInstruction}`;
 
 		return {
 			message: {
@@ -940,7 +1237,7 @@ ${currentPlanInstruction}`,
 
 		if (event.toolName === "bash") {
 			const command = String(event.input.command ?? "");
-			if (!isSafeCommand(command)) {
+			if (!isSafeCommand(ctx.cwd, command, getCommandState())) {
 				return {
 					block: true,
 					reason: `Plan mode only allows read-only bash commands. Use edit/write within ${PLAN_ROOT}/ for plan files.`,
@@ -953,7 +1250,7 @@ ${currentPlanInstruction}`,
 			const command = String(event.input.command ?? "");
 			const id = typeof event.input.id === "string" ? event.input.id : undefined;
 			const readOnlyActions = new Set(["list", "output", "logs"]);
-			const allowedStart = action === "start" && /^\s*plan-review\s+agent\s+next\b/i.test(command) && isAllowedPlanReviewCommand(command);
+			const allowedStart = action === "start" && isAllowedPlanReviewListenerCommand(command, getCommandState());
 			const allowedKill = action === "kill" && id !== undefined && id === currentPlanListenerProcessId;
 
 			if (!readOnlyActions.has(action) && !allowedStart && !allowedKill) {
@@ -988,9 +1285,28 @@ ${currentPlanInstruction}`,
 				return;
 			}
 			if (event.isError) return;
-			if (action === "start" && isPlanReviewListenerCommand(command)) {
-				const match = toolResultToText(event.content).match(/\b(proc_\w+)/);
-				currentPlanListenerProcessId = match?.[1] ?? currentPlanListenerProcessId;
+			const text = toolResultToText(event.content);
+			if (action === "start" && isAllowedPlanReviewListenerCommand(command, getCommandState())) {
+				const details = (event as unknown as { details?: { id?: string; processId?: string } }).details;
+				const match = text.match(/\b(proc_\w+)/);
+				currentPlanListenerProcessId = details?.id ?? details?.processId ?? match?.[1] ?? currentPlanListenerProcessId;
+				const claimState = noteClaimFromText(getCommandState(), text);
+				activeCommentId = claimState.activeCommentId ?? activeCommentId;
+				activeClaimId = claimState.activeClaimId ?? activeClaimId;
+				acknowledgedCommentId = claimState.acknowledgedCommentId;
+				updateUi(ctx);
+				persistState();
+				return;
+			}
+			if ((action === "output" || action === "logs") && event.input.id === currentPlanListenerProcessId) {
+				const claimState = noteClaimFromText(getCommandState(), text);
+				const capturedClaim = Boolean(claimState.activeCommentId && claimState.activeClaimId);
+				activeCommentId = claimState.activeCommentId ?? activeCommentId;
+				activeClaimId = claimState.activeClaimId ?? activeClaimId;
+				acknowledgedCommentId = claimState.acknowledgedCommentId ?? acknowledgedCommentId;
+				if (capturedClaim || isFinishedProcessOutput(text)) {
+					currentPlanListenerProcessId = undefined;
+				}
 				updateUi(ctx);
 				persistState();
 			}
@@ -1001,8 +1317,9 @@ ${currentPlanInstruction}`,
 
 		if (event.toolName === "bash") {
 			const command = String(event.input.command ?? "");
+			const text = toolResultToText(event.content);
 			if (/^\s*plan-review\s+register\b/i.test(command)) {
-				const registration = parsePlanReviewRegistrationOutput(toolResultToText(event.content));
+				const registration = parsePlanReviewRegistrationOutput(text);
 				if (registration.reviewUrl) {
 					currentPlanReviewUrl = registration.reviewUrl;
 					currentPlanId = registration.planId ?? currentPlanId;
@@ -1012,6 +1329,20 @@ ${currentPlanInstruction}`,
 					updateUi(ctx);
 					persistState();
 				}
+			} else if (/^\s*plan-review\s+agent\s+next\b/i.test(command)) {
+				const claimState = noteClaimFromText(getCommandState(), text);
+				activeCommentId = claimState.activeCommentId ?? activeCommentId;
+				activeClaimId = claimState.activeClaimId ?? activeClaimId;
+				acknowledgedCommentId = claimState.acknowledgedCommentId;
+				updateUi(ctx);
+				persistState();
+			} else if (/^\s*plan-review\s+(ack|resolve|release)\b/i.test(command)) {
+				const nextState = transitionClaimLifecycle(getCommandState(), command);
+				activeCommentId = nextState.activeCommentId;
+				activeClaimId = nextState.activeClaimId;
+				acknowledgedCommentId = nextState.acknowledgedCommentId;
+				updateUi(ctx);
+				persistState();
 			}
 			return;
 		}

--- a/_pi/extensions/pi-plan-mode/index.ts
+++ b/_pi/extensions/pi-plan-mode/index.ts
@@ -15,6 +15,7 @@ const GLOBAL_PROMPTS_DIRECTORY = resolve(homedir(), ".pi/agent/prompts");
 const EXECUTE_PLAN_COMMAND = "cmd:execute-plan";
 const STANDARD_PLAN_REVIEW_COMMAND = "review:plan";
 const CHANGE_REVIEW_COMMAND = "review:change";
+const CLAUDE_CHANGE_REVIEW_COMMAND = "review:change-claude-code";
 const ADVERSARIAL_PLAN_REVIEW_COMMAND = "review:plan-adversarial";
 const CHANGE_REVIEW_INTEGRATE_COMMAND = "review:change-integrate";
 const MAX_REVIEW_CYCLES = 3;
@@ -373,6 +374,12 @@ function isHtmlPlanFilePath(cwd: string, inputPath: string): boolean {
 	return isWithin(getPlansRoot(cwd), resolved) && /\.html$/i.test(resolved);
 }
 
+function isClaudeReviewTempPath(inputPath: string, extension: ".txt" | ".md"): boolean {
+	const resolved = resolve(inputPath);
+	const name = basename(resolved);
+	return resolved === `/tmp/${name}` && new RegExp(`^pi-claude-review-[A-Za-z0-9._-]+\\${extension}$`).test(name);
+}
+
 function hasShellHazards(command: string): boolean {
 	return /[\r\n;&|`<>]/.test(command) || /\$\(/.test(command) || />>/.test(command);
 }
@@ -582,12 +589,31 @@ function isAllowedPlanReviewCommand(cwd: string, tokens: string[], state: Partia
 	return false;
 }
 
+function isAllowedClaudeReviewLauncherCommand(cwd: string, tokens: string[]): boolean {
+	if (tokens[0] !== "python3" || tokens.length !== 12) return false;
+	const launcherPaths = new Set([
+		"$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py",
+		resolve(homedir(), ".agents/skills/claude-code-review/scripts/claude_interactive_review.py"),
+	]);
+	if (!launcherPaths.has(tokens[1])) return false;
+	const expectedFlags = ["--cwd", "--prompt-file", "--output", "--review-name", "--timeout-seconds"];
+	for (let index = 2; index < tokens.length; index += 2) {
+		if (tokens[index] !== expectedFlags[(index - 2) / 2]) return false;
+	}
+	if (tokens[3] !== "$PWD" && tokens[3] !== cwd) return false;
+	if (!isClaudeReviewTempPath(tokens[5], ".txt")) return false;
+	if (!isClaudeReviewTempPath(tokens[7], ".md")) return false;
+	if (!/^[A-Za-z0-9._-]+$/.test(tokens[9])) return false;
+	return /^\d+$/.test(tokens[11]);
+}
+
 function isSafeCommand(cwd: string, command: string, state: Partial<PlanModeState> = {}): boolean {
 	const normalized = command.trim();
 	if (hasShellHazards(normalized)) return false;
 	const tokens = parseCommandArgs(normalized);
 	if (tokens.length === 0) return false;
 	if (isAllowedPlanReviewCommand(cwd, tokens, state)) return true;
+	if (isAllowedClaudeReviewLauncherCommand(cwd, tokens)) return true;
 	if (isAllowedHealthCommand(tokens)) return true;
 	if (tokens[0] === "curl") return false;
 	if (isAllowedPlanNodeCommand(cwd, tokens)) return true;
@@ -627,7 +653,7 @@ function transitionClaimLifecycle(state: Partial<PlanModeState>, command: string
 	const subcommand = tokens[1];
 	const commentId = tokens[2];
 	if (subcommand === "ack" && commentId === state.activeCommentId && getOptionValue(tokens, "--claim") === state.activeClaimId) {
-		return { ...state, activeCommentId: undefined, activeClaimId: undefined, acknowledgedCommentId: commentId };
+		return { ...state, acknowledgedCommentId: commentId };
 	}
 	if (subcommand === "resolve" && commentId === state.acknowledgedCommentId) {
 		return { ...state, activeCommentId: undefined, activeClaimId: undefined, acknowledgedCommentId: undefined };
@@ -845,8 +871,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		if (currentPlanListenerProcessId) {
 			blockers.push(`Stop the active plan-review comment listener before execution: process kill ${currentPlanListenerProcessId}.`);
 		}
-		if (activeCommentId && activeClaimId && !acknowledgedCommentId) {
-			blockers.push(`Resolve or release the active browser comment claim before execution: ${activeCommentId} (${activeClaimId}).`);
+		if (activeCommentId && activeClaimId) {
+			const claimState = acknowledgedCommentId === activeCommentId ? "acknowledged" : "active";
+			blockers.push(`Resolve or release the ${claimState} browser comment claim before execution: ${activeCommentId} (${activeClaimId}).`);
 		}
 		return blockers.length > 0 ? blockers.join(" ") : undefined;
 	}
@@ -1165,10 +1192,13 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 			text.startsWith(`/${ADVERSARIAL_PLAN_REVIEW_COMMAND}`)
 			|| text.startsWith(`/${STANDARD_PLAN_REVIEW_COMMAND}`)
 			|| text.startsWith(`/${CHANGE_REVIEW_COMMAND}`)
+			|| text.startsWith(`/${CLAUDE_CHANGE_REVIEW_COMMAND}`)
 		) {
 			reviewInFlight = true;
 			if (text.startsWith(`/${ADVERSARIAL_PLAN_REVIEW_COMMAND}`)) {
 				lastReviewCommand = ADVERSARIAL_PLAN_REVIEW_COMMAND;
+			} else if (text.startsWith(`/${CLAUDE_CHANGE_REVIEW_COMMAND}`)) {
+				lastReviewCommand = CLAUDE_CHANGE_REVIEW_COMMAND;
 			} else {
 				const standardReviewCommand = text.startsWith(`/${CHANGE_REVIEW_COMMAND}`)
 					? CHANGE_REVIEW_COMMAND
@@ -1210,10 +1240,10 @@ You are in planning mode for this repository.
 
 Constraints:
 - Read the codebase freely.
-- You may write only under ${PLAN_ROOT}/ using edit/write tools.
+- You may write only under ${PLAN_ROOT}/ using edit/write tools, except transient Claude review prompt files matching /tmp/pi-claude-review-*.txt during review commands.
 - Keep plan files in ${PLAN_DIRECTORY}/.
 - Do not make implementation changes outside ${PLAN_ROOT}/.
-- Use read-only bash commands for exploration; file mutations must go through edit/write inside ${PLAN_ROOT}/.
+- Use read-only bash commands for exploration; file mutations must go through edit/write inside ${PLAN_ROOT}/, except the transient Claude review prompt file exception above.
 - Load and follow the planning skills needed for deterministic HTML planning: planning-workflow, html-plan-reviewer, reviewed-html-plan, product-principles for workflow-impacting plans, plus relevant domain skills.
 - Plans should align with thoughts/specs/product_intent.md and thoughts/plans/AGENTS.md when relevant.
 - New active plans should be semantic HTML under ${PLAN_DIRECTORY}/<slug>.html unless the user explicitly supplies an existing legacy Markdown plan.
@@ -1263,10 +1293,11 @@ ${currentPlanInstruction}`,
 
 		if (event.toolName === "edit" || event.toolName === "write") {
 			const inputPath = typeof event.input.path === "string" ? event.input.path : "";
-			if (!inputPath || !isThoughtsPath(ctx.cwd, inputPath)) {
+			const allowedClaudeReviewPrompt = reviewInFlight && isClaudeReviewTempPath(inputPath, ".txt");
+			if (!inputPath || (!isThoughtsPath(ctx.cwd, inputPath) && !allowedClaudeReviewPrompt)) {
 				return {
 					block: true,
-					reason: `Plan mode only allows edit/write under ${PLAN_ROOT}/.`,
+					reason: `Plan mode only allows edit/write under ${PLAN_ROOT}/, except transient Claude review prompt files under /tmp.`,
 				};
 			}
 		}
@@ -1291,9 +1322,13 @@ ${currentPlanInstruction}`,
 				const match = text.match(/\b(proc_\w+)/);
 				currentPlanListenerProcessId = details?.id ?? details?.processId ?? match?.[1] ?? currentPlanListenerProcessId;
 				const claimState = noteClaimFromText(getCommandState(), text);
+				const capturedClaim = Boolean(claimState.activeCommentId && claimState.activeClaimId);
 				activeCommentId = claimState.activeCommentId ?? activeCommentId;
 				activeClaimId = claimState.activeClaimId ?? activeClaimId;
 				acknowledgedCommentId = claimState.acknowledgedCommentId;
+				if (capturedClaim || isFinishedProcessOutput(text)) {
+					currentPlanListenerProcessId = undefined;
+				}
 				updateUi(ctx);
 				persistState();
 				return;
@@ -1358,6 +1393,10 @@ ${currentPlanInstruction}`,
 		if (nextPlanPath !== currentPlanPath) {
 			currentPlanReviewUrl = undefined;
 			currentPlanId = undefined;
+			currentPlanListenerProcessId = undefined;
+			activeCommentId = undefined;
+			activeClaimId = undefined;
+			acknowledgedCommentId = undefined;
 		}
 		currentPlanPath = nextPlanPath;
 		if (!reviewInFlight) {

--- a/_pi/prompts/review:change-claude-code.md
+++ b/_pi/prompts/review:change-claude-code.md
@@ -31,7 +31,7 @@ Smoke failure is a prerequisite/auth/readiness blocker from the real Pi caller c
 
 ## Review mode
 
-This command is review-only and should behave like `/review:change-opus`, except the Claude leg is required to use the canonical Claude Code launcher.
+This command is review-only and must use the canonical Claude Code launcher, which pins required Claude Code reviews to Sonnet 4.6.
 
 Your reviewer name is `CLAUDE`.
 

--- a/_pi/prompts/review:change-claude-code.md
+++ b/_pi/prompts/review:change-claude-code.md
@@ -14,17 +14,13 @@ Documents to review: $ARGUMENTS
 If `$ARGUMENTS` is exactly `--claude-smoke`, run this from the current Pi prompt context and stop after reporting the result:
 
 ```bash
-python3 "$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py" \
-  --smoke \
-  --cwd "$PWD" \
-  --review-name pi-review-change-smoke \
-  --output /tmp/pi-claude-review-smoke.txt
+python3 "$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py" --smoke --cwd "$PWD" --review-name pi-review-change-smoke --output /tmp/pi-claude-review-smoke.txt
 ```
 
 Pass condition:
 
 ```bash
-test -f /tmp/pi-claude-review-smoke.txt && rg -n "CLAUDE_REVIEW_SMOKE_READY|socket|session" /tmp/pi-claude-review-smoke.txt
+rg -n -e CLAUDE_REVIEW_SMOKE_READY -e socket -e session /tmp/pi-claude-review-smoke.txt
 ```
 
 Smoke failure is a prerequisite/auth/readiness blocker from the real Pi caller context. Preserve the output and inspect command. Do not retry with a different Claude transport.

--- a/_pi/prompts/review:change-claude-code.md
+++ b/_pi/prompts/review:change-claude-code.md
@@ -74,16 +74,11 @@ Review the provided plan as a cohesive unit. Decide whether it is ready to execu
 
 1. Resolve the plan path.
 2. Write the Claude review prompt to `/tmp/pi-claude-review-prompt.txt`.
-3. Run the shared launcher from the exact central path below.
+3. Run the shared launcher from the exact central path below as a single-line command, with no shell line continuations.
 4. Read `/tmp/pi-claude-review-output.md` after completion and validate whether Claude found blocker-level issues.
 
 ```bash
-python3 "$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py" \
-  --cwd "$PWD" \
-  --prompt-file /tmp/pi-claude-review-prompt.txt \
-  --output /tmp/pi-claude-review-output.md \
-  --review-name pi-review-change-claude \
-  --timeout-seconds 900
+python3 "$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py" --cwd "$PWD" --prompt-file /tmp/pi-claude-review-prompt.txt --output /tmp/pi-claude-review-output.md --review-name pi-review-change-claude --timeout-seconds 900
 ```
 
 The prompt written to `/tmp/pi-claude-review-prompt.txt` should instruct Claude Code to:

--- a/_pi/prompts/review:change-claude-code.md
+++ b/_pi/prompts/review:change-claude-code.md
@@ -1,180 +1,120 @@
 ---
-description: Run a review-only change review using Claude Code via interactive-shell hands-free, backgrounded
-argument-hint: '<existing-plan-path | plan slug | legacy: <spec> <tasks> | legacy: <directory containing spec.md and tasks.md>'
+description: Run a review-only change review using Claude Code through the canonical private-tmux interactive launcher
+argument-hint: '[--claude-smoke] <existing-plan-path | plan slug | legacy: <spec> <tasks> | legacy: <directory containing spec.md and tasks.md>'
 ---
 
 # Change Review via Claude Code
 
-Review the provided plan by launching real interactive Claude Code through `interactive_shell`.
-
-This command is review-only and should behave like `/review:change-opus`, except the review runs inside Claude Code via `interactive_shell`.
+Run a read-only Claude Code review through the shared canonical launcher. Do not launch Claude Code directly from this prompt. Do not use `interactive_shell` for Claude, direct `process`/`bash` snippets, `claude -p` [FORBIDDEN-EXAMPLE], `claude --print` [FORBIDDEN-EXAMPLE], prompt piping, or any fallback transport.
 
 Documents to review: $ARGUMENTS
 
-## Execution Mode
+## Smoke mode
 
-- Use `interactive_shell`, not `process`, to launch Claude Code.
-- Start exactly one real interactive Claude Code session and run a Claude Code review prompt against the target plan file.
-- Launch Claude Code through a login shell so PATH entries supplied by shell startup files are available (for example `zsh -lic` on macOS where `claude` may live in `~/.local/bin`).
-- If needed, prepend `export PATH="$HOME/.local/bin:$PATH"` before invoking `claude`.
-- Use `mode: "hands-free"`, not `dispatch`, so the launch creates a real Claude Code TUI session that can then be backgrounded.
-- Set `handsFree.autoExitOnQuiet: false` because interactive Claude does not exit on its own after answering.
-- Do not launch retry sessions just because stdout/stderr stays empty.
-- Do not inline the full Claude review prompt directly inside shell quotes. Instead, write the prompt body to `/tmp/pi-claude-review-prompt.txt`, write the exact Python wrapper below to `/tmp/pi-claude-review-wrapper.py`, and launch that wrapper through `interactive_shell`.
-- Immediately move the launched Claude session to the background.
-- Run a single Claude Code session that:
-  1. resolves the target plan file,
-  2. reviews the plan as a cohesive unit,
-  3. adds inline review comments using the `[REVIEW:CLAUDE] ... [/REVIEW]` format only for blockers, material risks, or missing decisions it finds,
-  4. does not rewrite or integrate the plan, and
-  5. stops after the review summary.
-- Do not delegate the review to a `reviewer-*` subagent.
-- Wait for the Claude Code interactive session to finish, then verify the resulting plan file in this session.
+If `$ARGUMENTS` is exactly `--claude-smoke`, run this from the current Pi prompt context and stop after reporting the result:
 
-Your reviewer name is CLAUDE
-
-Use this comment format:
+```bash
+python3 "$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py" \
+  --smoke \
+  --cwd "$PWD" \
+  --review-name pi-review-change-smoke \
+  --output /tmp/pi-claude-review-smoke.txt
 ```
+
+Pass condition:
+
+```bash
+test -f /tmp/pi-claude-review-smoke.txt && rg -n "CLAUDE_REVIEW_SMOKE_READY|socket|session" /tmp/pi-claude-review-smoke.txt
+```
+
+Smoke failure is a prerequisite/auth/readiness blocker from the real Pi caller context. Preserve the output and inspect command. Do not retry with a different Claude transport.
+
+## Review mode
+
+This command is review-only and should behave like `/review:change-opus`, except the Claude leg is required to use the canonical Claude Code launcher.
+
+Your reviewer name is `CLAUDE`.
+
+Use this inline-comment-compatible format for material plan findings in Claude's returned review text:
+
+```text
 [REVIEW:CLAUDE] Your critical feedback here [/REVIEW]
 ```
 
-To respond to other reviewers:
-```
+To respond to other reviewers in returned review text:
+
+```text
 [REVIEW:CLAUDE] RE: [OtherReviewer] - Your response [/REVIEW]
 ```
 
-# Change Review (Single Plan File)
+The launcher is review-output-only. Claude must not edit the plan file directly; if inline plan comments are needed, report copyable `[REVIEW:CLAUDE] ... [/REVIEW]` comments in `/tmp/pi-claude-review-output.md`.
 
-Review the provided plan as a cohesive unit. Your goal is to decide whether it is ready to execute within its stated goal and non-goals, flagging only blockers, material risks, or missing decisions that would change that readiness.
+## Scope
 
-Documents to review: $ARGUMENTS
+Review the provided plan as a cohesive unit. Decide whether it is ready to execute within its stated goal and non-goals. Flag only blockers, material risks, or missing decisions that would change execution readiness.
 
-## Scope (Review-Only; Do Not Integrate)
-
-This command is review-only.
-
-- Only modify the plan by inserting inline `[REVIEW:...] ... [/REVIEW]` comments.
-- HTML plans are first-class inputs; keep them as valid semantic HTML and insert review comments visibly without converting the plan to Markdown.
-- Do not change any other plan content (do not fix, rewrite, or reorganize anything).
+- This command is review-only.
+- Do not integrate or rewrite the plan.
+- For HTML plans, keep the HTML artifact authoritative and do not convert it to Markdown.
+- Only return copyable inline `[REVIEW:CLAUDE] ... [/REVIEW]` comments when blocker-level feedback is needed.
 - Do not remove or resolve review comments.
-- Do not run follow-up commands (including `/review:change-integrate`).
-- Only add a comment for blockers, material risks, or missing decisions required to execute the plan's stated goal while honoring its non-goals.
-- Do not comment on nice-to-haves, opportunistic cleanup, adjacent surfaces not required by the requested scope, or extra detail that would not change execution readiness.
-- After adding comments and providing the summary, stop.
+- Do not run follow-up integration commands.
+- Do not comment on nice-to-haves, opportunistic cleanup, adjacent surfaces, or extra detail that would not change execution readiness.
+- Do not delegate the Claude review to a subagent.
 
-## Process
+## Resolve inputs
 
-### 0) Resolve Inputs (Plan File, Slug, or Legacy Bundle)
-
-Preferred input:
-
-- A single plan file in the repo's active plan format
-
-Accept legacy inputs for migration only:
-
-- `<spec_path> <tasks_path>`
-- A directory containing `spec.md` and `tasks.md`
-
-Resolution rules:
-
-- If `$ARGUMENTS` starts with `@`, strip the leading `@` and treat as workspace-relative.
+- If `$ARGUMENTS` starts with `@`, strip the leading `@` and treat the rest as workspace-relative.
 - If a single argument is an existing plan file, treat it as `plan_path`.
-- If a single argument is a slug, resolve it using repo-local active plan guidance. Do not infer a markdown path; if guidance does not define slug resolution, ask for an explicit plan path.
-- Only migrate a legacy bundle when repo-local guidance explicitly allows migration to the repo's active plan format; otherwise ask for an explicit existing plan path.
+- If a single argument is a slug, resolve it using repo-local active plan guidance. Do not infer a Markdown path.
+- Accept legacy `<spec_path> <tasks_path>` or a directory containing `spec.md` and `tasks.md` only when repo-local guidance explicitly allows migration.
+- If multiple candidates match or a required file is missing, ask for an explicit plan file path.
 
-If multiple candidates match or a required file is missing, ask for an explicit plan file path.
+## Launch
 
-### 1) Launch Claude Code Directly
+1. Resolve the plan path.
+2. Write the Claude review prompt to `/tmp/pi-claude-review-prompt.txt`.
+3. Run the shared launcher from the exact central path below.
+4. Read `/tmp/pi-claude-review-output.md` after completion and validate whether Claude found blocker-level issues.
 
-Use `interactive_shell` to start one Claude Code session that performs the review.
-
-Prefer a login-shell launch shape such as:
-
-```javascript
-exec_command({
-  cmd: `cat > /tmp/pi-claude-review-prompt.txt <<'EOF'
-<prompt>
-EOF
-cat > /tmp/pi-claude-review-wrapper.py <<'PY'
-import os
-import subprocess
-import sys
-
-repo = sys.argv[1]
-prompt_path = sys.argv[2]
-with open(prompt_path, 'r', encoding='utf-8') as fh:
-    prompt = fh.read()
-
-cmd = [
-    'claude',
-    '--permission-mode', 'bypassPermissions',
-    '--effort', 'high',
-    prompt,
-]
-
-os.chdir(repo)
-os.execvp(cmd[0], cmd)
-PY`,
-})
-
-const claudeSession = interactive_shell({
-  command: `zsh -lic 'export PATH="$HOME/.local/bin:$PATH"; cd "$PWD" || exit 1; command -v claude >/dev/null 2>&1 || { echo "claude_not_found" >&2; exit 127; }; exec python3 /tmp/pi-claude-review-wrapper.py "$PWD" /tmp/pi-claude-review-prompt.txt'`,
-  mode: "hands-free",
-  handsFree: { autoExitOnQuiet: false, quietThreshold: 8000, updateInterval: 60000 },
-  reason: "Claude Code review",
-})
-
-interactive_shell({ sessionId: claudeSession.sessionId, background: true })
+```bash
+python3 "$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py" \
+  --cwd "$PWD" \
+  --prompt-file /tmp/pi-claude-review-prompt.txt \
+  --output /tmp/pi-claude-review-output.md \
+  --review-name pi-review-change-claude \
+  --timeout-seconds 900
 ```
 
-Lifecycle rules:
-
-- Launch one session only.
-- Do not start another Claude Code session while the first is still active.
-- Immediately move the launched session to the background with `interactive_shell({ sessionId: claudeSession.sessionId, background: true })` so the review keeps running without holding the foreground overlay.
-- Wait about 60 seconds before the first status query unless the user interrupts sooner.
-- Query the session with `interactive_shell({ sessionId, outputLines: 80, outputMaxChars: 12000 })`.
-- When the output shows Claude has returned to its `❯` prompt after finishing the review, send `/exit` with `interactive_shell({ sessionId, input: "/exit" })`, then press Enter with `interactive_shell({ sessionId, inputKeys: ["enter"] })`.
-- After sending `/exit` and Enter, wait briefly and query once more to confirm the session exited.
-- If the user wants to inspect the live TUI again, reattach with `interactive_shell({ attach: sessionId, mode: "dispatch" })` or equivalent before continuing.
-- Only if the session exits non-zero may you inspect the failure and decide whether a single explicit retry is warranted.
-- Do not invent alternate quoting strategies or new launcher shapes mid-run. The prompt-file + Python-wrapper transport above is the required transport.
-
-The launched Claude Code prompt should:
+The prompt written to `/tmp/pi-claude-review-prompt.txt` should instruct Claude Code to:
 
 - inspect the target plan,
-- look only for blockers, material risks, missing decisions, incorrect references, scope drift, or execution-readiness defects that would change readiness for the stated goal and non-goals,
-- explicitly check that each unchecked phase is a bounded execution slice with `### Tests first`, `### End State`, `### Work`, and `### Verify`,
-- flag unresolved `Open Questions` / `Decision Points` in any execution-ready plan,
-- flag phases that are too large and would likely require same-scope subdivision during execution,
-- write inline review comments only where they materially change whether the plan is ready as scoped,
-- skip nice-to-haves, opportunistic cleanup, adjacent surfaces not required by the source scope, and extra detail that would not change readiness,
-- preserve the plan structure and progress state,
-- not rewrite or resolve existing review comments,
-- and stop after the review summary.
+- look only for blockers, material risks, missing decisions, incorrect references, scope drift, or execution-readiness defects,
+- check that unchecked phases are bounded execution slices with `End State`, `Tests first`, `Work`, `Expected files`, and `Verify`,
+- flag unresolved `Open Questions` / `Decision Points` in execution-ready plans,
+- flag phases that are too large for same-scope execution,
+- return copyable inline review comments only where readiness changes materially,
+- preserve plan structure and progress state by not editing files,
+- not rewrite, integrate, or resolve comments,
+- stop after the review summary.
 
-Do not route the work through a review subagent. The whole point of this command is to use Claude Code itself as a review-only pass.
+## Validate result
 
-### 2) Validate the Result
+After the launcher exits:
 
-After the Claude Code session completes:
+- read `/tmp/pi-claude-review-output.md`,
+- if it begins with a classified launcher failure, report that blocker and the inspect/transcript path,
+- otherwise inspect the plan and confirm structure remains intact,
+- confirm any returned Claude comment suggestions use `[REVIEW:CLAUDE]`,
+- report only material findings.
 
-- read the resulting plan file,
-- confirm the plan structure is still intact,
-- confirm any Claude-written comments use the `[REVIEW:CLAUDE]` form,
-- and report whether Claude found issues or returned a clean review.
+## Summary format
 
-### 3) Summary
-
-After verification, provide a concise review summary focused on blockers and readiness.
-
-## Summary Format
-
-```
+```text
 ## Review Complete
 
 ### Claude Material Findings:
-- [List only the blocker-level or readiness-changing Claude review findings, or say none]
+- [List blocker-level or readiness-changing Claude findings, or say none]
 
 ### Plan Status:
 [Ready as scoped / Needs rework]

--- a/_pi/prompts/review:plan-adversarial.md
+++ b/_pi/prompts/review:plan-adversarial.md
@@ -26,7 +26,7 @@ Use this after the standard `/review:plan` flow when you want an explicit challe
 
 ## Execution Mode
 
-- Launch the Claude Code review via its interactive prompt template.
+- Launch the Claude Code review via `/review:change-claude-code`, which owns the canonical private-tmux interactive launcher.
 - Launch the GPT review via the canonical `/review:change-gpt` prompt.
 - Do not use the old adversarial reviewer subagents.
 - Do not run the adversarial review directly in the primary agent.
@@ -90,7 +90,7 @@ Use these prompt templates as the canonical transport + lifecycle specs:
 For each leg:
 
 - follow that prompt template's launcher shape, wrapper transport, shell setup, backgrounding behavior, and lifecycle rules,
-- keep the Claude Code review **interactive** via `interactive_shell`,
+- keep the Claude Code review on the canonical private-tmux interactive launcher owned by `/review:change-claude-code`,
 - run exactly one review per reviewer,
 - do not invent alternate launcher shapes,
 - do not route the work through deprecated provider-specific reviewer prompts.

--- a/skills/claude-code-review/SKILL.md
+++ b/skills/claude-code-review/SKILL.md
@@ -21,14 +21,14 @@ The launcher owns all Claude Code process mechanics:
 
 - creates a fresh private tmux server from the real caller process,
 - checks `claude auth status` inside that private tmux server as an early signal,
-- starts exactly one interactive Claude TUI with the launcher-internal command,
+- starts exactly one interactive Claude TUI with the launcher-internal command pinned to Sonnet 4.6 (`claude --model claude-sonnet-4-6`),
 - pastes the prompt through tmux,
 - extracts only the answer region after the post-submit boundary,
 - writes normalized review text at the beginning of `--output`,
 - tears down successful smoke/review tmux servers,
 - preserves transcript and inspect metadata on failure.
 
-Do not choose or document alternate required-review transports. In particular, do not use `claude -p` [FORBIDDEN-EXAMPLE], `claude --print` [FORBIDDEN-EXAMPLE], prompt piping, input redirection, direct `interactive_shell` Claude launches, direct `process` Claude launches, raw tmux Claude snippets outside the launcher, or model-provider substitutes for a required Claude Code gate.
+Do not choose or document alternate required-review transports or models. Required Claude Code reviews must use the launcher's Sonnet 4.6 pin. In particular, do not use `claude -p` [FORBIDDEN-EXAMPLE], `claude --print` [FORBIDDEN-EXAMPLE], prompt piping, input redirection, direct `interactive_shell` Claude launches, direct `process` Claude launches, raw tmux Claude snippets outside the launcher, Opus, or model-provider substitutes for a required Claude Code gate.
 
 ## Same-process smoke
 

--- a/skills/claude-code-review/SKILL.md
+++ b/skills/claude-code-review/SKILL.md
@@ -1,209 +1,79 @@
 ---
 name: claude-code-review
-description: Launch Claude Code through the user-owned codex tmux session for background plan/code reviews. Use when the task is to have Claude Code review a plan or code diff without editing files.
+description: Run read-only Claude Code plan/code reviews through the canonical private-tmux interactive launcher. Use when the task is to have Claude Code review a plan or code diff without editing files.
 ---
 
 # Claude Code Review
 
-Use this skill when you want Claude Code to review work in the background and report back reliably on the first try.
+Use this skill when a required Claude Code review must run reliably and produce a saved review artifact.
 
-Hard requirement: always invoke Claude through a login shell and a real PTY. Do not call `claude` directly from a plain non-login shell.
-
-On this machine, a Codex-created tmux server can still fail macOS Keychain access and cause `claude auth status` to report `loggedIn: false`. The durable background runner is the user-owned tmux session named `codex`, whose server is created from the user's authenticated interactive multiplexer context. Create review-specific windows inside that session; do not name sessions by review/date.
-
-## Preflight
-
-Before declaring Claude unavailable:
-
-1. Confirm the `codex` tmux session exists.
-2. If it is missing, recreate it through the existing authenticated `zellij main` session.
-3. Run the Claude auth check in a temporary window in `codex`.
+Required transport: call the canonical launcher:
 
 ```bash
-tmux has-session -t codex 2>/dev/null || \
-  zellij --session main run --name codex-tmux-bootstrap --close-on-exit -- \
-    /bin/zsh -ilc 'tmux new-session -d -s codex'
-
-out=/tmp/codex-claude-auth.txt
-rm -f "$out"
-tmux new-window -t codex -n claude-auth-probe \
-  "zsh -ilc 'claude auth status > $out 2>&1; echo EXIT=\$? >> $out'"
-for i in {1..30}; do
-  [ -f "$out" ] && grep -q '^EXIT=' "$out" && break
-  sleep 0.2
-done
-cat "$out"
-tmux kill-window -t codex:claude-auth-probe 2>/dev/null || true
+python3 "$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py" \
+  --cwd /path/to/repo \
+  --prompt-file /tmp/claude-review-prompt.md \
+  --output /tmp/claude-review-output.md \
+  --review-name claude-review
 ```
 
-If the zellij bootstrap fails because `zellij main` is not running, stop and report that the authenticated user multiplexer is unavailable. Do not open Terminal.app automatically.
+The launcher owns all Claude Code process mechanics:
 
-## Default launch pattern
+- creates a fresh private tmux server from the real caller process,
+- checks `claude auth status` inside that private tmux server as an early signal,
+- starts exactly one interactive Claude TUI with the launcher-internal command,
+- pastes the prompt through tmux,
+- extracts only the answer region after the post-submit boundary,
+- writes normalized review text at the beginning of `--output`,
+- tears down successful smoke/review tmux servers,
+- preserves transcript and inspect metadata on failure.
 
-Use one tmux session named `codex`. Name each review window for the review, such as `claude-plan-nod636` or `claude-diff-auth`.
+Do not choose or document alternate required-review transports. In particular, do not use `claude -p` [FORBIDDEN-EXAMPLE], `claude --print` [FORBIDDEN-EXAMPLE], prompt piping, input redirection, direct `interactive_shell` Claude launches, direct `process` Claude launches, raw tmux Claude snippets outside the launcher, or model-provider substitutes for a required Claude Code gate.
+
+## Same-process smoke
+
+Before relying on a caller context, smoke-test the launcher from that same context:
 
 ```bash
-prompt=/tmp/codex-claude-review-prompt.txt
-out=/tmp/codex-claude-review-output.txt
-window=claude-plan-review
-
-cat > "$prompt" <<'PROMPT'
-Review <plan_path> against AGENTS.md and thoughts/specs/product_intent.md.
-If <plan_path> is HTML, treat that HTML file as the authoritative plan artifact and do not require Markdown conversion.
-This is read-only. Do not edit files. Return a concise review with Verdict, Findings, Required Changes, Residual Risks.
-PROMPT
-
-tmux has-session -t codex 2>/dev/null || \
-  zellij --session main run --name codex-tmux-bootstrap --close-on-exit -- \
-    /bin/zsh -ilc 'tmux new-session -d -s codex'
-
-rm -f "$out"
-tmux new-window -t codex -n "$window" \
-  "cd /path/to/repo && zsh -ilc 'claude -p \"\$(< $prompt)\" > $out 2>&1; echo EXIT=\$? >> $out'"
-
-for i in {1..180}; do
-  [ -f "$out" ] && tail -1 "$out" | grep -q '^EXIT=' && break
-  sleep 1
-done
-cat "$out"
+python3 "$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py" \
+  --smoke \
+  --cwd /path/to/repo \
+  --review-name claude-review-smoke \
+  --output /tmp/claude-review-smoke.txt
 ```
 
-Keep the temp command read-only in behavior: ask Claude not to edit files and use `claude -p` for one-shot review output.
-
-## What worked in local testing
-
-### Reliable default
-Use the `codex` tmux session with:
-- one window per review
-- a login shell wrapper around Claude, e.g. `zsh -ilc 'claude -p "$(< /tmp/prompt.txt)"'`
-- a prompt that asks Claude Code to return the review in stdout, not save it to a file
-
-### Less reliable paths
-Avoid these as the first attempt:
-- creating a fresh tmux server directly from Codex
-- opening Terminal.app as an automatic fallback
-- asking Claude Code in `plan` mode to write review output to `/tmp` or repo files
-- starting `hands-free`, then backgrounding it, then trying to steer it later
-- using write-to-`/tmp` as the normal artifact path for read-only reviews
-
-In testing, the write-to-file flow stalled on Claude Code permission prompts after `Write(...)` failed and it fell back to `Bash(touch /tmp/file)`.
-
-## Default launch patterns
-
-### 1) One-shot plan review
-```bash
-prompt=/tmp/codex-claude-plan-review-prompt.txt
-out=/tmp/codex-claude-plan-review-output.txt
-window=claude-plan-review
-
-cat > "$prompt" <<'PROMPT'
-Review <plan_path> against thoughts/plans/AGENTS.md and thoughts/specs/product_intent.md.
-If <plan_path> is HTML, treat that HTML file as the authoritative plan artifact and do not require Markdown conversion.
-This is a read-only plan review. Do not edit files.
-Return concise sections: Verdict, Strengths, Issues, Required Changes.
-PROMPT
-
-tmux has-session -t codex 2>/dev/null || \
-  zellij --session main run --name codex-tmux-bootstrap --close-on-exit -- \
-    /bin/zsh -ilc 'tmux new-session -d -s codex'
-
-rm -f "$out"
-tmux new-window -t codex -n "$window" \
-  "cd /path/to/repo && zsh -ilc 'claude -p \"\$(< $prompt)\" > $out 2>&1; echo EXIT=\$? >> $out'"
-```
-
-### 2) One-shot code review
-```bash
-prompt=/tmp/codex-claude-code-review-prompt.txt
-out=/tmp/codex-claude-code-review-output.txt
-window=claude-code-review
-
-cat > "$prompt" <<'PROMPT'
-Review path/to/file.ts and path/to/test.ts for correctness, edge cases, and test gaps.
-This is a read-only code review. Do not edit files.
-Return concise sections: Summary, Findings, Suggested Follow-ups.
-PROMPT
-
-tmux has-session -t codex 2>/dev/null || \
-  zellij --session main run --name codex-tmux-bootstrap --close-on-exit -- \
-    /bin/zsh -ilc 'tmux new-session -d -s codex'
-
-rm -f "$out"
-tmux new-window -t codex -n "$window" \
-  "cd /path/to/repo && zsh -ilc 'claude -p \"\$(< $prompt)\" > $out 2>&1; echo EXIT=\$? >> $out'"
-```
+Pass condition: output contains `CLAUDE_REVIEW_SMOKE_READY`, `socket=`, and `session=`. Smoke success tears down its private tmux server. Smoke failure is a real prerequisite/auth/readiness failure; do not retry with another transport.
 
 ## Prompt rules
 
-Prefer prompts that:
-- explicitly say **read-only**
-- explicitly say **do not edit files**
-- ask for a **compact structured review on stdout**
-- name the exact files/docs to review
-- name the rubric or comparison docs
+Write the review prompt to a file, then pass that path via `--prompt-file`. Keep prompts read-only and scope-bounded:
 
-Good plan review structure:
-- `Verdict`
-- `Strengths`
-- `Issues`
-- `Required Changes`
+- explicitly say **read-only** and **do not edit files**,
+- name the plan path or diff/range under review,
+- name the expected verdict format,
+- ask for findings with file/path evidence,
+- exclude unrelated cleanup and broad audits.
 
-Good code review structure:
-- `Summary`
-- `Findings`
-- `Suggested Follow-ups`
+## Failure handling
 
-## When to use an attached session instead
+Launcher failures are classified and agent-legible:
 
-For one-pass reviews, prefer `claude -p` in a review-named tmux window. If you expect real follow-up interaction while Claude Code stays live, create a named window in the existing `codex` session and attach to it manually.
+- missing `tmux` or `claude`,
+- private-tmux auth unavailable,
+- TUI reports not logged in,
+- TUI readiness timeout,
+- prompt-boundary uncertainty,
+- review timeout.
 
-```bash
-tmux new-window -t codex -n claude-review-live \
-  "cd /path/to/repo && zsh -ilc 'claude'"
-```
+On failure, read the output file and sibling transcript. If an inspect command is present, use it to inspect the preserved private tmux server. Ask for the exact user action named by the failure, such as `/login` or unlocking the keychain. Never switch to a direct Claude transport as a fallback.
 
-Do not default to this for one-pass reviews.
+## Installed locations
 
-## If you need a saved artifact
+The canonical source is `skills/claude-code-review/scripts/claude_interactive_review.py`.
 
-Best path:
-1. ask Claude Code to return the review on stdout
-2. capture the review from the tmux-launched command output
-3. save it yourself with Codex file-editing tools
+Expected installed copies:
 
-Do not make Claude Code file-writing the default for review tasks.
+- Pi/shared skill: `$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py`
+- OpenCode compatibility skill: `$HOME/.config/opencode/skills/claude-code-review/scripts/claude_interactive_review.py`
 
-## If the run gets stuck
-
-Typical failure pattern in testing:
-- Claude Code attempts `Write(...)`
-- write fails
-- Claude falls back to `Bash(touch /tmp/file)`
-- session blocks on an approval prompt
-
-Recovery:
-1. inspect the session output via `tmux capture-pane -t codex:<window> -p`
-2. if the session is waiting on permissions, stop it
-3. relaunch with a simpler read-only prompt that returns the review on stdout
-4. save the result yourself if needed
-
-A non-zero exit does not automatically mean failure. In testing, a plan review produced a complete structured review in the transcript and still ended with exit code `143` after teardown. Judge success by whether the review content was fully produced.
-
-## Notes from testing
-
-Observed:
-- `tmux new-window -t codex ... claude auth status` reported logged in
-- if the `codex` tmux session is missing, creating it through `zellij --session main run ... tmux new-session -d -s codex` preserves Claude auth
-- creating a fresh tmux server directly from Codex reported Claude logged out
-- `plan mode + write to /tmp` did not succeed reliably
-- `acceptEdits` and extra `/tmp` access were not proven reliable enough to recommend as the default review workflow
-
-## Recommendation
-
-For “have Claude Code review this in the background,” the first try should be:
-- reuse tmux session `codex`
-- create a review-named window
-- run `zsh -ilc 'claude -p ...'`
-- return review in stdout
-- save artifacts with Codex, not Claude Code
-- if `codex` is missing, recreate it via `zellij --session main`; do not open Terminal.app automatically
+Pi prompts should call the central shared launcher under `$HOME/.agents/skills`. OpenCode scripts may resolve `$CLAUDE_REVIEW_LAUNCHER`, the shared installed launcher, the repo checkout launcher, or the OpenCode compatibility copy, in that order.

--- a/skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py
+++ b/skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Guardrail against direct Claude Code CLI launch transports in review surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_ROOTS = ["_pi", "skills", "_opencode", "_claude", "_omp", "_codex", "scripts"]
+REVIEW_HINT_RE = re.compile(r"claude-code-review|review|reviewed-html-plan|scoped-plan-run|codex-full-build|linear_build|linear-build|review:change-claude-code|review:plan-adversarial|_pi/README\.md", re.I)
+FORBIDDEN_MARKER = "[FORBIDDEN-EXAMPLE]"
+FORBIDDEN_FENCE = "forbidden-claude-launch"
+CANONICAL_LAUNCHER_SUFFIX = "claude-code-review/scripts/claude_interactive_review.py"
+GUARDRAIL_SUFFIX = "claude-code-review/scripts/check_no_direct_claude_review_launches.py"
+TEST_SUFFIX_FRAGMENT = "claude-code-review/tests/"
+ALLOWED_LAUNCHER_FORMS = (
+    "zsh -ilc 'command -v claude'",
+    "claude auth status",
+    "zsh -ilc 'claude'",
+)
+IGNORED_DIRS = {".git", "node_modules", "__pycache__", ".venv", "dist", "build"}
+SCAN_EXTENSIONS = {".md", ".py", ".sh", ".js", ".ts", ".json", ".yaml", ".yml", ".txt", ".html"}
+
+DIRECT_PATTERNS = [
+    re.compile(r"\bclaude\s+-(?:p|\-print)\b"),
+    re.compile(r"\bclaude\s+--permission-mode\b"),
+    re.compile(r"\bclaude\s+--file\b"),
+    re.compile(r"\bclaude\s+--future-[\w-]+\b"),
+    re.compile(r"\|\s*claude\b"),
+    re.compile(r"\bclaude\s*<"),
+    re.compile(r"\bos\.execvp\([^\n]*claude"),
+    re.compile(r"\bsubprocess\.[A-Za-z_]+\([^\n]*claude"),
+    re.compile(r"\binteractive_shell\([^\n]*claude"),
+    re.compile(r"\bprocess\([^\n]*claude"),
+    re.compile(r"\bbash\([^\n]*claude"),
+    re.compile(r"\btmux\s+(?:new-window|new-session|split-window|send-keys)[^\n]*\bclaude\b"),
+    re.compile(r"\bzsh\s+-il?c\s+['\"][^'\"]*\bclaude\b"),
+    re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\s*=\s*['\"]?(?:exec\s+)?claude(?:\s|['\"]|$)"),
+]
+RAW_CLAUDE_CMD_RE = re.compile(r"(^|[;&|`$({\[]|\s)(?:exec\s+)?claude(?:\s|$)")
+MULTILINE_DIRECT_PATTERNS = [
+    re.compile(r"\bsubprocess\.[A-Za-z_]+\s*\([^\n)]*\[[^\]]*['\"]claude['\"]", re.S),
+    re.compile(r"\bos\.execv?p?\s*\([^\n)]*\[[^\]]*['\"]claude['\"]", re.S),
+    re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\s*=\s*\[\s*['\"]claude['\"]", re.S),
+]
+
+
+def rel_suffix(path: Path) -> str:
+    return str(path).replace(os.sep, "/")
+
+
+def is_exempt_path(path: Path) -> bool:
+    rel = rel_suffix(path)
+    return rel.endswith(GUARDRAIL_SUFFIX) or TEST_SUFFIX_FRAGMENT in rel
+
+
+def is_launcher_path(path: Path) -> bool:
+    return rel_suffix(path).endswith(CANONICAL_LAUNCHER_SUFFIX)
+
+
+def is_scan_path(path: Path) -> bool:
+    rel = rel_suffix(path)
+    if "/thoughts/plans/" in f"/{rel}" or rel.startswith("thoughts/plans/"):
+        return False
+    if path.suffix and path.suffix not in SCAN_EXTENSIONS:
+        return False
+    return REVIEW_HINT_RE.search(rel) is not None
+
+
+def iter_files(root: Path):
+    if root.is_file():
+        if is_scan_path(root):
+            yield root
+        return
+    if not root.exists():
+        return
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if name not in IGNORED_DIRS]
+        for name in filenames:
+            path = Path(dirpath) / name
+            if is_scan_path(path):
+                yield path
+
+
+def in_forbidden_fence(lines: list[str], index: int) -> bool:
+    in_fence = False
+    for line in lines[: index + 1]:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            if not in_fence:
+                in_fence = stripped[3:].strip() == FORBIDDEN_FENCE
+            else:
+                in_fence = False
+    return in_fence
+
+
+def is_marked_forbidden_example(lines: list[str], index: int) -> bool:
+    line = lines[index]
+    return FORBIDDEN_MARKER in line or in_forbidden_fence(lines, index)
+
+
+def is_benign_non_candidate(line: str) -> bool:
+    stripped = line.strip()
+    benign_bits = [
+        "claude-code-review",
+        "claude_interactive_review.py",
+        "claude-plan-",
+        "CLAUDE_REVIEW_",
+        "interactive Claude review",
+        "Claude Code review",
+        "claude-opus",
+        "opencode-zen/claude",
+        "canonical private-tmux interactive launcher",
+        "missing `tmux` or `claude`",
+    ]
+    if any(bit in stripped for bit in benign_bits) and not any(p.search(stripped) for p in DIRECT_PATTERNS):
+        return True
+    return False
+
+
+def line_has_invocation_candidate(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or is_benign_non_candidate(stripped):
+        return False
+    if any(p.search(stripped) for p in DIRECT_PATTERNS):
+        return True
+    if RAW_CLAUDE_CMD_RE.search(stripped):
+        # Do not flag prose sentences like "Claude Code ..."; require command-like context.
+        commandish_prefixes = ("claude ", "claude", "exec claude", "command -v claude", "cd ", "RUN_", "CLAUDE_", "python", "node", "tmux", "zsh", "bash")
+        return stripped.startswith(commandish_prefixes) or any(token in stripped for token in ("| claude", "&& claude", "; claude", "'claude", '"claude'))
+    return False
+
+
+def allowed_launcher_line(path: Path, line: str) -> bool:
+    if not is_launcher_path(path):
+        return False
+    return any(form in line for form in ALLOWED_LAUNCHER_FORMS)
+
+
+def scan_file(path: Path) -> list[tuple[int, str]]:
+    if is_exempt_path(path):
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        text = path.read_text(errors="replace")
+    lines = text.splitlines()
+    findings: list[tuple[int, str]] = []
+    seen_lines: set[int] = set()
+    for idx, line in enumerate(lines):
+        if not line_has_invocation_candidate(line):
+            continue
+        if is_marked_forbidden_example(lines, idx):
+            continue
+        if allowed_launcher_line(path, line):
+            continue
+        findings.append((idx + 1, line.strip()))
+        seen_lines.add(idx + 1)
+    for pattern in MULTILINE_DIRECT_PATTERNS:
+        for match in pattern.finditer(text):
+            line_no = text.count("\n", 0, match.start()) + 1
+            if line_no in seen_lines:
+                continue
+            if is_marked_forbidden_example(lines, line_no - 1):
+                continue
+            snippet = " ".join(match.group(0).split())
+            findings.append((line_no, snippet))
+            seen_lines.add(line_no)
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Fail if review surfaces contain direct Claude Code CLI launches")
+    parser.add_argument("--root", action="append", dest="roots")
+    args = parser.parse_args(argv)
+    roots = [Path(p).expanduser() for p in (args.roots or DEFAULT_ROOTS)]
+    all_findings: list[str] = []
+    for root in roots:
+        for path in iter_files(root):
+            for line_no, line in scan_file(path):
+                all_findings.append(f"{path}:{line_no}: direct Claude review launch candidate: {line}")
+    if all_findings:
+        print("CLAUDE_DIRECT_REVIEW_LAUNCHES_FOUND")
+        print("\n".join(all_findings))
+        return 1
+    print("NO_DIRECT_CLAUDE_REVIEW_LAUNCHES")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py
+++ b/skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py
@@ -19,7 +19,8 @@ TEST_SUFFIX_FRAGMENT = "claude-code-review/tests/"
 ALLOWED_LAUNCHER_FORMS = (
     "zsh -ilc 'command -v claude'",
     "claude auth status",
-    "zsh -ilc 'claude'",
+    "zsh -ilc 'claude --model claude-sonnet-4-6'",
+    "zsh -ilc 'claude --model {CLAUDE_REVIEW_MODEL}'",
 )
 IGNORED_DIRS = {".git", "node_modules", "__pycache__", ".venv", "dist", "build"}
 SCAN_EXTENSIONS = {".md", ".py", ".sh", ".js", ".ts", ".json", ".yaml", ".yml", ".txt", ".html"}

--- a/skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py
+++ b/skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py
@@ -63,8 +63,6 @@ def is_launcher_path(path: Path) -> bool:
 
 def is_scan_path(path: Path) -> bool:
     rel = rel_suffix(path)
-    if "/thoughts/plans/" in f"/{rel}" or rel.startswith("thoughts/plans/"):
-        return False
     if path.suffix and path.suffix not in SCAN_EXTENSIONS:
         return False
     return REVIEW_HINT_RE.search(rel) is not None

--- a/skills/claude-code-review/scripts/claude_interactive_review.py
+++ b/skills/claude-code-review/scripts/claude_interactive_review.py
@@ -288,7 +288,17 @@ def run_review(args: argparse.Namespace) -> int:
         boundary_deadline = time.time() + BOUNDARY_TIMEOUT_SECONDS
         baseline = ""
         while time.time() < boundary_deadline:
-            candidate = normalize(capture(socket, session, window))
+            raw = capture(socket, session, window)
+            candidate = normalize(raw)
+            check_tui_unavailable(candidate, after_submit=True)
+            prompt_cleared_answer = extract_prompt_cleared_answer(candidate, marker, sentinel)
+            if prompt_cleared_answer:
+                transcript_path = output.with_suffix(output.suffix + ".transcript.txt")
+                transcript_path.write_text(raw, encoding="utf-8")
+                metadata = f"\n\n---\nCLAUDE_REVIEW_LAUNCHER_METADATA\nsocket={socket}\nsession={session}\nwindow={window}\ntranscript={transcript_path}\nreadiness_regex={READY_RE.pattern}\nclear_boundary=prompt-cleared marker/sentinel extraction before baseline\nhistory_limit={TMUX_HISTORY_LIMIT}\ncapture_depth={CAPTURE_DEPTH}\n"
+                output.write_text(prompt_cleared_answer.strip() + metadata, encoding="utf-8")
+                teardown_success(socket, session, window)
+                return 0
             marker_count = count_token(candidate, marker)
             sentinel_count = count_token(candidate, sentinel)
             if marker_count == prompt_marker_count and sentinel_count == prompt_sentinel_count:

--- a/skills/claude-code-review/scripts/claude_interactive_review.py
+++ b/skills/claude-code-review/scripts/claude_interactive_review.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Canonical interactive tmux launcher for required Claude Code reviews."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import secrets
+import shutil
+import string
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+READY_RE = re.compile(r"❯")
+ANSWER_MARKER_PREFIX = "CLAUDE_REVIEW_ANSWER_START_"
+DEFAULT_TIMEOUT_SECONDS = 900
+READY_TIMEOUT_SECONDS = 120
+BOUNDARY_TIMEOUT_SECONDS = 45
+TEARDOWN_TIMEOUT_SECONDS = 8
+TMUX_HISTORY_LIMIT = 50000
+CAPTURE_DEPTH = 50000
+MIN_SENTINEL_LENGTH = 16
+COMMON_SENTINELS = {"DONE", "END", "SUCCESS", "STOP", "EOF", "FINISHED", "COMPLETE"}
+SHELL_AMBIGUOUS = set("`$\\;|&<>(){}[]*!?\"'")
+
+ANSI_RE = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+class LauncherError(RuntimeError):
+    def __init__(self, code: str, message: str, exit_code: int = 2) -> None:
+        super().__init__(message)
+        self.code = code
+        self.exit_code = exit_code
+
+
+def run(cmd: list[str], *, cwd: str | None = None, env: dict[str, str] | None = None, check: bool = True, timeout: int | None = None) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(cmd, cwd=cwd, env=env, text=True, capture_output=True, timeout=timeout)
+    if check and proc.returncode != 0:
+        raise LauncherError("CLAUDE_REVIEW_COMMAND_FAILED", f"command failed: {' '.join(cmd)}\n{proc.stderr or proc.stdout}")
+    return proc
+
+
+def normalize(text: str) -> str:
+    text = ANSI_RE.sub("", text.replace("\r", ""))
+    text = CONTROL_RE.sub("", text)
+    return "\n".join(line.rstrip() for line in text.splitlines())
+
+
+def slugify(value: str) -> str:
+    safe = "".join(ch.lower() if ch.isalnum() else "-" for ch in value).strip("-")
+    safe = re.sub(r"-+", "-", safe)
+    return safe or "claude-review"
+
+
+def make_nonce() -> str:
+    return secrets.token_hex(6)
+
+
+def generated_sentinel(review_name: str, nonce: str) -> str:
+    return f"CLAUDE_REVIEW_DONE_{slugify(review_name).replace('-', '_')}_{os.getpid()}_{nonce}"
+
+
+def validate_sentinel(sentinel: str) -> None:
+    if not sentinel:
+        raise LauncherError("CLAUDE_REVIEW_INVALID_SENTINEL", "sentinel must not be empty")
+    if len(sentinel) < MIN_SENTINEL_LENGTH:
+        raise LauncherError("CLAUDE_REVIEW_INVALID_SENTINEL", f"sentinel must be at least {MIN_SENTINEL_LENGTH} characters")
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in sentinel):
+        raise LauncherError("CLAUDE_REVIEW_INVALID_SENTINEL", "sentinel must not contain control characters or newlines")
+    if sentinel.upper() in COMMON_SENTINELS:
+        raise LauncherError("CLAUDE_REVIEW_INVALID_SENTINEL", "sentinel must not be a common completion token")
+    if any(ch in SHELL_AMBIGUOUS for ch in sentinel):
+        raise LauncherError("CLAUDE_REVIEW_INVALID_SENTINEL", "sentinel must avoid shell-ambiguous punctuation")
+
+
+def require_tool(name: str) -> None:
+    if shutil.which(name) is None:
+        raise LauncherError("CLAUDE_REVIEW_MISSING_PREREQUISITE", f"missing required tool: {name}")
+
+
+def require_claude_login_shell() -> None:
+    proc = run(["zsh", "-ilc", "command -v claude"], check=False, timeout=30)
+    if proc.returncode != 0 or not proc.stdout.strip():
+        raise LauncherError("CLAUDE_REVIEW_MISSING_PREREQUISITE", "missing required tool in login shell: claude")
+
+
+def tmux(socket: str, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["tmux", "-L", socket, *args], check=check)
+
+
+def capture(socket: str, session: str, window: str) -> str:
+    proc = tmux(socket, ["capture-pane", "-t", f"{session}:{window}", "-p", "-J", "-S", f"-{CAPTURE_DEPTH}"], check=False)
+    return proc.stdout or ""
+
+
+def count_token(text: str, token: str) -> int:
+    return text.count(token)
+
+
+def write_failure(output: Path, code: str, message: str, *, socket: str | None = None, session: str | None = None, transcript: str | None = None) -> None:
+    lines = [code, message]
+    if output:
+        if transcript:
+            transcript_path = output.with_suffix(output.suffix + ".transcript.txt")
+            transcript_path.write_text(transcript, encoding="utf-8")
+            lines.append(f"transcript={transcript_path}")
+        if socket and session:
+            lines.append(f"inspect=tmux -L {socket} attach -t {session}")
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def check_tui_unavailable(text: str, *, after_submit: bool = False) -> None:
+    if re.search(r"not logged in|please run /login", text, re.I):
+        suffix = " after submit" if after_submit else ""
+        raise LauncherError("CLAUDE_AUTH_UNAVAILABLE_IN_TUI", f"Claude TUI reported not logged in{suffix}; run /login in Claude Code or unlock the keychain", 21)
+    if re.search(r"session limit|rate limit|usage limit|resets\s+\d", text, re.I):
+        suffix = " after submit" if after_submit else ""
+        raise LauncherError("CLAUDE_SESSION_LIMIT_IN_TUI", f"Claude TUI reported a session/rate limit{suffix}; wait for reset or choose a non-required review path only if the workflow allows it", 25)
+
+
+def wait_for_prompt(socket: str, session: str, window: str, output: Path, timeout_seconds: int) -> str:
+    deadline = time.time() + timeout_seconds
+    last = ""
+    while time.time() < deadline:
+        raw = capture(socket, session, window)
+        text = normalize(raw)
+        last = raw
+        check_tui_unavailable(text)
+        if READY_RE.search(text):
+            return raw
+        time.sleep(1)
+    raise LauncherError("CLAUDE_TUI_NOT_READY", "Claude TUI did not reach a usable prompt before readiness timeout", 22)
+
+
+def start_private_tmux(socket: str, session: str) -> None:
+    tmux(socket, ["new-session", "-d", "-s", session, "-n", "control", "sleep 3600"])
+    tmux(socket, ["set-option", "-g", "history-limit", str(TMUX_HISTORY_LIMIT)], check=False)
+
+
+def auth_preflight(socket: str, session: str, cwd: Path, output: Path) -> None:
+    auth_path = output.with_suffix(output.suffix + ".auth.json")
+    command = f"cd {sh_quote(str(cwd))} && zsh -ilc 'claude auth status; printf EXIT=%s\\n $?' > {sh_quote(str(auth_path))} 2>&1"
+    tmux(socket, ["new-window", "-t", session, "-n", "auth", command])
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        if auth_path.exists() and "EXIT=" in auth_path.read_text(errors="replace"):
+            break
+        time.sleep(0.5)
+    text = auth_path.read_text(errors="replace") if auth_path.exists() else ""
+    if '"loggedIn": true' not in text:
+        raise LauncherError("CLAUDE_AUTH_UNAVAILABLE_IN_TMUX_PREFLIGHT", "claude auth status inside private tmux did not report loggedIn true; run /login or unlock the keychain", 20)
+
+
+def sh_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+def launch_tui(socket: str, session: str, window: str, cwd: Path) -> None:
+    command = f"cd {sh_quote(str(cwd))} && zsh -ilc 'claude'"
+    tmux(socket, ["new-window", "-t", session, "-n", window, command])
+    tmux(socket, ["resize-window", "-t", f"{session}:{window}", "-x", "220", "-y", "60"], check=False)
+
+
+def teardown_success(socket: str, session: str, window: str) -> None:
+    tmux(socket, ["send-keys", "-t", f"{session}:{window}", "/exit", "Enter"], check=False)
+    deadline = time.time() + TEARDOWN_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        if tmux(socket, ["has-session", "-t", session], check=False).returncode != 0:
+            return
+        time.sleep(0.5)
+    tmux(socket, ["kill-server"], check=False)
+
+
+def compose_prompt(prompt_file: Path, marker: str, sentinel: str) -> str:
+    body = prompt_file.read_text(encoding="utf-8")
+    return f"""{body.rstrip()}
+
+---
+Claude review launcher emission protocol:
+Return the review text only. Do not edit files. Emit the following answer-start marker on its own line, then the review, then the final sentinel on its own line. Do not repeat the final sentinel anywhere except the final line.
+{marker}
+<review text here>
+{sentinel}
+CLAUDE_REVIEW_FINAL_SENTINEL:{sentinel}"""
+
+
+def extract_answer(new_text: str, marker: str, sentinel: str) -> str:
+    marker_index = new_text.find(marker)
+    if marker_index < 0:
+        raise LauncherError("CLAUDE_REVIEW_MARKER_MISSING", "answer marker not found after prompt boundary")
+    answer_start = marker_index + len(marker)
+    sentinel_index = new_text.rfind(sentinel)
+    if sentinel_index < answer_start:
+        raise LauncherError("CLAUDE_REVIEW_SENTINEL_MISSING", "sentinel not found after answer marker")
+    answer = new_text[answer_start:sentinel_index].strip("\n ")
+    if not answer:
+        raise LauncherError("CLAUDE_REVIEW_EMPTY_ANSWER", "answer region between marker and sentinel was empty")
+    return answer
+
+
+def suffix_after_baseline(baseline: str, later: str, marker: str, sentinel: str) -> str | None:
+    if later.startswith(baseline):
+        return later[len(baseline):]
+    base_marker_count = count_token(baseline, marker)
+    base_sentinel_count = count_token(baseline, sentinel)
+    marker_positions = [m.start() for m in re.finditer(re.escape(marker), later)]
+    sentinel_positions = [m.start() for m in re.finditer(re.escape(sentinel), later)]
+    if len(marker_positions) > base_marker_count and len(sentinel_positions) > base_sentinel_count:
+        start = min(marker_positions[base_marker_count], sentinel_positions[base_sentinel_count])
+        return later[start:]
+    return None
+
+
+def extract_prompt_cleared_answer(text: str, marker: str, sentinel: str) -> str | None:
+    if marker not in text or sentinel not in text:
+        return None
+    if f"CLAUDE_REVIEW_FINAL_SENTINEL:{sentinel}" in text:
+        return None
+    try:
+        answer = extract_answer(text, marker, sentinel)
+    except LauncherError:
+        return None
+    if "Claude review launcher emission protocol" in answer or "<review text here>" in answer:
+        return None
+    return answer
+
+
+def run_smoke(args: argparse.Namespace) -> int:
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    nonce = make_nonce()
+    socket = f"claude-review-{slugify(args.review_name)}-{os.getpid()}-{nonce}"
+    session = "review"
+    window = "claude-smoke"
+    cwd = Path(args.cwd or os.getcwd()).resolve()
+    try:
+        require_tool("tmux")
+        require_claude_login_shell()
+        start_private_tmux(socket, session)
+        auth_preflight(socket, session, cwd, output)
+        launch_tui(socket, session, window, cwd)
+        wait_for_prompt(socket, session, window, output, min(args.timeout_seconds, READY_TIMEOUT_SECONDS))
+        text = f"CLAUDE_REVIEW_SMOKE_READY\nsocket={socket}\nsession={session}\nwindow={window}\nreadiness_regex={READY_RE.pattern}\nhistory_limit={TMUX_HISTORY_LIMIT}\ncapture_depth={CAPTURE_DEPTH}\n"
+        output.write_text(text, encoding="utf-8")
+        print(text, end="")
+        teardown_success(socket, session, window)
+        return 0
+    except LauncherError as exc:
+        raw = capture(socket, session, window) if shutil.which("tmux") else ""
+        write_failure(output, exc.code, str(exc), socket=socket, session=session, transcript=raw)
+        print(output.read_text(errors="replace"), file=sys.stderr, end="")
+        return exc.exit_code
+
+
+def run_review(args: argparse.Namespace) -> int:
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    cwd = Path(args.cwd).resolve()
+    prompt_file = Path(args.prompt_file).resolve()
+    nonce = make_nonce()
+    sentinel = args.sentinel or generated_sentinel(args.review_name, nonce)
+    try:
+        validate_sentinel(sentinel)
+        require_tool("tmux")
+        require_claude_login_shell()
+        marker = f"{ANSWER_MARKER_PREFIX}{nonce}"
+        socket = f"claude-review-{slugify(args.review_name)}-{os.getpid()}-{nonce}"
+        session = "review"
+        window = "claude-review"
+        start_private_tmux(socket, session)
+        auth_preflight(socket, session, cwd, output)
+        launch_tui(socket, session, window, cwd)
+        wait_for_prompt(socket, session, window, output, min(args.timeout_seconds, READY_TIMEOUT_SECONDS))
+        final_prompt = compose_prompt(prompt_file, marker, sentinel)
+        prompt_tmp = output.with_suffix(output.suffix + ".submitted-prompt.md")
+        prompt_tmp.write_text(final_prompt, encoding="utf-8")
+        tmux(socket, ["load-buffer", "-b", "review-prompt", str(prompt_tmp)])
+        tmux(socket, ["paste-buffer", "-d", "-b", "review-prompt", "-t", f"{session}:{window}"])
+        prompt_marker_count = count_token(final_prompt, marker)
+        prompt_sentinel_count = count_token(final_prompt, sentinel)
+        pre_submit = normalize(capture(socket, session, window))
+        tmux(socket, ["send-keys", "-t", f"{session}:{window}", "Enter"])
+        boundary_deadline = time.time() + BOUNDARY_TIMEOUT_SECONDS
+        baseline = ""
+        while time.time() < boundary_deadline:
+            candidate = normalize(capture(socket, session, window))
+            marker_count = count_token(candidate, marker)
+            sentinel_count = count_token(candidate, sentinel)
+            if marker_count == prompt_marker_count and sentinel_count == prompt_sentinel_count:
+                baseline = candidate
+                break
+            if marker_count > prompt_marker_count or sentinel_count > prompt_sentinel_count:
+                raise LauncherError("CLAUDE_TUI_BOUNDARY_UNCERTAIN", "answer marker appeared before a post-submit baseline could be established", 23)
+            time.sleep(0.1)
+        if not baseline:
+            raise LauncherError("CLAUDE_TUI_BOUNDARY_UNCERTAIN", "could not establish post-submit baseline before answer extraction", 23)
+        deadline = time.time() + args.timeout_seconds
+        last_raw = ""
+        while time.time() < deadline:
+            last_raw = capture(socket, session, window)
+            text = normalize(last_raw)
+            check_tui_unavailable(text, after_submit=True)
+            suffix = suffix_after_baseline(baseline, text, marker, sentinel)
+            answer = None
+            boundary = "baseline-relative marker/sentinel occurrence diff after submit"
+            if suffix and count_token(suffix, marker) >= 1 and count_token(suffix, sentinel) >= 1:
+                answer = extract_answer(suffix, marker, sentinel)
+            else:
+                answer = extract_prompt_cleared_answer(text, marker, sentinel)
+                boundary = "prompt-cleared marker/sentinel extraction after submit"
+            if answer:
+                transcript_path = output.with_suffix(output.suffix + ".transcript.txt")
+                transcript_path.write_text(last_raw, encoding="utf-8")
+                metadata = f"\n\n---\nCLAUDE_REVIEW_LAUNCHER_METADATA\nsocket={socket}\nsession={session}\nwindow={window}\ntranscript={transcript_path}\nreadiness_regex={READY_RE.pattern}\nclear_boundary={boundary}\nhistory_limit={TMUX_HISTORY_LIMIT}\ncapture_depth={CAPTURE_DEPTH}\n"
+                output.write_text(answer.strip() + metadata, encoding="utf-8")
+                teardown_success(socket, session, window)
+                return 0
+            time.sleep(1)
+        raise LauncherError("CLAUDE_REVIEW_TIMEOUT", f"timed out waiting for {marker} and sentinel after prompt boundary", 24)
+    except LauncherError as exc:
+        socket_val = locals().get("socket")
+        session_val = locals().get("session")
+        window_val = locals().get("window")
+        raw = capture(socket_val, session_val, window_val) if socket_val and session_val and window_val and shutil.which("tmux") else ""
+        write_failure(output, exc.code, str(exc), socket=socket_val, session=session_val, transcript=raw)
+        print(output.read_text(errors="replace"), file=sys.stderr, end="")
+        return exc.exit_code
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Claude Code reviews through an interactive private tmux TUI")
+    parser.add_argument("--cwd", default=os.getcwd())
+    parser.add_argument("--prompt-file")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--review-name", required=True)
+    parser.add_argument("--timeout-seconds", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--sentinel")
+    parser.add_argument("--smoke", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.smoke:
+        if args.prompt_file:
+            raise SystemExit("--smoke does not accept --prompt-file")
+        return run_smoke(args)
+    if not args.prompt_file:
+        raise SystemExit("--prompt-file is required unless --smoke is set")
+    return run_review(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/claude-code-review/scripts/claude_interactive_review.py
+++ b/skills/claude-code-review/scripts/claude_interactive_review.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 READY_RE = re.compile(r"❯")
 ANSWER_MARKER_PREFIX = "CLAUDE_REVIEW_ANSWER_START_"
+CLAUDE_REVIEW_MODEL = "claude-sonnet-4-6"
 DEFAULT_TIMEOUT_SECONDS = 900
 READY_TIMEOUT_SECONDS = 120
 BOUNDARY_TIMEOUT_SECONDS = 45
@@ -161,7 +162,7 @@ def sh_quote(value: str) -> str:
 
 
 def launch_tui(socket: str, session: str, window: str, cwd: Path) -> None:
-    command = f"cd {sh_quote(str(cwd))} && zsh -ilc 'claude'"
+    command = f"cd {sh_quote(str(cwd))} && zsh -ilc 'claude --model {CLAUDE_REVIEW_MODEL}'"
     tmux(socket, ["new-window", "-t", session, "-n", window, command])
     tmux(socket, ["resize-window", "-t", f"{session}:{window}", "-x", "220", "-y", "60"], check=False)
 

--- a/skills/claude-code-review/scripts/claude_interactive_review.py
+++ b/skills/claude-code-review/scripts/claude_interactive_review.py
@@ -143,6 +143,20 @@ def start_private_tmux(socket: str, session: str) -> None:
     tmux(socket, ["set-option", "-g", "history-limit", str(TMUX_HISTORY_LIMIT)], check=False)
 
 
+def auth_status_logged_in(text: str) -> bool:
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            payload, _ = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and payload.get("loggedIn") is True:
+            return True
+    return False
+
+
 def auth_preflight(socket: str, session: str, cwd: Path, output: Path) -> None:
     auth_path = output.with_suffix(output.suffix + ".auth.json")
     command = f"cd {sh_quote(str(cwd))} && zsh -ilc 'claude auth status; printf EXIT=%s\\n $?' > {sh_quote(str(auth_path))} 2>&1"
@@ -153,7 +167,7 @@ def auth_preflight(socket: str, session: str, cwd: Path, output: Path) -> None:
             break
         time.sleep(0.5)
     text = auth_path.read_text(errors="replace") if auth_path.exists() else ""
-    if '"loggedIn": true' not in text:
+    if not auth_status_logged_in(text):
         raise LauncherError("CLAUDE_AUTH_UNAVAILABLE_IN_TMUX_PREFLIGHT", "claude auth status inside private tmux did not report loggedIn true; run /login or unlock the keychain", 20)
 
 

--- a/skills/claude-code-review/tests/fixtures/fake_claude.py
+++ b/skills/claude-code-review/tests/fixtures/fake_claude.py
@@ -34,50 +34,48 @@ def interactive() -> int:
         tty.setcbreak(sys.stdin.fileno())
     except Exception:
         old_tty = None
-    if os.environ.get("FAKE_CLAUDE_NO_READY") == "1":
-        print("Claude Code fake loading", flush=True)
-        time.sleep(300)
+    try:
+        if os.environ.get("FAKE_CLAUDE_NO_READY") == "1":
+            print("Claude Code fake loading", flush=True)
+            time.sleep(300)
+            return 0
+        if os.environ.get("FAKE_CLAUDE_NOT_LOGGED_IN") == "1":
+            print("Not logged in · Please run /login", flush=True)
+            time.sleep(300)
+            return 0
+        print("Claude Code fake\n❯ ", end="", flush=True)
+        buf = ""
+        echoed = os.environ.get("FAKE_CLAUDE_NO_ECHO") != "1"
+        answered = False
+        while True:
+            ready, _, _ = select.select([sys.stdin], [], [], 300)
+            if not ready:
+                return 0
+            ch = sys.stdin.read(1)
+            if ch == "":
+                return 0
+            buf += ch
+            if echoed:
+                print(ch, end="", flush=True)
+            if "/exit" in buf:
+                return 0
+            marker_match = re.search(r"CLAUDE_REVIEW_ANSWER_START_[0-9a-f]+", buf)
+            sentinel_match = re.search(r"CLAUDE_REVIEW_FINAL_SENTINEL:([^\n\r]+)", buf)
+            if marker_match and sentinel_match and ch in "\n\r" and not answered:
+                answered = True
+                marker = marker_match.group(0)
+                sentinel = sentinel_match.group(1).strip()
+                if os.environ.get("FAKE_CLAUDE_BOUNDARY_UNCERTAIN") == "1":
+                    print(f"\n{marker}\nVERDICT: PASS_SCOPED\nBoundary-bad fake review\n{sentinel}\n❯ ", flush=True)
+                    continue
+                if os.environ.get("FAKE_CLAUDE_SESSION_LIMIT") == "1":
+                    print("\n⎿  You've hit your session limit · resets 11:30am (America/Denver)\n❯ ", flush=True)
+                    continue
+                time.sleep(float(os.environ.get("FAKE_CLAUDE_ANSWER_DELAY", "1.5")))
+                print(f"\n✻ Cooked for 0s\n{marker}\nVERDICT: PASS_SCOPED\nFake Claude review body\n{sentinel}\n❯ ", flush=True)
+                buf = ""
+    finally:
         restore_tty(old_tty)
-        return 0
-    if os.environ.get("FAKE_CLAUDE_NOT_LOGGED_IN") == "1":
-        print("Not logged in · Please run /login", flush=True)
-        time.sleep(300)
-        restore_tty(old_tty)
-        return 0
-    print("Claude Code fake\n❯ ", end="", flush=True)
-    buf = ""
-    echoed = os.environ.get("FAKE_CLAUDE_NO_ECHO") != "1"
-    answered = False
-    while True:
-        ready, _, _ = select.select([sys.stdin], [], [], 300)
-        if not ready:
-            restore_tty(old_tty)
-            return 0
-        ch = sys.stdin.read(1)
-        if ch == "":
-            restore_tty(old_tty)
-            return 0
-        buf += ch
-        if echoed:
-            print(ch, end="", flush=True)
-        if "/exit" in buf:
-            restore_tty(old_tty)
-            return 0
-        marker_match = re.search(r"CLAUDE_REVIEW_ANSWER_START_[0-9a-f]+", buf)
-        sentinel_match = re.search(r"CLAUDE_REVIEW_FINAL_SENTINEL:([^\n\r]+)", buf)
-        if marker_match and sentinel_match and ch in "\n\r" and not answered:
-            answered = True
-            marker = marker_match.group(0)
-            sentinel = sentinel_match.group(1).strip()
-            if os.environ.get("FAKE_CLAUDE_BOUNDARY_UNCERTAIN") == "1":
-                print(f"\n{marker}\nVERDICT: PASS_SCOPED\nBoundary-bad fake review\n{sentinel}\n❯ ", flush=True)
-                continue
-            if os.environ.get("FAKE_CLAUDE_SESSION_LIMIT") == "1":
-                print("\n⎿  You've hit your session limit · resets 11:30am (America/Denver)\n❯ ", flush=True)
-                continue
-            time.sleep(float(os.environ.get("FAKE_CLAUDE_ANSWER_DELAY", "1.5")))
-            print(f"\n✻ Cooked for 0s\n{marker}\nVERDICT: PASS_SCOPED\nFake Claude review body\n{sentinel}\n❯ ", flush=True)
-            buf = ""
 
 
 def main() -> int:

--- a/skills/claude-code-review/tests/fixtures/fake_claude.py
+++ b/skills/claude-code-review/tests/fixtures/fake_claude.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Interactive fake Claude TUI for claude_interactive_review.py tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import select
+import sys
+import termios
+import time
+import tty
+
+
+def auth_status() -> int:
+    logged_in = os.environ.get("FAKE_CLAUDE_AUTH", "1") != "0"
+    print(json.dumps({"loggedIn": logged_in, "authMethod": "fake" if logged_in else "none"}))
+    return 0 if logged_in else 1
+
+
+def restore_tty(old_tty) -> None:
+    if old_tty is not None:
+        try:
+            termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, old_tty)
+        except Exception:
+            pass
+
+
+def interactive() -> int:
+    old_tty = None
+    try:
+        old_tty = termios.tcgetattr(sys.stdin.fileno())
+        tty.setcbreak(sys.stdin.fileno())
+    except Exception:
+        old_tty = None
+    if os.environ.get("FAKE_CLAUDE_NO_READY") == "1":
+        print("Claude Code fake loading", flush=True)
+        time.sleep(300)
+        restore_tty(old_tty)
+        return 0
+    if os.environ.get("FAKE_CLAUDE_NOT_LOGGED_IN") == "1":
+        print("Not logged in · Please run /login", flush=True)
+        time.sleep(300)
+        restore_tty(old_tty)
+        return 0
+    print("Claude Code fake\n❯ ", end="", flush=True)
+    buf = ""
+    echoed = os.environ.get("FAKE_CLAUDE_NO_ECHO") != "1"
+    answered = False
+    while True:
+        ready, _, _ = select.select([sys.stdin], [], [], 300)
+        if not ready:
+            restore_tty(old_tty)
+            return 0
+        ch = sys.stdin.read(1)
+        if ch == "":
+            restore_tty(old_tty)
+            return 0
+        buf += ch
+        if echoed:
+            print(ch, end="", flush=True)
+        if "/exit" in buf:
+            restore_tty(old_tty)
+            return 0
+        marker_match = re.search(r"CLAUDE_REVIEW_ANSWER_START_[0-9a-f]+", buf)
+        sentinel_match = re.search(r"CLAUDE_REVIEW_FINAL_SENTINEL:([^\n\r]+)", buf)
+        if marker_match and sentinel_match and ch in "\n\r" and not answered:
+            answered = True
+            marker = marker_match.group(0)
+            sentinel = sentinel_match.group(1).strip()
+            if os.environ.get("FAKE_CLAUDE_BOUNDARY_UNCERTAIN") == "1":
+                print(f"\n{marker}\nVERDICT: PASS_SCOPED\nBoundary-bad fake review\n{sentinel}\n❯ ", flush=True)
+                continue
+            if os.environ.get("FAKE_CLAUDE_SESSION_LIMIT") == "1":
+                print("\n⎿  You've hit your session limit · resets 11:30am (America/Denver)\n❯ ", flush=True)
+                continue
+            time.sleep(float(os.environ.get("FAKE_CLAUDE_ANSWER_DELAY", "1.5")))
+            print(f"\n✻ Cooked for 0s\n{marker}\nVERDICT: PASS_SCOPED\nFake Claude review body\n{sentinel}\n❯ ", flush=True)
+            buf = ""
+
+
+def main() -> int:
+    if len(sys.argv) >= 3 and sys.argv[1:] == ["auth", "status"]:
+        return auth_status()
+    return interactive()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/claude-code-review/tests/fixtures/tui_transcripts/ansi_spinner_prompt_echo.txt
+++ b/skills/claude-code-review/tests/fixtures/tui_transcripts/ansi_spinner_prompt_echo.txt
@@ -1,0 +1,9 @@
+\u001b[32mClaude Code fake\u001b[0m
+❯ Review this plan
+CLAUDE_REVIEW_ANSWER_START_deadbeef
+Return sentinel CLAUDE_REVIEW_DONE_TEST_SENTINEL_123
+✻ Cooking…
+CLAUDE_REVIEW_ANSWER_START_deadbeef
+VERDICT: PASS_SCOPED
+ANSI-stripped answer
+CLAUDE_REVIEW_DONE_TEST_SENTINEL_123

--- a/skills/claude-code-review/tests/test_claude_interactive_review.py
+++ b/skills/claude-code-review/tests/test_claude_interactive_review.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Tests for the canonical Claude interactive tmux review launcher."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+LAUNCHER = ROOT / "skills/claude-code-review/scripts/claude_interactive_review.py"
+GUARDRAIL = ROOT / "skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py"
+FAKE_CLAUDE = ROOT / "skills/claude-code-review/tests/fixtures/fake_claude.py"
+LINEAR_REVIEW = ROOT / "_opencode/scripts/linear_build_review.py"
+
+
+def run_cmd(args: list[str], *, env: dict[str, str] | None = None, cwd: Path | None = None, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    return subprocess.run(args, cwd=str(cwd or ROOT), env=merged, text=True, capture_output=True, timeout=timeout)
+
+
+class LauncherTestCase(unittest.TestCase):
+    def make_fake_env(self, tmp: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+        fake_bin = tmp / "bin"
+        fake_home = tmp / "home"
+        zdotdir = tmp / "zdotdir"
+        fake_bin.mkdir()
+        fake_home.mkdir()
+        zdotdir.mkdir()
+        claude = fake_bin / "claude"
+        claude.write_text(f"#!/usr/bin/env bash\nexec {sys.executable!r} {str(FAKE_CLAUDE)!r} \"$@\"\n", encoding="utf-8")
+        claude.chmod(0o755)
+        zshenv = zdotdir / ".zshenv"
+        zshenv.write_text(f"export PATH={fake_bin}:$PATH\n", encoding="utf-8")
+        env = {
+            "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
+            "HOME": str(fake_home),
+            "ZDOTDIR": str(zdotdir),
+        }
+        if extra:
+            env.update(extra)
+        return env
+
+    def launcher_args(self, tmp: Path, *, sentinel: str = "CLAUDE_REVIEW_DONE_TEST_SENTINEL_12345", timeout: int = 8) -> tuple[list[str], Path]:
+        prompt = tmp / "prompt.md"
+        output = tmp / "review.md"
+        prompt.write_text("Read-only review. Return VERDICT: PASS_SCOPED and one sentence.", encoding="utf-8")
+        args = [
+            sys.executable,
+            str(LAUNCHER),
+            "--cwd",
+            str(ROOT),
+            "--prompt-file",
+            str(prompt),
+            "--output",
+            str(output),
+            "--review-name",
+            "fake-review",
+            "--timeout-seconds",
+            str(timeout),
+        ]
+        if sentinel:
+            args.extend(["--sentinel", sentinel])
+        return args, output
+
+    def test_fake_interactive_success_outputs_answer_and_tears_down(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            args, output = self.launcher_args(tmp)
+            proc = run_cmd(args, env=self.make_fake_env(tmp), timeout=30)
+            self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+            text = output.read_text(encoding="utf-8")
+            self.assertTrue(text.startswith("VERDICT: PASS_SCOPED"), text)
+            socket_line = next(line for line in text.splitlines() if line.startswith("socket="))
+            socket = socket_line.split("=", 1)[1]
+            tmux_probe = run_cmd(["tmux", "-L", socket, "list-sessions"], timeout=5)
+            self.assertNotEqual(tmux_probe.returncode, 0, "successful review leaked private tmux server")
+
+    def test_omitted_sentinel_generates_nonce_sentinel(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            args, output = self.launcher_args(tmp, sentinel="")
+            proc = run_cmd(args, env=self.make_fake_env(tmp), timeout=30)
+            self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+            self.assertIn("Fake Claude review body", output.read_text(encoding="utf-8"))
+
+    def test_invalid_sentinel_rejected_before_tmux_launch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            args, output = self.launcher_args(tmp, sentinel="DONE")
+            proc = run_cmd(args, env=self.make_fake_env(tmp), timeout=15)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("CLAUDE_REVIEW_INVALID_SENTINEL", output.read_text(encoding="utf-8"))
+
+    def test_claude_discovery_uses_login_shell_path(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            args, output = self.launcher_args(tmp)
+            env = self.make_fake_env(tmp)
+            fake_bin = str(tmp / "bin")
+            env["PATH"] = os.pathsep.join(part for part in env["PATH"].split(os.pathsep) if part != fake_bin)
+            proc = run_cmd(args, env=env, timeout=30)
+            self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+            self.assertIn("Fake Claude review body", output.read_text(encoding="utf-8"))
+
+    def test_auth_preflight_false_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            args, output = self.launcher_args(tmp)
+            proc = run_cmd(args, env=self.make_fake_env(tmp, {"FAKE_CLAUDE_AUTH": "0"}), timeout=20)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("CLAUDE_AUTH_UNAVAILABLE_IN_TMUX_PREFLIGHT", output.read_text(encoding="utf-8"))
+            self.assertIn("inspect=tmux", output.read_text(encoding="utf-8"))
+
+    def test_tui_not_logged_in_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            args, output = self.launcher_args(tmp)
+            proc = run_cmd(args, env=self.make_fake_env(tmp, {"FAKE_CLAUDE_NOT_LOGGED_IN": "1"}), timeout=20)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("CLAUDE_AUTH_UNAVAILABLE_IN_TUI", output.read_text(encoding="utf-8"))
+
+    def test_session_limit_after_submit_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            args, output = self.launcher_args(tmp)
+            proc = run_cmd(args, env=self.make_fake_env(tmp, {"FAKE_CLAUDE_SESSION_LIMIT": "1"}), timeout=30)
+            self.assertEqual(proc.returncode, 25, proc.stderr + proc.stdout)
+            text = output.read_text(encoding="utf-8")
+            self.assertIn("CLAUDE_SESSION_LIMIT_IN_TUI", text)
+            self.assertIn("session/rate limit after submit", text)
+
+    def test_tui_not_ready_does_not_succeed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            args, output = self.launcher_args(tmp, timeout=3)
+            proc = run_cmd(args, env=self.make_fake_env(tmp, {"FAKE_CLAUDE_NO_READY": "1"}), timeout=20)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("CLAUDE_TUI_NOT_READY", output.read_text(encoding="utf-8"))
+
+    def test_answer_before_post_submit_baseline_fails_boundary_uncertain(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            args, output = self.launcher_args(tmp)
+            proc = run_cmd(args, env=self.make_fake_env(tmp, {"FAKE_CLAUDE_BOUNDARY_UNCERTAIN": "1"}), timeout=20)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("CLAUDE_TUI_BOUNDARY_UNCERTAIN", output.read_text(encoding="utf-8"))
+
+    def test_baseline_mismatch_without_occurrence_diff_is_uncertain(self) -> None:
+        spec = importlib.util.spec_from_file_location("launcher_under_test", LAUNCHER)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        marker = "CLAUDE_REVIEW_ANSWER_START_deadbeef"
+        sentinel = "CLAUDE_REVIEW_DONE_TEST_SENTINEL_12345"
+        self.assertIsNone(module.suffix_after_baseline("old prompt", "unrelated later text", marker, sentinel))
+
+    def test_prompt_cleared_answer_extraction_rejects_visible_prompt(self) -> None:
+        spec = importlib.util.spec_from_file_location("launcher_under_test", LAUNCHER)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        marker = "CLAUDE_REVIEW_ANSWER_START_deadbeef"
+        sentinel = "CLAUDE_REVIEW_DONE_TEST_SENTINEL_12345"
+        visible_prompt = f"Claude review launcher emission protocol\n{marker}\n<review text here>\n{sentinel}\nCLAUDE_REVIEW_FINAL_SENTINEL:{sentinel}"
+        cleared_answer = f"Claude Code\n{marker}\nVERDICT: PASS_SCOPED\nPrompt cleared answer\n{sentinel}\n❯"
+        self.assertIsNone(module.extract_prompt_cleared_answer(visible_prompt, marker, sentinel))
+        self.assertIn("Prompt cleared answer", module.extract_prompt_cleared_answer(cleared_answer, marker, sentinel))
+
+    def test_smoke_success_tears_down(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            output = tmp / "smoke.txt"
+            proc = run_cmd([
+                sys.executable,
+                str(LAUNCHER),
+                "--smoke",
+                "--cwd",
+                str(ROOT),
+                "--output",
+                str(output),
+                "--review-name",
+                "fake-smoke",
+                "--timeout-seconds",
+                "8",
+            ], env=self.make_fake_env(tmp), timeout=25)
+            self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+            text = output.read_text(encoding="utf-8")
+            self.assertIn("CLAUDE_REVIEW_SMOKE_READY", text)
+            socket = next(line for line in text.splitlines() if line.startswith("socket=")).split("=", 1)[1]
+            self.assertNotEqual(run_cmd(["tmux", "-L", socket, "list-sessions"], timeout=5).returncode, 0)
+
+
+class GuardrailTestCase(unittest.TestCase):
+    def run_guardrail(self, root: Path) -> subprocess.CompletedProcess[str]:
+        return run_cmd([sys.executable, str(GUARDRAIL), "--root", str(root)], timeout=20)
+
+    def test_guardrail_allows_benign_prose_paths_and_constants(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            path = root / "review-doc.md"
+            path.write_text(textwrap.dedent("""
+                This mentions skills/claude-code-review and claude_interactive_review.py.
+                The marker CLAUDE_REVIEW_DONE_X and slug claude-plan-nod636 are prose.
+                We want interactive Claude review reliability.
+            """), encoding="utf-8")
+            proc = self.run_guardrail(root)
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+    def test_guardrail_rejects_direct_transport_candidates(self) -> None:
+        bad_lines = [
+            "claude -p prompt",
+            "claude --print prompt",
+            "cat prompt | claude",
+            "claude < prompt.txt",
+            "claude --future-noninteractive x",
+            "interactive_shell({ command: 'claude hello' })",
+            "process({ command: 'claude hello' })",
+            "os.execvp('claude', ['claude', '--permission-mode', 'bypassPermissions'])",
+            "cd repo && zsh -ilc 'claude'",
+            "Review command: tmux new-window -n review 'claude'",
+            "REVIEW_CMD=claude --dangerously-skip-permissions prompt",
+            "cmd=claude prompt",
+            "RUN_CLAUDE=claude prompt",
+            'cmd="claude prompt"',
+        ]
+        for line in bad_lines:
+            with self.subTest(line=line), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                (root / "review.md").write_text(line + "\n", encoding="utf-8")
+                proc = self.run_guardrail(root)
+                self.assertNotEqual(proc.returncode, 0, proc.stdout)
+                self.assertIn("CLAUDE_DIRECT_REVIEW_LAUNCHES_FOUND", proc.stdout)
+
+    def test_guardrail_rejects_multiline_python_argv_candidates(self) -> None:
+        bad_blocks = [
+            'cmd = ["claude", "-p", prompt]\nsubprocess.run(cmd)\n',
+            'RUN_CLAUDE = ["claude", "--print", prompt]\n',
+            'subprocess.run([\n    "claude",\n    "-p",\n    prompt,\n])\n',
+            'os.execvp("claude", [\n    "claude",\n    "--permission-mode",\n    "bypassPermissions",\n])\n',
+        ]
+        for block in bad_blocks:
+            with self.subTest(block=block), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                (root / "review.py").write_text(block, encoding="utf-8")
+                proc = self.run_guardrail(root)
+                self.assertNotEqual(proc.returncode, 0, proc.stdout)
+                self.assertIn("CLAUDE_DIRECT_REVIEW_LAUNCHES_FOUND", proc.stdout)
+
+    def test_guardrail_allows_marked_forbidden_examples(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "review.md").write_text("claude -p prompt  # [FORBIDDEN-EXAMPLE]\n", encoding="utf-8")
+            self.assertEqual(self.run_guardrail(root).returncode, 0)
+
+    def test_guardrail_rejects_previous_line_forbidden_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "review.md").write_text("# [FORBIDDEN-EXAMPLE]\nclaude -p prompt\n", encoding="utf-8")
+            self.assertNotEqual(self.run_guardrail(root).returncode, 0)
+
+    def test_guardrail_self_and_tests_exemptions_are_path_scoped(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            exempt = root / "skills/claude-code-review/tests/sample.md"
+            exempt.parent.mkdir(parents=True)
+            exempt.write_text("claude -p prompt\n", encoding="utf-8")
+            non_exempt = root / "other/review/sample.md"
+            non_exempt.parent.mkdir(parents=True)
+            non_exempt.write_text("claude -p prompt\n", encoding="utf-8")
+            proc = self.run_guardrail(root)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn(str(non_exempt), proc.stdout)
+            self.assertNotIn(str(exempt), proc.stdout)
+
+
+class OpenCodeResolverTestCase(unittest.TestCase):
+    def load_module(self):
+        spec = importlib.util.spec_from_file_location("linear_build_review_under_test", LINEAR_REVIEW)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        return module
+
+    def test_env_override_resolves_launcher(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "launcher.py"
+            path.write_text("# launcher\n", encoding="utf-8")
+            old = os.environ.get("CLAUDE_REVIEW_LAUNCHER")
+            os.environ["CLAUDE_REVIEW_LAUNCHER"] = str(path)
+            try:
+                self.assertEqual(self.load_module().resolve_claude_review_launcher(), path)
+            finally:
+                if old is None:
+                    os.environ.pop("CLAUDE_REVIEW_LAUNCHER", None)
+                else:
+                    os.environ["CLAUDE_REVIEW_LAUNCHER"] = old
+
+    def test_repo_checkout_resolves_launcher(self) -> None:
+        old_launcher = os.environ.pop("CLAUDE_REVIEW_LAUNCHER", None)
+        old_home = os.environ.get("HOME")
+        with tempfile.TemporaryDirectory() as td:
+            os.environ["HOME"] = td
+            try:
+                self.assertEqual(self.load_module().resolve_claude_review_launcher(), LAUNCHER)
+            finally:
+                if old_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = old_home
+                if old_launcher is not None:
+                    os.environ["CLAUDE_REVIEW_LAUNCHER"] = old_launcher
+
+    def test_installed_agents_resolves_before_repo_checkout(self) -> None:
+        old_launcher = os.environ.pop("CLAUDE_REVIEW_LAUNCHER", None)
+        old_home = os.environ.get("HOME")
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            installed = home / ".agents/skills/claude-code-review/scripts/claude_interactive_review.py"
+            installed.parent.mkdir(parents=True)
+            installed.write_text("# installed launcher\n", encoding="utf-8")
+            os.environ["HOME"] = str(home)
+            try:
+                self.assertEqual(self.load_module().resolve_claude_review_launcher(), installed)
+            finally:
+                if old_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = old_home
+                if old_launcher is not None:
+                    os.environ["CLAUDE_REVIEW_LAUNCHER"] = old_launcher
+
+    def test_opencode_compatibility_copy_resolves_launcher(self) -> None:
+        old_launcher = os.environ.pop("CLAUDE_REVIEW_LAUNCHER", None)
+        old_home = os.environ.get("HOME")
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td) / "home"
+            os.environ["HOME"] = str(home)
+            opencode = home / ".config/opencode/skills/claude-code-review/scripts/claude_interactive_review.py"
+            opencode.parent.mkdir(parents=True)
+            opencode.write_text("# opencode launcher\n", encoding="utf-8")
+            module = self.load_module()
+            module.__file__ = str(Path(td) / "checkout/_opencode/scripts/linear_build_review.py")
+            try:
+                self.assertEqual(module.resolve_claude_review_launcher(), opencode)
+            finally:
+                if old_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = old_home
+                if old_launcher is not None:
+                    os.environ["CLAUDE_REVIEW_LAUNCHER"] = old_launcher
+
+    def test_missing_launcher_failure_message_lists_install_and_override(self) -> None:
+        old_launcher = os.environ.pop("CLAUDE_REVIEW_LAUNCHER", None)
+        old_home = os.environ.get("HOME")
+        with tempfile.TemporaryDirectory() as td:
+            os.environ["HOME"] = str(Path(td) / "home")
+            module = self.load_module()
+            module.__file__ = str(Path(td) / "checkout/_opencode/scripts/linear_build_review.py")
+            try:
+                with self.assertRaises(FileNotFoundError) as exc:
+                    module.resolve_claude_review_launcher()
+                message = str(exc.exception)
+                self.assertIn("Run ./install.sh --opencode", message)
+                self.assertIn("CLAUDE_REVIEW_LAUNCHER", message)
+                self.assertIn(".config/opencode/skills/claude-code-review", message)
+            finally:
+                if old_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = old_home
+                if old_launcher is not None:
+                    os.environ["CLAUDE_REVIEW_LAUNCHER"] = old_launcher
+
+
+class RealClaudeTestCase(unittest.TestCase):
+    def test_real_smoke(self) -> None:
+        if os.environ.get("RUN_REAL_CLAUDE_SMOKE") != "1":
+            self.skipTest("RUN_REAL_CLAUDE_SMOKE not set")
+        with tempfile.TemporaryDirectory() as td:
+            output = Path(td) / "real-smoke.txt"
+            proc = run_cmd([
+                sys.executable,
+                str(LAUNCHER),
+                "--smoke",
+                "--cwd",
+                str(ROOT),
+                "--output",
+                str(output),
+                "--review-name",
+                "real-smoke",
+                "--timeout-seconds",
+                "120",
+            ], timeout=180)
+            self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+            self.assertIn("CLAUDE_REVIEW_SMOKE_READY", output.read_text(encoding="utf-8"))
+
+    def test_real_e2e_review(self) -> None:
+        if os.environ.get("RUN_REAL_CLAUDE_E2E") != "1":
+            self.skipTest("RUN_REAL_CLAUDE_E2E not set")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            prompt = tmp / "prompt.md"
+            output = tmp / "real-review.md"
+            prompt.write_text("Read-only smoke review. Return exactly: VERDICT: PASS_SCOPED followed by one short sentence.", encoding="utf-8")
+            proc = run_cmd([
+                sys.executable,
+                str(LAUNCHER),
+                "--cwd",
+                str(ROOT),
+                "--prompt-file",
+                str(prompt),
+                "--output",
+                str(output),
+                "--review-name",
+                "real-e2e-review",
+                "--timeout-seconds",
+                "300",
+            ], timeout=420)
+            text = output.read_text(encoding="utf-8") if output.exists() else ""
+            if proc.returncode == 25 and "CLAUDE_SESSION_LIMIT_IN_TUI" in text:
+                self.skipTest("real Claude session/rate limit is active")
+            self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+            self.assertIn("VERDICT: PASS_SCOPED", text)
+            self.assertIn("clear_boundary=", text)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--real-smoke", action="store_true")
+    parser.add_argument("--real-e2e-review", action="store_true")
+    args, remaining = parser.parse_known_args()
+    if args.real_smoke:
+        os.environ["RUN_REAL_CLAUDE_SMOKE"] = "1"
+    if args.real_e2e_review:
+        os.environ["RUN_REAL_CLAUDE_E2E"] = "1"
+    unittest.main(argv=[sys.argv[0], *remaining])
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/claude-code-review/tests/test_claude_interactive_review.py
+++ b/skills/claude-code-review/tests/test_claude_interactive_review.py
@@ -111,6 +111,16 @@ class LauncherTestCase(unittest.TestCase):
             self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
             self.assertIn("Fake Claude review body", output.read_text(encoding="utf-8"))
 
+    def test_prompt_cleared_tui_output_succeeds_before_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            args, output = self.launcher_args(tmp)
+            proc = run_cmd(args, env=self.make_fake_env(tmp, {"FAKE_CLAUDE_NO_ECHO": "1"}), timeout=30)
+            self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+            text = output.read_text(encoding="utf-8")
+            self.assertIn("Fake Claude review body", text)
+            self.assertIn("clear_boundary=prompt-cleared marker/sentinel extraction before baseline", text)
+
     def test_auth_preflight_false_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
@@ -282,6 +292,16 @@ class GuardrailTestCase(unittest.TestCase):
             self.assertNotEqual(proc.returncode, 0)
             self.assertIn(str(non_exempt), proc.stdout)
             self.assertNotIn(str(exempt), proc.stdout)
+
+    def test_guardrail_scans_plan_artifacts_when_explicitly_rooted(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            plan = root / "thoughts/plans/review-plan.html"
+            plan.parent.mkdir(parents=True)
+            plan.write_text("claude -p prompt\n", encoding="utf-8")
+            proc = self.run_guardrail(root)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn(str(plan), proc.stdout)
 
 
 class OpenCodeResolverTestCase(unittest.TestCase):

--- a/skills/claude-code-review/tests/test_claude_interactive_review.py
+++ b/skills/claude-code-review/tests/test_claude_interactive_review.py
@@ -174,6 +174,14 @@ class LauncherTestCase(unittest.TestCase):
         sentinel = "CLAUDE_REVIEW_DONE_TEST_SENTINEL_12345"
         self.assertIsNone(module.suffix_after_baseline("old prompt", "unrelated later text", marker, sentinel))
 
+    def test_launcher_pins_claude_code_to_sonnet_4_6(self) -> None:
+        spec = importlib.util.spec_from_file_location("launcher_under_test", LAUNCHER)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        self.assertEqual(module.CLAUDE_REVIEW_MODEL, "claude-sonnet-4-6")
+
     def test_prompt_cleared_answer_extraction_rejects_visible_prompt(self) -> None:
         spec = importlib.util.spec_from_file_location("launcher_under_test", LAUNCHER)
         self.assertIsNotNone(spec)

--- a/skills/claude-code-review/tests/test_claude_interactive_review.py
+++ b/skills/claude-code-review/tests/test_claude_interactive_review.py
@@ -182,6 +182,16 @@ class LauncherTestCase(unittest.TestCase):
         spec.loader.exec_module(module)
         self.assertEqual(module.CLAUDE_REVIEW_MODEL, "claude-sonnet-4-6")
 
+    def test_auth_status_accepts_compact_json(self) -> None:
+        spec = importlib.util.spec_from_file_location("launcher_under_test", LAUNCHER)
+        self.assertIsNotNone(spec)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        self.assertTrue(module.auth_status_logged_in('{"loggedIn":true,"authMethod":"fake"}\nEXIT=0\n'))
+        self.assertTrue(module.auth_status_logged_in('noise\n{"authMethod":"fake","loggedIn": true}\nEXIT=0\n'))
+        self.assertFalse(module.auth_status_logged_in('{"loggedIn":false,"authMethod":"none"}\nEXIT=1\n'))
+
     def test_prompt_cleared_answer_extraction_rejects_visible_prompt(self) -> None:
         spec = importlib.util.spec_from_file_location("launcher_under_test", LAUNCHER)
         self.assertIsNotNone(spec)

--- a/skills/codex-full-build/SKILL.md
+++ b/skills/codex-full-build/SKILL.md
@@ -140,7 +140,7 @@ Use `codex-review-partner` in `plan-review` mode. Provide a bounded prompt with:
 
 #### Claude Code Plan Review
 
-Use `claude-code-review` through the user-owned `codex` tmux session. Prompt Claude Code to review the plan read-only and return output on stdout. Do not ask Claude to edit files.
+Use `claude-code-review` through its canonical private-tmux interactive launcher. Prompt Claude Code to review the plan read-only and return structured output. Do not ask Claude to edit files, and do not use alternate Claude transports.
 
 #### Plan Review Verdicts
 

--- a/skills/install-matrix.json
+++ b/skills/install-matrix.json
@@ -94,10 +94,11 @@
     "claude-code-review": {
       "class": "consumer-specific-installable",
       "allowedConsumers": [
-        "pi"
+        "pi",
+        "opencode"
       ],
       "canonicalSource": "skills/claude-code-review",
-      "notes": "Pi-only: launches Claude Code through the user-owned codex tmux session for background plan/code reviews.",
+      "notes": "Pi and OpenCode: required Claude Code reviews use the canonical private-tmux interactive launcher; no codex tmux reuse or direct Claude transport.",
       "sourceType": "repo"
     },
     "claude-review-partner": {

--- a/skills/reviewed-html-plan/SKILL.md
+++ b/skills/reviewed-html-plan/SKILL.md
@@ -133,7 +133,7 @@ Use `codex-review-partner` in `plan-review` mode. The review input should includ
 
 #### Claude Code
 
-Use `claude-code-review` through the documented tmux/login-shell path. Prompt Claude Code to review the plan read-only and return structured output on stdout. Do not ask Claude to edit files.
+Use `claude-code-review` through its canonical private-tmux interactive launcher. Prompt Claude Code to review the plan read-only and return structured output. Do not ask Claude to edit files, and do not use alternate Claude transports.
 
 Ask both reviewers for one of these verdicts:
 

--- a/skills/scoped-plan-run/SKILL.md
+++ b/skills/scoped-plan-run/SKILL.md
@@ -158,9 +158,9 @@ Reject malformed reviews and rerun once with a tighter prompt.
 
 ### 6. Claude Review
 
-Use the `claude-code-review` skill for a read-only Claude review.
+Use the `claude-code-review` skill for a read-only Claude review through its canonical private-tmux interactive launcher.
 
-Claude must receive the same bounded prompt as Codex. It must not edit files. It must return findings in chat, classified with the same scope categories.
+Claude must receive the same bounded prompt as Codex. It must not edit files. It must return findings in chat, classified with the same scope categories. Do not use alternate Claude transports for this required gate.
 
 If Claude reports broad adjacent risks, keep them as deferred follow-ups unless they pass the scope classification test.
 

--- a/thoughts/plans/claude-review-reliability-plan.html
+++ b/thoughts/plans/claude-review-reliability-plan.html
@@ -1,0 +1,1542 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Claude Review Reliability Plan</title>
+  <style>
+    /* Default styles provided by pandoc.
+    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+    */
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+    /* CSS for syntax highlighting */
+    html { -webkit-text-size-adjust: 100%; }
+    pre > code.sourceCode { white-space: pre; position: relative; }
+    pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+    pre > code.sourceCode > span:empty { height: 1.2em; }
+    .sourceCode { overflow: visible; }
+    code.sourceCode > span { color: inherit; text-decoration: inherit; }
+    div.sourceCode { margin: 1em 0; }
+    pre.sourceCode { margin: 0; }
+    @media screen {
+    div.sourceCode { overflow: auto; }
+    }
+    @media print {
+    pre > code.sourceCode { white-space: pre-wrap; }
+    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+    }
+    pre.numberSource code
+      { counter-reset: source-line 0; }
+    pre.numberSource code > span
+      { position: relative; left: -4em; counter-increment: source-line; }
+    pre.numberSource code > span > a:first-child::before
+      { content: counter(source-line);
+        position: relative; left: -1em; text-align: right; vertical-align: baseline;
+        border: none; display: inline-block;
+        -webkit-touch-callout: none; -webkit-user-select: none;
+        -khtml-user-select: none; -moz-user-select: none;
+        -ms-user-select: none; user-select: none;
+        padding: 0 4px; width: 4em;
+        color: #aaaaaa;
+      }
+    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+    div.sourceCode
+      {   }
+    @media screen {
+    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+    }
+    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+    code span.at { color: #7d9029; } /* Attribute */
+    code span.bn { color: #40a070; } /* BaseN */
+    code span.bu { color: #008000; } /* BuiltIn */
+    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+    code span.ch { color: #4070a0; } /* Char */
+    code span.cn { color: #880000; } /* Constant */
+    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+    code span.dt { color: #902000; } /* DataType */
+    code span.dv { color: #40a070; } /* DecVal */
+    code span.er { color: #ff0000; font-weight: bold; } /* Error */
+    code span.ex { } /* Extension */
+    code span.fl { color: #40a070; } /* Float */
+    code span.fu { color: #06287e; } /* Function */
+    code span.im { color: #008000; font-weight: bold; } /* Import */
+    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+    code span.op { color: #666666; } /* Operator */
+    code span.ot { color: #007020; } /* Other */
+    code span.pp { color: #bc7a00; } /* Preprocessor */
+    code span.sc { color: #4070a0; } /* SpecialChar */
+    code span.ss { color: #bb6688; } /* SpecialString */
+    code span.st { color: #4070a0; } /* String */
+    code span.va { color: #19177c; } /* Variable */
+    code span.vs { color: #4070a0; } /* VerbatimString */
+    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+  </style>
+  <style>
+:root { color-scheme: dark; --bg:#0b1020; --panel:#111827; --text:#e5e7eb; --muted:#9ca3af; --accent:#7dd3fc; --border:#334155; --code:#020617; }
+html { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.55; }
+body { max-width: 1120px; margin: 0 auto; padding: 40px 28px 80px; background: var(--bg); color: var(--text); }
+a { color: var(--accent); }
+h1, h2, h3 { color: #f8fafc; line-height: 1.2; }
+h1 { border-bottom: 1px solid var(--border); padding-bottom: 0.45em; }
+h2 { margin-top: 2.2em; border-bottom: 1px solid rgba(148,163,184,.35); padding-bottom: .25em; }
+h3 { margin-top: 1.5em; }
+p, li { color: var(--text); }
+blockquote, .muted { color: var(--muted); }
+code { background: var(--code); color: #dbeafe; padding: .1em .28em; border-radius: 4px; }
+pre { background: var(--code); color: #dbeafe; border: 1px solid var(--border); border-radius: 10px; padding: 16px; overflow-x: auto; }
+pre code { background: transparent; color: #dbeafe; padding: 0; }
+pre code span, code.sourceCode span, div.sourceCode, code.sourceCode { color: inherit !important; background: transparent !important; }
+pre code span.kw, pre code span.fu, pre code span.va, pre code span.dt, pre code span.cn, pre code span.st, pre code span.co { color: #dbeafe !important; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+th, td { border: 1px solid var(--border); padding: 8px 10px; vertical-align: top; }
+th { background: var(--panel); }
+nav#TOC { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 16px 20px; margin: 20px 0 32px; }
+section { scroll-margin-top: 20px; }
+
+</style>
+</head>
+<body>
+<header id="title-block-header">
+<h1 class="title">Claude Review Reliability Plan</h1>
+</header>
+<nav id="TOC" role="doc-toc">
+<ul>
+<li><a href="#claude-review-reliability-plan"
+id="toc-claude-review-reliability-plan">Claude Review Reliability
+Plan</a>
+<ul>
+<li><a href="#status" id="toc-status">Status</a></li>
+<li><a href="#goal" id="toc-goal">Goal</a></li>
+<li><a href="#why-this-plan-exists" id="toc-why-this-plan-exists">Why
+this plan exists</a></li>
+<li><a href="#authority-and-inputs"
+id="toc-authority-and-inputs">Authority and inputs</a></li>
+<li><a href="#current-implementation-reality"
+id="toc-current-implementation-reality">Current implementation
+reality</a></li>
+<li><a href="#progress" id="toc-progress">Progress</a></li>
+<li><a href="#resume-instructions-agent"
+id="toc-resume-instructions-agent">Resume instructions (agent)</a></li>
+<li><a href="#product-intent-alignment"
+id="toc-product-intent-alignment">Product intent alignment</a></li>
+<li><a href="#locked-decisions" id="toc-locked-decisions">Locked
+decisions</a></li>
+<li><a href="#acceptance-criteria"
+id="toc-acceptance-criteria">Acceptance criteria</a></li>
+<li><a href="#bdd-scenarios" id="toc-bdd-scenarios">BDD
+scenarios</a></li>
+<li><a href="#phase-by-phase-execution-plan"
+id="toc-phase-by-phase-execution-plan">Phase-by-phase execution
+plan</a></li>
+<li><a href="#p0--inventory-every-claude-review-surface"
+id="toc-p0--inventory-every-claude-review-surface">P0 — Inventory every
+Claude review surface</a>
+<ul>
+<li><a href="#end-state" id="toc-end-state">End State</a></li>
+<li><a href="#tests-first" id="toc-tests-first">Tests first</a></li>
+<li><a href="#work" id="toc-work">Work</a></li>
+<li><a href="#expected-files" id="toc-expected-files">Expected
+files</a></li>
+<li><a href="#verify" id="toc-verify">Verify</a></li>
+</ul></li>
+<li><a href="#p1--add-tests-first-for-launcher-and-guardrail-contracts"
+id="toc-p1--add-tests-first-for-launcher-and-guardrail-contracts">P1 —
+Add tests first for launcher and guardrail contracts</a>
+<ul>
+<li><a href="#end-state-1" id="toc-end-state-1">End State</a></li>
+<li><a href="#tests-first-1" id="toc-tests-first-1">Tests first</a></li>
+<li><a href="#work-1" id="toc-work-1">Work</a></li>
+<li><a href="#expected-files-1" id="toc-expected-files-1">Expected
+files</a></li>
+<li><a href="#verify-1" id="toc-verify-1">Verify</a></li>
+</ul></li>
+<li><a href="#p2--implement-the-canonical-interactive-tmux-launcher"
+id="toc-p2--implement-the-canonical-interactive-tmux-launcher">P2 —
+Implement the canonical interactive tmux launcher</a>
+<ul>
+<li><a href="#end-state-2" id="toc-end-state-2">End State</a></li>
+<li><a href="#tests-first-2" id="toc-tests-first-2">Tests first</a></li>
+<li><a href="#work-2" id="toc-work-2">Work</a></li>
+<li><a href="#expected-files-2" id="toc-expected-files-2">Expected
+files</a></li>
+<li><a href="#verify-2" id="toc-verify-2">Verify</a></li>
+</ul></li>
+<li><a
+href="#p3--route-pi-opencode-and-shared-review-docs-to-the-launcher"
+id="toc-p3--route-pi-opencode-and-shared-review-docs-to-the-launcher">P3
+— Route Pi, OpenCode, and shared review docs to the launcher</a>
+<ul>
+<li><a href="#end-state-3" id="toc-end-state-3">End State</a></li>
+<li><a href="#tests-first-3" id="toc-tests-first-3">Tests first</a></li>
+<li><a href="#work-3" id="toc-work-3">Work</a></li>
+<li><a href="#expected-files-3" id="toc-expected-files-3">Expected
+files</a></li>
+<li><a href="#verify-3" id="toc-verify-3">Verify</a></li>
+</ul></li>
+<li><a
+href="#p4--validate-installed-fan-out-smoke-paths-and-final-guardrails"
+id="toc-p4--validate-installed-fan-out-smoke-paths-and-final-guardrails">P4
+— Validate installed fan-out, smoke paths, and final guardrails</a>
+<ul>
+<li><a href="#end-state-4" id="toc-end-state-4">End State</a></li>
+<li><a href="#tests-first-4" id="toc-tests-first-4">Tests first</a></li>
+<li><a href="#work-4" id="toc-work-4">Work</a></li>
+<li><a href="#expected-files-4" id="toc-expected-files-4">Expected
+files</a></li>
+<li><a href="#verify-4" id="toc-verify-4">Verify</a></li>
+</ul></li>
+<li><a href="#verification-strategy"
+id="toc-verification-strategy">Verification strategy</a></li>
+<li><a href="#delivery-order" id="toc-delivery-order">Delivery
+order</a></li>
+<li><a href="#non-goals" id="toc-non-goals">Non-goals</a></li>
+<li><a href="#decisions--deviations-log"
+id="toc-decisions--deviations-log">Decisions / Deviations log</a></li>
+</ul></li>
+</ul>
+</nav>
+<section id="claude-review-reliability-plan" class="level1">
+<h1>Claude Review Reliability Plan</h1>
+<section id="status" class="level2">
+<h2>Status</h2>
+<p>Implementation complete on branch <code>claude-review-reliability</code>.
+All P0-P4 checkboxes are complete, source and installed guardrails/smokes
+pass, and Codex implementation review v5 returned
+<code>VERDICT: PASS_SCOPED</code>. The required Claude implementation review
+was attempted through the canonical launcher and failed closed with
+<code>CLAUDE_SESSION_LIMIT_IN_TUI</code> because the real Claude account
+session/rate limit is currently active; no alternate Claude transport was
+used.</p>
+</section>
+<section id="goal" class="level2">
+<h2>Goal</h2>
+<p>Make every required Claude Code review in this repository use one
+canonical interactive Claude launcher: a real <code>claude</code> TUI
+created inside a launcher-owned private tmux server and driven by
+paste/send/capture. No required review path may use
+<code>claude -p</code>, prompt piping, direct <code>claude</code> shell
+snippets, direct <code>interactive_shell</code>/<code>process</code>
+launches, or model-provider substitutes.</p>
+</section>
+<section id="why-this-plan-exists" class="level2">
+<h2>Why this plan exists</h2>
+<p>The last week of Pi sessions showed Claude review reliability
+failures and repeated rework when agents mixed direct
+<code>claude -p</code>, tmux-wrapped <code>claude -p</code>, and direct
+interactive launches. The user specifically asked for a reviewed plan
+before repo changes because <code>claude -p</code> uses a different
+token/session path than interactive Claude and has produced misleading
+login/time-out failures.</p>
+</section>
+<section id="authority-and-inputs" class="level2">
+<h2>Authority and inputs</h2>
+<p>Sources of truth:</p>
+<ul>
+<li>User instruction in this session: always use interactive Claude
+sessions through tmux for Claude reviews, review recent Pi sessions,
+test suggestions in mock scenarios, and do not modify the repo until
+plan approval.</li>
+<li>Repo guidance in
+<code>/Users/anichols/code/ai-configs/AGENTS.md</code>: operate directly
+on <code>main</code>, use the plan-review service for reviewed HTML
+plans, and keep plan/task artifacts resumable.</li>
+<li>Planning doctrine from <code>planning-workflow</code>:
+execution-ready plans need status, progress, resume instructions, BDD
+scenarios, phase subheads, concrete verification, and no unresolved
+foundational decisions.</li>
+<li>Product doctrine from <code>product-principles</code>: make the
+correct path the easiest path, fail closed on identity/auth uncertainty,
+and return agent-legible recovery guidance.</li>
+<li>Session evidence from <code>~/.pi/agent/sessions</code> covering
+2026-05-30 through 2026-06-06.</li>
+<li>Repo inspection of <code>_pi</code>, <code>skills</code>,
+<code>_opencode</code>, <code>_claude</code>, <code>_omp</code>,
+<code>_codex</code>, <code>scripts</code>, <code>install.sh</code>, and
+<code>skills/install-matrix.json</code>.</li>
+<li>Mock tmux/Claude drivers built under <code>/tmp</code>, plus live
+auth smoke checks from the current Pi process and from an existing
+<code>codex</code> tmux session.</li>
+</ul>
+</section>
+<section id="current-implementation-reality" class="level2">
+<h2>Current implementation reality</h2>
+<p>Claude review workflows currently mix three launch styles:</p>
+<ol type="1">
+<li>direct <code>claude -p</code> from <code>process</code> or
+shell,</li>
+<li><code>claude -p</code> inside tmux,</li>
+<li>real interactive Claude sessions.</li>
+</ol>
+<p>The first two do not satisfy the requirement. Existing evidence:</p>
+<ul>
+<li><code>2026-06-06 ... heddle-bunyip</code>: PR186 review attempted
+one tmux <code>claude -p</code> run, then at least eight direct
+<code>claude -p</code> retries. The tmux auth probe returned
+<code>loggedIn: false</code>, <code>authMethod: none</code>, and
+<code>EXIT=1</code>. Direct <code>claude -p</code> attempts were killed
+or exited without useful output; one artifact only contained
+<code>Warning: no stdin data received in 3s...</code>.</li>
+<li><code>2026-06-01 ... heddle-dev-worktrees-auto-update</code>: tmux
+plus <code>claude -p</code> worked in 2-3 minutes, showing the old path
+can work but still uses the wrong non-interactive token path.</li>
+<li><code>2026-06-05 ... plan-reviewer</code>: tmux plus
+<code>claude -p</code> plan and rereview succeeded, proving reliability
+varies by session state.</li>
+<li><code>2026-06-05/06 ... NOD-906</code>: four tmux plus
+<code>claude -p</code> plan review passes succeeded, but required
+multiple reruns for plan convergence.</li>
+</ul>
+<p>Local auth checks during planning showed:</p>
+<ul>
+<li>direct current shell: <code>claude auth status</code> returns
+<code>loggedIn: true</code>,</li>
+<li>existing <code>codex</code> tmux session:
+<code>claude auth status</code> returns
+<code>loggedIn: false</code>,</li>
+<li>private tmux socket created from the current shell:
+<code>claude auth status</code> returns
+<code>loggedIn: true</code>.</li>
+</ul>
+<p>Implication: tmux has no independent auth state. Claude credential
+availability depends on the parent process/environment that creates the
+tmux server and runs the CLI.</p>
+<p>Mock and smoke validation already performed without modifying repo
+files:</p>
+<ul>
+<li>Direct <code>claude -p</code> path rejected by mock.</li>
+<li>Interactive tmux prompt paste plus sentinel capture succeeded in
+mock.</li>
+<li>Auth failure path returned an explicit preflight failure.</li>
+<li>Hung review path timed out and preserved transcript output.</li>
+<li>Real private-tmux smoke from this Pi process reached
+<code>loggedIn: true</code>, while existing <code>codex</code> tmux
+returned <code>loggedIn: false</code>.</li>
+<li>An early interactive Claude review driver had a false-positive
+sentinel bug because it matched prompt echo; this plan now requires
+post-submit/post-clear boundary tests.</li>
+</ul>
+<p>Known implementation targets from draft inventory:</p>
+<ul>
+<li><code>skills/claude-code-review/SKILL.md</code></li>
+<li><code>skills/claude-code-review/scripts/claude_interactive_review.py</code></li>
+<li><code>skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py</code></li>
+<li><code>skills/claude-code-review/tests/test_claude_interactive_review.py</code></li>
+<li><code>skills/claude-code-review/tests/fixtures/fake_claude.py</code></li>
+<li><code>skills/claude-code-review/tests/fixtures/tui_transcripts/ansi_spinner_prompt_echo.txt</code></li>
+<li><code>_pi/prompts/review:change-claude-code.md</code></li>
+<li><code>_pi/prompts/dev:reviewed-html-plan.md</code></li>
+<li><code>_pi/prompts/review:plan-adversarial.md</code></li>
+<li><code>_pi/README.md</code></li>
+<li><code>skills/reviewed-html-plan/SKILL.md</code></li>
+<li><code>skills/codex-full-build/SKILL.md</code></li>
+<li><code>skills/scoped-plan-run/SKILL.md</code></li>
+<li><code>skills/install-matrix.json</code></li>
+<li><code>_opencode/scripts/linear_build_review.py</code></li>
+<li><code>_opencode/commands/cmd:linear-build-workspace.md</code></li>
+<li><code>_omp/commands/review:plan-adversarial.md</code> and similar
+model-provider review docs if inventory confirms relevant
+references.</li>
+</ul>
+</section>
+<section id="progress" class="level2">
+<h2>Progress</h2>
+<ul class="task-list">
+<li><label><input type="checkbox" checked="" />P0 — Inventory every Claude review
+surface.</label></li>
+<li><label><input type="checkbox" checked="" />P1 — Add tests first for launcher
+and guardrail contracts.</label></li>
+<li><label><input type="checkbox" checked="" />P2 — Implement the canonical
+interactive tmux launcher.</label></li>
+<li><label><input type="checkbox" checked="" />P3 — Route Pi, OpenCode, and shared
+review docs to the launcher.</label></li>
+<li><label><input type="checkbox" checked="" />P4 — Validate installed fan-out,
+same-process smoke paths, and guardrails.</label></li>
+</ul>
+</section>
+<section id="resume-instructions-agent" class="level2">
+<h2>Resume instructions (agent)</h2>
+<p>Read this whole plan first. Identify the first unchecked item in
+<code>Progress</code>, execute only that phase, update its checkbox
+immediately after successful verification, then continue phase-by-phase.
+Do not modify repo files before this plan is approved. During execution,
+do not create alternate Claude launch transports, do not use
+<code>claude -p</code> for required reviews, and do not mark the work
+done until the final source and installed guardrail scans plus
+Pi/OpenCode same-process smokes pass. If a Claude auth or TUI readiness
+check fails, preserve the transcript and inspect command, stop with the
+classified error, and ask for the exact user action named by the
+failure; never retry by changing transport.</p>
+</section>
+<section id="product-intent-alignment" class="level2">
+<h2>Product intent alignment</h2>
+<ul>
+<li>Golden path: agents call one canonical launcher; the launcher owns
+tmux, readiness, prompt delivery, answer extraction, failure
+classification, and transcript preservation.</li>
+<li>Safe default: create a fresh private tmux server from the real
+review-launching process. Do not reuse the existing <code>codex</code>
+tmux session, because it currently reports
+<code>loggedIn: false</code>.</li>
+<li>Self-healing boundary: the launcher can verify prerequisites,
+classify failures, preserve inspectable tmux state, and point to exact
+smoke commands. It must not silently switch to <code>claude -p</code>,
+<code>--file</code>, prompt piping, direct
+<code>interactive_shell</code>, or model-provider substitutes.</li>
+<li>Fail-closed boundary: identity/auth, TUI readiness, and prompt-echo
+boundary uncertainty must stop execution. A false successful review is
+worse than a blocked review.</li>
+<li>Agent-legible errors: missing <code>tmux</code>/<code>claude</code>,
+<code>claude auth status</code> false, TUI not logged in, TUI readiness
+timeout, prompt-boundary uncertainty, and review timeout all include
+what was tried, where the raw transcript is, how to inspect tmux, and
+the next safe action.</li>
+</ul>
+</section>
+<section id="locked-decisions" class="level2">
+<h2>Locked decisions</h2>
+<ul>
+<li>Required Claude Code reviews use only
+<code>skills/claude-code-review/scripts/claude_interactive_review.py</code>
+or its installed copies.</li>
+<li>The launcher starts exactly one real interactive <code>claude</code>
+TUI inside a private tmux server and drives it through tmux
+paste/send/capture.</li>
+<li>Required reviews must never use <code>claude -p</code>,
+<code>claude --print</code>, direct prompt args, input redirection into
+<code>claude</code>, stdin/prompt piping into <code>claude</code>,
+<code>--file</code>, future unknown non-interactive Claude flags, direct
+<code>interactive_shell</code>/<code>process</code>/<code>bash</code>
+Claude snippets, raw <code>tmux new-window ... claude</code> outside the
+launcher, or model-provider substitutes.</li>
+<li>Guardrail enforcement is allowlist-based for executable Claude Code
+CLI invocation candidates in review surfaces. Candidate invocations are
+defined by the guardrail detection grammar below; prose mentions,
+headings, directory/path names such as <code>claude-code-review</code>,
+filenames such as <code>claude_interactive_review.py</code>, slugs like
+<code>claude-plan-*</code>, environment/marker names such as
+<code>CLAUDE_REVIEW_*</code>, JSON metadata, and non-command explanatory
+text are not invocation candidates. Any candidate invocation outside the
+canonical launcher/test exemptions and outside the exact
+launcher-internal forms allowed only in canonical launcher copies fails,
+even if it does not match a known denylist pattern.</li>
+<li>Anthropic/Claude model-provider reviews that are not Claude Code CLI
+launches, such as OpenCode Zen <code>claude-opus-*</code>, are optional
+non-gating reviewers only.</li>
+<li><code>claude auth status</code> in the launcher-created tmux server
+is an early signal only. Final readiness also requires live TUI prompt
+detection and post-submit answer-boundary extraction.</li>
+<li>The existing <code>codex</code> tmux session is not the default
+review host.</li>
+<li>The launcher validates transport completion only. Domain verdict
+parsing remains owned by callers such as
+<code>_opencode/scripts/linear_build_review.py</code>.</li>
+<li><code>skills/install-matrix.json</code> keeps
+<code>class: "consumer-specific-installable"</code> and sets
+<code>claude-code-review.allowedConsumers</code> to
+<code>['pi', 'opencode']</code>.</li>
+<li>OpenCode invokes the launcher via <code>sys.executable</code>, not
+by requiring executable bits.</li>
+<li>Tests may fake Claude only by controlling temporary
+<code>HOME</code>/<code>ZDOTDIR</code>/<code>PATH</code>; production
+code has no fake-Claude or binary override flag except the explicit
+OpenCode resolver env <code>CLAUDE_REVIEW_LAUNCHER</code> for source
+validation.</li>
+</ul>
+</section>
+<section id="acceptance-criteria" class="level2">
+<h2>Acceptance criteria</h2>
+<p>AC1. No Claude review skill, prompt, script, command, or documented
+required review process recommends or executes <code>claude -p</code> or
+another direct Claude transport.</p>
+<p>AC2. All required Claude review paths call one deterministic launcher
+entrypoint; agents cannot choose alternate shell snippets, fallback
+transports, flags, or retry strategies.</p>
+<p>AC3. The launcher creates a private tmux server from the real caller
+process, starts interactive <code>claude</code>, drives it through
+paste/send/capture, tears down successful review and smoke tmux servers,
+and preserves transcript/inspect metadata on failure.</p>
+<p>AC4. Prompt-echo cannot satisfy completion. Success requires an
+answer-start marker and sentinel after a post-submit/post-clear boundary
+in Claude's answer region.</p>
+<p>AC5. Mock tests pass without real Claude, including auth failures,
+timeout, prompt echo, ANSI/chrome, wrapping, and parseable output
+cases.</p>
+<p>AC6. Same-process real smoke tests pass for every consumer that
+invokes the launcher: Pi prompt path and OpenCode
+<code>linear_build_review.py</code> source and installed paths.</p>
+<p>AC7. Auth failure, missing prerequisites, TUI not ready,
+prompt-boundary uncertainty, and timeout produce classified,
+agent-legible failures with preserved transcript and inspect
+command.</p>
+<p>AC8. Existing workflows still support plan review, implementation
+review, rereview, verdict extraction, and parent-agent artifact
+saving.</p>
+<p>AC9. OpenCode <code>linear_build_review.py</code> continues to own
+verdict parsing while delegating only Claude transport to the
+launcher.</p>
+<p>AC10. Source and installed guardrail scans pass across repo,
+<code>~/.agents/skills</code>, <code>~/.config/opencode/skills</code>,
+<code>~/.config/opencode/scripts</code>,
+<code>~/.config/opencode/commands</code>,
+<code>~/.config/opencode/agents</code>,
+<code>~/.config/opencode/prompts</code>,
+<code>~/.pi/agent/prompts</code>, and <code>~/.pi/agent/agents</code>;
+scans fail by default for any non-exempt executable Claude Code CLI
+invocation candidate in review surfaces that is not inside a canonical
+launcher copy or approved test fixture/marked forbidden example.</p>
+<p>AC11. A real-Claude prompt-submitting end-to-end validation passes
+before completion: it submits a tiny live review prompt through the
+launcher, observes the real TUI readiness and post-submit/post-clear
+boundary, extracts only the answer-region marker/sentinel pair, and
+records the confirmed readiness regex plus clear-boundary observable
+used by production code.</p>
+</section>
+<section id="bdd-scenarios" class="level2">
+<h2>BDD scenarios</h2>
+<p>Scenario S1 — Required review uses canonical interactive tmux
+launcher</p>
+<ul>
+<li>Given an agent needs a required Claude Code review,</li>
+<li>When it invokes the review workflow from Pi or OpenCode,</li>
+<li>Then the workflow calls the canonical launcher,</li>
+<li>And only the launcher starts
+<code>cd &lt;repo&gt; &amp;&amp; zsh -ilc 'claude'</code> inside a
+launcher-created private tmux server,</li>
+<li>And no <code>claude -p</code> or alternate direct transport is
+used.</li>
+</ul>
+<p>Scenario S2 — Direct or fallback Claude transports are rejected</p>
+<ul>
+<li>Given a skill, prompt, or script contains a runnable
+<code>claude -p</code>, <code>claude --print</code>, direct
+<code>claude --permission-mode</code>, direct prompt args, stdin piping
+into <code>claude</code>, input redirection such as
+<code>claude &lt; prompt.txt</code>, unknown future forms such as
+<code>claude --future-noninteractive x</code>, prompt piping, raw
+<code>interactive_shell(...claude...)</code>,
+<code>process(...claude...)</code>, or
+<code>os.execvp(...claude...)</code> review path,</li>
+<li>When the guardrail scans source or installed roots,</li>
+<li>Then it fails unless the reference is a marked forbidden example or
+approved test fixture,</li>
+<li>And it reports the offending path and line.</li>
+</ul>
+<p>Scenario S3 — Auth works only in the real caller context</p>
+<ul>
+<li>Given the current shell can authenticate Claude but an existing
+unrelated tmux session cannot,</li>
+<li>When the launcher is run from the Pi prompt context or OpenCode
+subprocess context,</li>
+<li>Then it creates its own private tmux server from that caller
+process,</li>
+<li>And <code>claude auth status</code> is checked there as an early
+signal,</li>
+<li>And the same-process smoke proves the real caller context is usable
+before relying on the launcher.</li>
+</ul>
+<p>Scenario S4 — Auth failure fails closed with actionable evidence</p>
+<ul>
+<li>Given <code>claude auth status</code> is false/nonzero or the TUI
+reports <code>Not logged in</code>,</li>
+<li>When a smoke or review run starts,</li>
+<li>Then the launcher exits nonzero with a classified auth failure,</li>
+<li>And the output names what was tried, transcript path, tmux inspect
+command, and next user action,</li>
+<li>And no alternate transport retry is attempted.</li>
+</ul>
+<p>Scenario S5 — TUI readiness failure does not paste a prompt</p>
+<ul>
+<li>Given interactive Claude starts but never reaches a usable input
+prompt,</li>
+<li>When the readiness timeout expires,</li>
+<li>Then the launcher fails as <code>CLAUDE_TUI_NOT_READY</code>,</li>
+<li>And it preserves transcript and inspect command,</li>
+<li>And it does not paste or submit the review prompt.</li>
+</ul>
+<p>Scenario S6 — Prompt echo cannot produce false success</p>
+<ul>
+<li>Given the pasted prompt wrapper contains both
+<code>CLAUDE_REVIEW_ANSWER_START_&lt;nonce&gt;</code> and the sentinel
+instructions,</li>
+<li>When tmux captures prompt echo after Enter,</li>
+<li>Then the launcher treats the pre-submit capture as diagnostics
+only,</li>
+<li>And records a post-submit/post-clear boundary after the input box
+clears,</li>
+<li>And ignores marker/sentinel text at or before that boundary,</li>
+<li>And succeeds only on a marker/sentinel pair in Claude's answer
+region.</li>
+</ul>
+<p>Scenario S7 — Boundary uncertainty fails closed</p>
+<ul>
+<li>Given the launcher cannot prove the prompt echo has cleared before
+answer text appears,</li>
+<li>When extracting the review output,</li>
+<li>Then it fails as <code>CLAUDE_TUI_BOUNDARY_UNCERTAIN</code>,</li>
+<li>And it preserves raw transcript and inspect metadata,</li>
+<li>And it does not write a parseable success artifact.</li>
+</ul>
+<p>Scenario S8 — OpenCode verdict parsing remains deterministic</p>
+<ul>
+<li>Given OpenCode calls the launcher for a plan or implementation
+review,</li>
+<li>When the launcher succeeds,</li>
+<li>Then <code>--output</code> begins with ANSI-stripped, de-wrapped
+answer text strictly between the post-boundary answer-start marker and
+sentinel,</li>
+<li>And <code>linear_build_review.py</code> parses verdicts only from
+that normalized answer region,</li>
+<li>And raw pane transcript/TUI chrome cannot affect verdict
+parsing.</li>
+</ul>
+<p>Scenario S9 — Installed fan-out matches source behavior</p>
+<ul>
+<li>Given <code>./install.sh --pi</code> and
+<code>./install.sh --opencode</code> have run,</li>
+<li>When installed prompts, commands, scripts, and skills are inspected
+and smoke-tested,</li>
+<li>Then installed Pi and OpenCode paths resolve the same canonical
+launcher,</li>
+<li>And installed roots contain no stale direct Claude transports.</li>
+</ul>
+<p>Scenario S10 — Optional model-provider reviews cannot satisfy the
+required gate</p>
+<ul>
+<li>Given a workflow mentions <code>opencode-zen/claude-*</code> or
+<code>claude-opus-*</code>,</li>
+<li>When that workflow needs a required Claude Code review gate,</li>
+<li>Then the model-provider review is classified as
+optional/non-gating,</li>
+<li>And the required gate remains unsatisfied until the canonical Claude
+Code launcher succeeds.</li>
+</ul>
+</section>
+<section id="phase-by-phase-execution-plan" class="level2">
+<h2>Phase-by-phase execution plan</h2>
+</section>
+<section id="p0--inventory-every-claude-review-surface" class="level2">
+<h2>P0 — Inventory every Claude review surface</h2>
+<section id="end-state" class="level3">
+<h3>End State</h3>
+<p>Every Claude-related review reference is classified before edits:
+update target, non-review mention, forbidden example, guardrail-covered
+launcher internals, optional non-gating model-provider review, or test
+fixture.</p>
+</section>
+<section id="tests-first" class="level3">
+<h3>Tests first</h3>
+<p>Strict TDD is not applicable because this phase produces the evidence
+list that drives later tests. The compensating verification is the exact
+inventory command plus a manual classification record in the PR
+description or committed checklist only if requested by a reviewer.</p>
+</section>
+<section id="work" class="level3">
+<h3>Work</h3>
+<p>Run this exact inventory command and classify every hit:</p>
+<div class="sourceCode" id="cb1"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">rg</span> <span class="at">-n</span> <span class="st">&quot;claude -p|claude --print|\|[[:space:]]*claude\b|Claude Code|claude-code-review|claude.*review|review.*claude|run_claude|interactive Claude|tmux.*claude|os\.execvp\(.*claude|interactive_shell.*claude|claude --permission-mode|subprocess.*claude|exec.*claude|bash.*claude|process.*claude|claude-opus|opencode-zen/claude|\[[^]]*claude[^]]*\]&quot;</span> <span class="dt">\</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  _pi skills _opencode _claude _omp _codex scripts <span class="dv">2</span><span class="op">&gt;</span>/dev/null</span></code></pre></div>
+<p>Specific classifications required:</p>
+<ul>
+<li><code>skills/claude-review-partner/**</code> is a Codex wrapper
+despite the name unless inventory proves otherwise.</li>
+<li><code>claude-opus</code> / <code>opencode-zen/claude-*</code> hits,
+including <code>_omp/commands/review:plan-adversarial.md</code>, are
+optional non-gating model-provider reviews unless they invoke the Claude
+Code CLI.</li>
+<li>Known update targets listed in
+<code>Current implementation reality</code> must be checked even if the
+inventory pattern misses them.</li>
+</ul>
+</section>
+<section id="expected-files" class="level3">
+<h3>Expected files</h3>
+<p>No required repo file changes in this phase. Optional PR evidence can
+reference the command output and classification summary.</p>
+</section>
+<section id="verify" class="level3">
+<h3>Verify</h3>
+<p>Rerun the inventory after later phases and confirm every remaining
+Claude launch reference is canonical launcher use, a non-review mention,
+an optional non-gating model-provider review, an approved launcher
+internal form, a fixture, or a marked forbidden example.</p>
+</section>
+</section>
+<section id="p1--add-tests-first-for-launcher-and-guardrail-contracts"
+class="level2">
+<h2>P1 — Add tests first for launcher and guardrail contracts</h2>
+<section id="end-state-1" class="level3">
+<h3>End State</h3>
+<p>Tests and fixtures exist before implementation and fail for the
+current direct/fallback Claude transports. They lock transport, auth,
+readiness, prompt-boundary, extraction, guardrail, and installed-root
+expectations.</p>
+</section>
+<section id="tests-first-1" class="level3">
+<h3>Tests first</h3>
+<p>Create or update:</p>
+<ul>
+<li><code>skills/claude-code-review/tests/test_claude_interactive_review.py</code></li>
+<li><code>skills/claude-code-review/tests/fixtures/fake_claude.py</code></li>
+<li><code>skills/claude-code-review/tests/fixtures/tui_transcripts/ansi_spinner_prompt_echo.txt</code></li>
+<li><code>skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py</code></li>
+<li>optional minimal
+<code>skills/claude-code-review/scripts/claude_interactive_review.py</code>
+stub only as needed to make RED failures explicit.</li>
+</ul>
+<p>Launcher tests must cover:</p>
+<ul>
+<li>fake-Claude seam using temporary <code>HOME</code>,
+<code>ZDOTDIR</code>, and shell startup files that prepend fixture
+directory to <code>PATH</code>, so fixed <code>zsh -ilc 'claude'</code>
+resolves a test shim without production override flags,</li>
+<li>accidental <code>-p</code>, <code>--permission-mode</code>,
+<code>--file</code>, direct prompt args, or alternate Claude subprocess
+forms rejected,</li>
+<li>successful interactive prompt paste and sentinel capture,</li>
+<li>auth preflight false failure,</li>
+<li>TUI <code>Not logged in</code> failure,</li>
+<li>pre-paste prompt never ready failure as
+<code>CLAUDE_TUI_NOT_READY</code>,</li>
+<li>timeout preserving transcript and inspect command,</li>
+<li>successful fake review tears down the review-created tmux
+session/server after exit <code>0</code>,</li>
+<li>omitted <code>--sentinel</code> generates a nonce-derived unique
+sentinel and uses it in the wrapper/extraction path,</li>
+<li>invalid sentinels such as empty strings, newline/control-character
+values, and common tokens are rejected before tmux launch,</li>
+<li>multiline prompt paste preservation,</li>
+<li>deterministic collision-safe private tmux socket/session naming from
+review slug plus pid/nonce,</li>
+<li>echoed final prompt wrapper containing both
+<code>CLAUDE_REVIEW_ANSWER_START_&lt;nonce&gt;</code> and sentinel does
+not satisfy success,</li>
+<li>only a post-submit/post-clear answer-region marker/sentinel pair
+satisfies success,</li>
+<li>failure as <code>CLAUDE_TUI_BOUNDARY_UNCERTAIN</code> when the
+post-submit/post-clear boundary cannot be established,</li>
+<li>ANSI escape sequences, redraw/spinner text, Claude prompt chrome,
+and pane-width wrapping are handled,</li>
+<li>launcher output remains parseable when Claude exits or when the tmux
+pane stays live in failure/timeout paths before cleanup; successful
+review completion must still tear down its private tmux server.</li>
+</ul>
+<p>Guardrail detection grammar:</p>
+<ul>
+<li>Invocation candidates are <code>claude</code> tokens that appear in
+executable command-bearing contexts: shell fenced code blocks, inline
+code spans that contain runnable shell snippets, <code>.sh</code>
+command lines, Python/JavaScript/Ruby/etc. string literals passed to
+subprocess/process/exec/interpreter-launch APIs, tmux command strings,
+prompt-template command recipes, and command-like lines in lists or
+paragraphs that begin with a shell prompt, command verb, assignment plus
+command, redirection, or pipe.</li>
+<li>Non-candidates are prose mentions, headings, JSON keys/metadata that
+are not executed, directory/path references such as
+<code>skills/claude-code-review</code>, filenames such as
+<code>claude_interactive_review.py</code>, slugs/review names such as
+<code>claude-plan-nod636</code>, environment variables and constants
+such as <code>CLAUDE_REVIEW_*</code> /
+<code>CLAUDE_REVIEW_LAUNCHER</code>, model/provider names that do not
+launch the Claude Code CLI, and marked forbidden examples.</li>
+<li>Allowed-token exemptions are path/context based, not global string
+allowances: canonical launcher source copies by relative suffix
+<code>claude-code-review/scripts/claude_interactive_review.py</code>,
+tests/fixtures by relative suffix
+<code>claude-code-review/tests/**</code>, the guardrail implementation
+itself by relative suffix
+<code>claude-code-review/scripts/check_no_direct_claude_review_launches.py</code>,
+and marked forbidden/example documentation.
+Prose/path/slug/<code>CLAUDE_*</code> non-candidates need no exemption
+because they are outside the detection surface.</li>
+<li>The three launcher-internal command forms are allowed only in
+canonical launcher copies identified by suffix
+<code>claude-code-review/scripts/claude_interactive_review.py</code> and
+in marked forbidden/example documentation; the same strings in any other
+non-exempt review surface are violations.</li>
+<li>Tests must lock this grammar so broad source scans do not flag
+ordinary prose/path/slug/constant mentions, but do flag runnable or
+command-like Claude invocations.</li>
+</ul>
+<p>Guardrail tests must cover:</p>
+<ul>
+<li>guardrail behavior is allowlist-based for executable Claude
+invocation candidates in review surfaces: any candidate outside exempt
+files and outside canonical launcher copies fails, even if no enumerated
+denylist regex recognizes it,</li>
+<li>runnable <code>claude -p</code>, <code>claude --print</code>,
+<code>claude --permission-mode</code>, stdin-pipe forms such as
+<code>cat prompt | claude</code>, input-redirection forms such as
+<code>claude &lt; prompt.txt</code>, unknown future forms such as
+<code>claude --future-noninteractive x</code>, raw <code>claude</code>
+command strings, <code>interactive_shell(...claude...)</code>,
+<code>process(...claude...)</code>, and
+<code>os.execvp(...claude...)</code> in review docs/scripts are rejected
+outside the canonical launcher and fixtures,</li>
+<li>only explicitly marked forbidden examples are allowed,</li>
+<li>no-argument guardrail runs scan the same source roots as Phase 0
+inventory by default: <code>_pi</code>, <code>skills</code>,
+<code>_opencode</code>, <code>_claude</code>, <code>_omp</code>,
+<code>_codex</code>, and <code>scripts</code>,</li>
+<li>explicit <code>--root</code> arguments override the default root set
+and are used in P4 for installed-root scans,</li>
+<li>the guardrail script self-excludes its own path by relative suffix
+<code>claude-code-review/scripts/check_no_direct_claude_review_launches.py</code>
+in source and installed roots, because its detection-pattern literals
+must include forbidden strings,</li>
+<li>the guardrail exempts <code>claude-code-review/tests/**</code> in
+source and installed roots, because test modules and fixtures
+intentionally contain forbidden strings as inputs,</li>
+<li>tests assert the guardrail does not flag its own source path or
+source/installed <code>claude-code-review/tests/**</code> trees while
+still rejecting equivalent forbidden strings elsewhere,</li>
+<li>tests assert benign files containing only
+<code>skills/claude-code-review</code>,
+<code>claude_interactive_review.py</code>,
+<code>claude-plan-nod636</code>, <code>CLAUDE_REVIEW_*</code>, and prose
+such as “interactive Claude review” pass, while equivalent runnable
+invocations elsewhere fail,</li>
+<li>tests assert novel direct transports such as
+<code>claude &lt; prompt.txt</code> and
+<code>claude --future-noninteractive x</code> fail under the
+candidate-invocation allowlist rule even when they do not match a named
+denylist pattern,</li>
+<li>tests assert
+<code>cd &lt;repo&gt; &amp;&amp; zsh -ilc 'claude'</code> and raw
+<code>zsh -ilc 'claude'</code> in any non-exempt prompt/script are
+violations even though those strings are valid inside the launcher,</li>
+<li>canonical launcher copies are identified by relative path suffix
+<code>claude-code-review/scripts/claude_interactive_review.py</code>
+across repo, <code>~/.agents/skills</code>, and
+<code>~/.config/opencode/skills</code>,</li>
+<li>launcher-internal allowed forms inside canonical launcher copies are
+exactly <code>zsh -ilc 'command -v claude'</code>, private-tmux
+<code>claude auth status</code>, and
+<code>cd &lt;repo&gt; &amp;&amp; zsh -ilc 'claude'</code>.</li>
+</ul>
+<p>Forbidden-example convention:</p>
+<ul>
+<li>Any allowed documentation mention of a forbidden launch must be on a
+line containing <code>[FORBIDDEN-EXAMPLE]</code> or inside a fenced
+block whose info string is <code>forbidden-claude-launch</code>.</li>
+</ul>
+</section>
+<section id="work-1" class="level3">
+<h3>Work</h3>
+<p>Write the tests and guardrail script. Keep the production launcher as
+a stub if needed for RED. Define <code>fake_claude.py</code> as an
+interactive fake TUI, not just a command-output fixture: it must render
+readiness chrome compatible with the launcher's prompt detection, accept
+a multiline pasted prompt, echo the final prompt wrapper so the echo
+contains both <code>CLAUDE_REVIEW_ANSWER_START_&lt;nonce&gt;</code> and
+the sentinel, persist that submitted prompt in scrollback above the
+answer region, transition the input area to a cleared/non-editing state
+on Enter, and only then emit marker, answer text, and sentinel in the
+answer region. The prompt-echo and
+<code>CLAUDE_TUI_BOUNDARY_UNCERTAIN</code> cases must run end-to-end
+through launcher plus tmux against this fake TUI so one post-clear
+capture contains duplicate marker/sentinel pairs: the persisted prompt
+echo and the real answer pair. Reserve
+<code>ansi_spinner_prompt_echo.txt</code> for unit coverage of ANSI
+stripping, wrapping, redraw/spinner text, and normalization. Add
+guardrail self-scan tests proving the script exempts only
+<code>check_no_direct_claude_review_launches.py</code> and
+<code>claude-code-review/tests/**</code> in source/installed paths, not
+arbitrary files containing the same forbidden literals. Do not implement
+the full launcher until P2.</p>
+</section>
+<section id="expected-files-1" class="level3">
+<h3>Expected files</h3>
+<ul>
+<li><code>skills/claude-code-review/tests/test_claude_interactive_review.py</code></li>
+<li><code>skills/claude-code-review/tests/fixtures/fake_claude.py</code></li>
+<li><code>skills/claude-code-review/tests/fixtures/tui_transcripts/ansi_spinner_prompt_echo.txt</code></li>
+<li><code>skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py</code></li>
+<li><code>skills/claude-code-review/scripts/claude_interactive_review.py</code>
+if a stub is needed.</li>
+</ul>
+</section>
+<section id="verify-1" class="level3">
+<h3>Verify</h3>
+<div class="sourceCode" id="cb2"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> skills/claude-code-review/tests/test_claude_interactive_review.py</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py</span></code></pre></div>
+<p>Expected RED behavior before P2/P3: launcher behavior tests fail
+against the stub or current transports; guardrail fails while stale
+direct Claude review transports still exist.</p>
+</section>
+</section>
+<section id="p2--implement-the-canonical-interactive-tmux-launcher"
+class="level2">
+<h2>P2 — Implement the canonical interactive tmux launcher</h2>
+<section id="end-state-2" class="level3">
+<h3>End State</h3>
+<p><code>skills/claude-code-review/scripts/claude_interactive_review.py</code>
+satisfies P1 launcher tests and provides a single deterministic
+entrypoint for smoke and review modes.</p>
+</section>
+<section id="tests-first-2" class="level3">
+<h3>Tests first</h3>
+<p>Run the P1 launcher test suite before implementation and confirm the
+relevant tests fail for the current stub/current behavior. During
+implementation, make the tests pass without weakening prompt-boundary,
+auth, readiness, or guardrail assertions.</p>
+</section>
+<section id="work-2" class="level3">
+<h3>Work</h3>
+<p>Implement locked CLI contract:</p>
+<ul>
+<li>Normal review mode required inputs: <code>--cwd &lt;repo&gt;</code>,
+<code>--prompt-file &lt;path&gt;</code>,
+<code>--output &lt;path&gt;</code>,
+<code>--review-name &lt;slug&gt;</code>.</li>
+<li>Normal review mode optional inputs:
+<code>--timeout-seconds &lt;n&gt;</code>,
+<code>--sentinel &lt;string&gt;</code>.</li>
+<li>If <code>--sentinel</code> is omitted, the launcher generates a
+nonce-derived sentinel such as
+<code>CLAUDE_REVIEW_DONE_&lt;review-slug&gt;_&lt;pid&gt;_&lt;nonce&gt;</code>
+using the same collision-safe nonce source as the tmux socket.</li>
+<li>Sentinel validation rejects empty strings, newline/control
+characters, strings shorter than a documented minimum length, strings
+containing shell metacharacter ambiguity that would affect prompt
+wrapper readability, and common/generic tokens such as
+<code>DONE</code>, <code>END</code>, or <code>SUCCESS</code>; invalid
+sentinels fail before tmux launch with a classified input-validation
+error.</li>
+<li>Smoke mode required inputs: <code>--smoke</code>,
+<code>--output &lt;path&gt;</code>,
+<code>--review-name &lt;slug&gt;</code>.</li>
+<li>Smoke mode optional inputs: <code>--cwd &lt;repo&gt;</code>
+defaulting to <code>os.getcwd()</code>,
+<code>--timeout-seconds &lt;n&gt;</code>.</li>
+<li>Smoke mode has no <code>--prompt-file</code>; it runs same-process
+private-tmux auth and interactive TUI readiness only, without submitting
+a review prompt.</li>
+<li>Smoke success exits <code>0</code> and writes/prints
+<code>CLAUDE_REVIEW_SMOKE_READY</code> plus private tmux socket/session
+metadata.</li>
+<li>Smoke failure exits nonzero with the same classified
+missing-prerequisite/auth/TUI-readiness failure used by review
+mode.</li>
+<li>There is deliberately no <code>--verdict-regex</code>; callers
+validate domain verdicts from output.</li>
+</ul>
+<p>Implement tmux and Claude behavior:</p>
+<ul>
+<li>Verify <code>tmux</code> exists.</li>
+<li>Verify <code>claude</code> exists through
+<code>zsh -ilc 'command -v claude'</code>.</li>
+<li>Create a private tmux server/socket named by a documented function
+of review slug plus pid/nonce.</li>
+<li>Run <code>claude auth status</code> inside the private tmux server
+as an early signal; fail explicitly if <code>loggedIn</code> is
+false/nonzero.</li>
+<li>Launch only fixed command
+<code>cd &lt;repo&gt; &amp;&amp; zsh -ilc 'claude'</code> in the review
+pane.</li>
+<li>Never reuse the stale <code>codex</code> tmux session as
+default.</li>
+<li>Poll <code>tmux capture-pane -p -J</code> for a usable prompt
+signal, initially <code>❯</code>; confirm or adjust this regex against
+live Claude TUI during real smoke before finalizing, then commit the
+confirmed readiness regex or documented replacement as constants in
+<code>claude_interactive_review.py</code> so later runs do not re-guess
+it.</li>
+<li>Use a readiness timeout distinct from full review timeout.</li>
+<li>On pre-paste readiness timeout, fail as
+<code>CLAUDE_TUI_NOT_READY</code>, preserve transcript and inspect
+command, and do not paste the prompt.</li>
+<li>For the post-submit/post-clear baseline, detect the observable
+transition from editing to answer mode by checking that the echoed
+prompt/wrapper text is no longer present in the current input region and
+that Claude has returned to non-editing answer output chrome, initially
+modeled as disappearance of the bottom input-box content plus absence of
+the cursor/input line that contained the pasted wrapper. This observable
+cannot be validated by prompt-less smoke mode; confirm or adjust it
+during the required live prompt-submitting end-to-end validation below,
+then commit the confirmed observable or documented replacement as
+constants in <code>claude_interactive_review.py</code>.</li>
+</ul>
+<p>Implement capture and extraction:</p>
+<ul>
+<li>The launcher composes the final pasted prompt by appending a fixed
+emission-protocol wrapper to caller <code>--prompt-file</code>
+content.</li>
+<li>The wrapper instructs Claude to emit
+<code>CLAUDE_REVIEW_ANSWER_START_&lt;nonce&gt;</code> on its own line,
+then the answer, then the <code>--sentinel</code> value on its own final
+line.</li>
+<li>Callers must not embed answer-start marker or sentinel instructions
+themselves.</li>
+<li>Create or resize the review window to a fixed wide geometry,
+initially 220 columns; account for tmux versions where
+<code>new-window -x/-y</code> is unsupported by using a compatible
+resize step.</li>
+<li>Capture with
+<code>tmux capture-pane -p -J -S -&lt;history-limit&gt;</code>.</li>
+<li>Record a pre-submit capture for diagnostics only;
+pre-submit/pre-Enter capture is never parseable evidence.</li>
+<li>After sending Enter, wait until the concrete
+input-cleared/non-editing observable is seen, then record and store a
+normalized post-submit/post-clear baseline snapshot.</li>
+<li>If the post-submit/post-clear baseline observable cannot be
+established before answer text appears, fail closed as
+<code>CLAUDE_TUI_BOUNDARY_UNCERTAIN</code>.</li>
+<li>Strip ANSI/control sequences before matching.</li>
+<li>Use baseline-relative extraction rather than presence matching:
+normalize later captures the same way, compute the suffix/new text
+relative to the stored baseline by exact prefix match or
+occurrence-index diff, and only scan marker/sentinel occurrences newly
+appearing after that baseline.</li>
+<li>If the stored baseline is not a prefix of the later normalized
+capture and occurrence-index diff cannot prove which marker/sentinel
+pairs are new, fail closed as
+<code>CLAUDE_TUI_BOUNDARY_UNCERTAIN</code>.</li>
+<li>Ignore all marker/sentinel occurrences already present in the
+baseline, including persisted prompt-echo copies in scrollback.</li>
+<li>Require answer-start marker plus sentinel in the baseline-relative
+new text before returning success.</li>
+<li>Extract the deterministic answer region strictly between the first
+new answer-start marker and following new sentinel.</li>
+<li>Write <code>--output</code> with the normalized, ANSI-stripped,
+de-wrapped answer region first. Preserve raw transcript and inspect
+metadata after a delimiter or in a sibling transcript file.</li>
+</ul>
+<p>Implement failure and teardown:</p>
+<ul>
+<li>Missing <code>tmux</code>/<code>claude</code> fails as missing
+prerequisite.</li>
+<li><code>claude auth status</code> false/nonzero or TUI
+<code>Not logged in</code> fails as user-action-required auth
+error.</li>
+<li>Timeout preserves transcript and inspect command.</li>
+<li>Never retry with another transport or <code>claude -p</code>.</li>
+<li>After review sentinel success and answer extraction, send
+<code>/exit</code>, wait a bounded teardown timeout for the private tmux
+session/server to disappear, and kill the private tmux server if
+graceful exit does not complete; successful review completion must not
+leak a live Claude process.</li>
+<li>On smoke success, after writing/printing
+<code>CLAUDE_REVIEW_SMOKE_READY</code> and socket/session metadata, tear
+down the smoke-created interactive TUI by sending <code>/exit</code> and
+killing the private tmux server, or by directly killing the private tmux
+server if graceful exit is not available; smoke success must not leak a
+live Claude process.</li>
+<li>Leave failed/time-out tmux servers available unless explicit cleanup
+flag is used.</li>
+<li>Provide an optional documented cleanup/reap command for accumulated
+failed-run private tmux servers without making it part of normal success
+teardown.</li>
+</ul>
+</section>
+<section id="expected-files-2" class="level3">
+<h3>Expected files</h3>
+<ul>
+<li><code>skills/claude-code-review/scripts/claude_interactive_review.py</code></li>
+<li><code>skills/claude-code-review/tests/test_claude_interactive_review.py</code>
+only if tests need non-weakened updates from implementation discoveries,
+including smoke-success and review-success teardown assertions that the
+created tmux server is gone after exit <code>0</code>.</li>
+</ul>
+</section>
+<section id="verify-2" class="level3">
+<h3>Verify</h3>
+<div class="sourceCode" id="cb3"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> skills/claude-code-review/tests/test_claude_interactive_review.py</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py <span class="dt">\</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--root</span> skills/claude-code-review/scripts <span class="dt">\</span></span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--root</span> skills/claude-code-review/tests</span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a><span class="va">RUN_REAL_CLAUDE_SMOKE</span><span class="op">=</span>1 <span class="ex">python3</span> skills/claude-code-review/tests/test_claude_interactive_review.py <span class="at">--real-smoke</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a><span class="va">RUN_REAL_CLAUDE_E2E</span><span class="op">=</span>1 <span class="ex">python3</span> skills/claude-code-review/tests/test_claude_interactive_review.py <span class="at">--real-e2e-review</span></span></code></pre></div>
+<p>Pass condition: mock tests pass, the targeted guardrail check passes
+for implemented launcher internals plus guardrail/test exemptions,
+prompt-less real smoke from a manually invoked repo context reaches
+<code>CLAUDE_REVIEW_SMOKE_READY</code>, and the real prompt-submitting
+E2E review validates marker/sentinel extraction strictly after the
+post-submit/post-clear boundary. The E2E run must submit a tiny live
+prompt through the launcher, require the answer-start marker and
+sentinel in the answer region, fail on prompt echo, and produce or
+update the committed readiness regex plus post-submit clear-boundary
+observable. The full no-argument source-root guardrail is expected to
+keep failing until P3 removes stale consumer routes; carry those
+findings into P3 rather than treating them as a P2 failure. Manual real
+smoke/E2E is necessary but not sufficient; P4 validates actual
+Pi/OpenCode caller contexts.</p>
+</section>
+</section>
+<section
+id="p3--route-pi-opencode-and-shared-review-docs-to-the-launcher"
+class="level2">
+<h2>P3 — Route Pi, OpenCode, and shared review docs to the launcher</h2>
+<section id="end-state-3" class="level3">
+<h3>End State</h3>
+<p>Every real Claude Code review consumer calls the canonical launcher.
+Stale docs and command prompts no longer describe direct
+<code>claude -p</code>, direct interactive shell, old <code>codex</code>
+tmux defaults, or model-provider substitutes as required review
+paths.</p>
+</section>
+<section id="tests-first-3" class="level3">
+<h3>Tests first</h3>
+<p>Before edits, run the guardrail and inventory commands and confirm
+they fail or report stale routes. Add/update tests for OpenCode resolver
+and <code>--claude-smoke</code> before replacing
+<code>run_claude()</code> behavior.</p>
+</section>
+<section id="work-3" class="level3">
+<h3>Work</h3>
+<p>Update <code>skills/claude-code-review/SKILL.md</code>:</p>
+<ul>
+<li>frontmatter no longer says it launches through user-owned
+<code>codex</code> tmux,</li>
+<li>remove runnable <code>claude -p</code> examples and “prefer claude
+-p” language,</li>
+<li>remove old <code>codex</code> tmux default claim,</li>
+<li>document canonical launcher command, credential inheritance,
+same-process smoke testing, and fixed auth/timeout behavior.</li>
+</ul>
+<p>Update <code>_pi/prompts/review:change-claude-code.md</code>:</p>
+<ul>
+<li>frontmatter no longer says
+<code>interactive-shell hands-free, backgrounded</code>,</li>
+<li>replace direct <code>interactive_shell</code> plus Python wrapper
+plus <code>os.execvp(... claude ...)</code> transport with canonical
+launcher,</li>
+<li>the Pi prompt must invoke the central shared launcher at exact path
+<code>$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py</code>
+via <code>python3</code>; Pi must not guess alternate launcher locations
+or construct shell snippets,</li>
+<li>add exact smoke path:
+<code>/review:change-claude-code --claude-smoke</code> runs
+<code>$HOME/.agents/skills/claude-code-review/scripts/claude_interactive_review.py</code>
+with
+<code>--smoke --cwd &lt;current repo&gt; --review-name pi-review-change-smoke --output /tmp/pi-claude-review-smoke.txt</code>
+from Pi prompt context,</li>
+<li>keep review-only behavior and inline <code>[REVIEW:CLAUDE]</code>
+comment requirements,</li>
+<li>forbid fallback to direct Claude transport.</li>
+</ul>
+<p>Update shared workflow docs:</p>
+<ul>
+<li><code>skills/reviewed-html-plan/SKILL.md</code>,
+<code>skills/codex-full-build/SKILL.md</code>, and
+<code>skills/scoped-plan-run/SKILL.md</code> point to
+<code>claude-code-review</code> canonical launcher and explicitly say
+private-tmux interactive launcher only.</li>
+<li><code>_pi/prompts/dev:reviewed-html-plan.md</code> is a no-op unless
+P0 finds concrete launch mechanics; if edited, it delegates Claude
+review instead of launching Claude.</li>
+<li><code>_pi/prompts/review:plan-adversarial.md</code> replaces launch
+ambiguity with canonical launcher reference and deletes stale
+wrapper/backgrounding lifecycle language.</li>
+<li><code>_pi/README.md</code> updates
+<code>review-change-claude-code</code> description so it no longer says
+direct pi-interactive-shell hands-free launch/backgrounding.</li>
+<li><code>_omp/commands/review:plan-adversarial.md</code> and similar
+model-provider docs classify <code>opencode-zen/claude-*</code> as
+optional/non-gating if retained.</li>
+</ul>
+<p>Update <code>skills/install-matrix.json</code>:</p>
+<ul>
+<li>set <code>claude-code-review.allowedConsumers</code> unconditionally
+to <code>['pi', 'opencode']</code>,</li>
+<li>leave <code>class: 'consumer-specific-installable'</code>
+unchanged,</li>
+<li>update notes so they no longer describe old <code>codex</code>
+tmux-session behavior,</li>
+<li>verify <code>install.sh</code> fan-out copies <code>scripts/</code>
+and <code>tests/</code> subdirectories via existing
+<code>cp -a "$source_path/."</code> behavior,</li>
+<li>verify Pi discovers this consumer-specific shared skill from the
+central shared root
+<code>$HOME/.agents/skills/claude-code-review</code>; Pi does not need
+or use a mirror under <code>$HOME/.pi/agent/skills</code>.</li>
+</ul>
+<p>Update <code>_opencode/scripts/linear_build_review.py</code>:</p>
+<ul>
+<li>replace <code>run_claude()</code> using <code>claude -p</code> with
+a subprocess call to the canonical launcher,</li>
+<li>remove <code>ensure_codex_tmux()</code> from Claude review path and
+delete helper if dead,</li>
+<li>add <code>--claude-smoke</code> branch in <code>main()</code> before
+prompt build, verdict extraction, and artifact writing,</li>
+<li>smoke examples satisfy argparse's existing required inputs with
+<code>--reviewer</code>, <code>--kind</code>, <code>--issue-key</code>,
+<code>--plan</code>, <code>--output</code>, and
+<code>--claude-smoke</code>; after parsing, the smoke branch runs before
+prompt build, verdict extraction, and artifact writing, and ignores
+prompt/verdict inputs,</li>
+<li>smoke resolves the launcher, invokes
+<code>--smoke --cwd &lt;repo&gt; --review-name opencode-linear-build-smoke --output &lt;output&gt;</code>,
+exits <code>0</code> on <code>CLAUDE_REVIEW_SMOKE_READY</code>, exits
+nonzero with launcher classified error, and writes no review
+artifact.</li>
+</ul>
+<p>Use this resolver contract:</p>
+<div class="sourceCode" id="cb4"><pre
+class="sourceCode python"><code class="sourceCode python"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="kw">def</span> resolve_claude_review_launcher() <span class="op">-&gt;</span> Path:</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>    candidates <span class="op">=</span> []</span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> os.environ.get(<span class="st">&quot;CLAUDE_REVIEW_LAUNCHER&quot;</span>):</span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>        candidates.append(Path(os.environ[<span class="st">&quot;CLAUDE_REVIEW_LAUNCHER&quot;</span>]).expanduser())</span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>    candidates.append(Path.home() <span class="op">/</span> <span class="st">&quot;.agents/skills/claude-code-review/scripts/claude_interactive_review.py&quot;</span>)</span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>    <span class="co"># Repo checkout path for development before install; only meaningful when this script is in the repo checkout.</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>    repo_candidate <span class="op">=</span> Path(<span class="va">__file__</span>).resolve().parents[<span class="dv">2</span>] <span class="op">/</span> <span class="st">&quot;skills/claude-code-review/scripts/claude_interactive_review.py&quot;</span></span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> repo_candidate.is_file():</span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>        candidates.append(repo_candidate)</span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a>    candidates.append(Path.home() <span class="op">/</span> <span class="st">&quot;.config/opencode/skills/claude-code-review/scripts/claude_interactive_review.py&quot;</span>)</span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> candidate <span class="kw">in</span> candidates:</span>
+<span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> candidate.is_file():</span>
+<span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a>            <span class="cf">return</span> candidate</span>
+<span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a>    <span class="cf">raise</span> <span class="pp">FileNotFoundError</span>(</span>
+<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Claude review launcher not found. Run ./install.sh --opencode, or set &quot;</span></span>
+<span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;CLAUDE_REVIEW_LAUNCHER to the repo or installed claude_interactive_review.py path. &quot;</span></span>
+<span id="cb4-17"><a href="#cb4-17" aria-hidden="true" tabindex="-1"></a>        <span class="st">&quot;Checked: &quot;</span> <span class="op">+</span> <span class="st">&quot;, &quot;</span>.join(<span class="bu">str</span>(path) <span class="cf">for</span> path <span class="kw">in</span> candidates)</span>
+<span id="cb4-18"><a href="#cb4-18" aria-hidden="true" tabindex="-1"></a>    )</span></code></pre></div>
+<p>Add resolver tests for env override, installed
+<code>~/.agents</code>, repo checkout, OpenCode compatibility-link, and
+failure message.</p>
+<p>Use this invocation shape:</p>
+<div class="sourceCode" id="cb5"><pre
+class="sourceCode python"><code class="sourceCode python"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a>prompt_path <span class="op">=</span> output_path.with_suffix(<span class="st">&quot;.prompt.md&quot;</span>)</span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>prompt_path.write_text(build_claude_review_prompt(...), encoding<span class="op">=</span><span class="st">&quot;utf-8&quot;</span>)</span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>raw_path <span class="op">=</span> output_path.with_suffix(<span class="st">&quot;.raw.md&quot;</span>)</span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>sentinel <span class="op">=</span> <span class="ss">f&quot;CLAUDE_REVIEW_DONE_</span><span class="sc">{</span>issue_key<span class="sc">}</span><span class="ss">_</span><span class="sc">{</span>kind<span class="sc">}</span><span class="ss">_</span><span class="sc">{</span><span class="bu">int</span>(time.time())<span class="sc">}</span><span class="ss">&quot;</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>review_name <span class="op">=</span> <span class="ss">f&quot;claude-</span><span class="sc">{</span>kind<span class="sc">.</span>lower()<span class="sc">}</span><span class="ss">-</span><span class="sc">{</span>issue_key<span class="sc">.</span>lower()<span class="sc">}</span><span class="ss">&quot;</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>launcher <span class="op">=</span> resolve_claude_review_launcher()</span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>subprocess.run([</span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>    sys.executable,</span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>    <span class="bu">str</span>(launcher),</span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;--cwd&quot;</span>, cwd,</span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;--prompt-file&quot;</span>, <span class="bu">str</span>(prompt_path),</span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;--output&quot;</span>, <span class="bu">str</span>(raw_path),</span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;--review-name&quot;</span>, review_name,</span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;--timeout-seconds&quot;</span>, <span class="st">&quot;900&quot;</span>,</span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a>    <span class="st">&quot;--sentinel&quot;</span>, sentinel,</span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a>], check<span class="op">=</span><span class="va">True</span>)</span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a>raw_output <span class="op">=</span> raw_path.read_text(errors<span class="op">=</span><span class="st">&quot;replace&quot;</span>)</span></code></pre></div>
+<p>OpenCode output contract:</p>
+<ul>
+<li>Launcher <code>--output</code> begins with deterministic normalized
+answer text strictly between the first baseline-relative new
+<code>CLAUDE_REVIEW_ANSWER_START_&lt;nonce&gt;</code> and following new
+sentinel after the stored post-submit/post-clear baseline.</li>
+<li>Pre-submit/pre-Enter capture is diagnostics only and is never
+parseable evidence; prompt-echo marker/sentinel occurrences already
+present in the stored baseline are never parseable evidence.</li>
+<li>Verdict line and sentinel protocol are on dedicated lines; with
+220-column tmux pane and <code>capture-pane -J</code>,
+<code>extract_verdict()</code> can parse <code>VERDICT:</code> /
+<code>Verdict:</code> without pane-width wrapping or TUI chrome.</li>
+<li>Raw transcript and inspect metadata are preserved after a delimiter
+or in a sibling transcript file.</li>
+<li><code>linear_build_review.py</code> parses only the normalized
+answer region.</li>
+<li>Launcher output does not append <code>EXIT=&lt;n&gt;</code> as the
+old <code>claude -p</code> wrapper did.</li>
+<li><code>linear_build_review.py</code> remains responsible for
+<code>extract_verdict()</code> and expected verdict handling.</li>
+<li>On launcher failure, <code>run_claude()</code> raises with launcher
+error and points to preserved raw transcript/inspect command.</li>
+</ul>
+</section>
+<section id="expected-files-3" class="level3">
+<h3>Expected files</h3>
+<ul>
+<li><code>skills/claude-code-review/SKILL.md</code></li>
+<li><code>_pi/prompts/review:change-claude-code.md</code></li>
+<li><code>_pi/prompts/dev:reviewed-html-plan.md</code> if inventory
+confirms relevant wording</li>
+<li><code>_pi/prompts/review:plan-adversarial.md</code></li>
+<li><code>_pi/README.md</code></li>
+<li><code>skills/reviewed-html-plan/SKILL.md</code></li>
+<li><code>skills/codex-full-build/SKILL.md</code></li>
+<li><code>skills/scoped-plan-run/SKILL.md</code></li>
+<li><code>skills/install-matrix.json</code></li>
+<li><code>_opencode/scripts/linear_build_review.py</code></li>
+<li><code>_opencode/commands/cmd:linear-build-workspace.md</code></li>
+<li><code>_omp/commands/review:plan-adversarial.md</code> and similar
+model-provider docs if inventory confirms required updates</li>
+<li>tests near OpenCode launcher resolution if existing test structure
+supports them.</li>
+</ul>
+</section>
+<section id="verify-3" class="level3">
+<h3>Verify</h3>
+<div class="sourceCode" id="cb6"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> skills/claude-code-review/tests/test_claude_interactive_review.py</span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py</span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="ex">rg</span> <span class="at">-n</span> <span class="st">&quot;ensure_codex_tmux|codex-tmux-bootstrap|tmux .*codex.*claude|tmux .*claude.*codex&quot;</span> _opencode skills _pi <span class="dv">2</span><span class="op">&gt;</span>/dev/null</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> _opencode/scripts/linear_build_review.py <span class="at">--help</span></span></code></pre></div>
+<p>Pass condition: tests pass, guardrail passes for source, help still
+works, codex-tmux search has no live Claude review path, and remaining
+hits are marked forbidden examples or non-gating/non-review
+references.</p>
+</section>
+</section>
+<section
+id="p4--validate-installed-fan-out-smoke-paths-and-final-guardrails"
+class="level2">
+<h2>P4 — Validate installed fan-out, smoke paths, and final
+guardrails</h2>
+<section id="end-state-4" class="level3">
+<h3>End State</h3>
+<p>Source and installed consumers all use the same launcher behavior. Pi
+and OpenCode same-process smokes pass. Source and installed guardrails
+pass. Final inventory has no unaccepted live direct Claude review
+transport.</p>
+</section>
+<section id="tests-first-4" class="level3">
+<h3>Tests first</h3>
+<p>Run source tests and guardrail before install. Any failure must be
+fixed in source before installed-path validation, not patched only in
+installed files.</p>
+</section>
+<section id="work-4" class="level3">
+<h3>Work</h3>
+<p>Run source verification, install Pi and OpenCode consumers
+sequentially, verify installed path existence, run source and installed
+OpenCode smoke paths, run Pi smoke through the Pi prompt path, and scan
+all source/installed roots.</p>
+<p>Install and installed-path existence checks:</p>
+<div class="sourceCode" id="cb7"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="ex">./install.sh</span> <span class="at">--pi</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="ex">./install.sh</span> <span class="at">--opencode</span></span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> <span class="at">-</span> <span class="op">&lt;&lt;&#39;PY&#39;</span></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a><span class="st">from pathlib import Path</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a><span class="st">paths = [</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a><span class="st">    # Pi prompt path and central shared launcher path are intentionally the same.</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a><span class="st">    Path.home()/&#39;.agents/skills/claude-code-review/scripts/claude_interactive_review.py&#39;,</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="st">    Path.home()/&#39;.config/opencode/skills/claude-code-review/scripts/claude_interactive_review.py&#39;,</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a><span class="st">    Path.home()/&#39;.config/opencode/scripts/linear_build_review.py&#39;,</span></span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a><span class="st">    Path.home()/&#39;.config/opencode/commands/cmd:linear-build-workspace.md&#39;,</span></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a><span class="st">    Path.home()/&#39;.config/opencode/agents&#39;,</span></span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a><span class="st">    Path.home()/&#39;.config/opencode/prompts&#39;,</span></span>
+<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a><span class="st">    Path.home()/&#39;.pi/agent/prompts/review:change-claude-code.md&#39;,</span></span>
+<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a><span class="st">    Path.home()/&#39;.pi/agent/agents&#39;,</span></span>
+<span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a><span class="st">]</span></span>
+<span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a><span class="st">missing = [str(path) for path in paths if not path.exists()]</span></span>
+<span id="cb7-17"><a href="#cb7-17" aria-hidden="true" tabindex="-1"></a><span class="st">print(&#39;\n&#39;.join(str(path) for path in paths))</span></span>
+<span id="cb7-18"><a href="#cb7-18" aria-hidden="true" tabindex="-1"></a><span class="st">if missing:</span></span>
+<span id="cb7-19"><a href="#cb7-19" aria-hidden="true" tabindex="-1"></a><span class="st">    raise SystemExit(&#39;missing installed path: &#39; + &#39;, &#39;.join(missing))</span></span>
+<span id="cb7-20"><a href="#cb7-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-21"><a href="#cb7-21" aria-hidden="true" tabindex="-1"></a><span class="st">import json</span></span>
+<span id="cb7-22"><a href="#cb7-22" aria-hidden="true" tabindex="-1"></a><span class="st">matrix = json.loads(Path(&#39;skills/install-matrix.json&#39;).read_text())</span></span>
+<span id="cb7-23"><a href="#cb7-23" aria-hidden="true" tabindex="-1"></a><span class="st">consumers = matrix[&#39;installableSkills&#39;][&#39;claude-code-review&#39;][&#39;allowedConsumers&#39;]</span></span>
+<span id="cb7-24"><a href="#cb7-24" aria-hidden="true" tabindex="-1"></a><span class="st">if &#39;pi&#39; not in consumers or &#39;opencode&#39; not in consumers:</span></span>
+<span id="cb7-25"><a href="#cb7-25" aria-hidden="true" tabindex="-1"></a><span class="st">    raise SystemExit(f&#39;claude-code-review not installed for pi+opencode: {consumers}&#39;)</span></span>
+<span id="cb7-26"><a href="#cb7-26" aria-hidden="true" tabindex="-1"></a><span class="op">PY</span></span></code></pre></div>
+<p>Use <code>./install.sh --opencode</code> or
+<code>./install.sh --all</code> for OpenCode verification on clean
+machines. <code>./install.sh --skills</code> is insufficient unless
+<code>~/.config/opencode/skills</code>,
+<code>~/.config/opencode/scripts</code>, and
+<code>~/.config/opencode/commands</code> already exist.</p>
+<p>Pi smoke:</p>
+<div class="sourceCode" id="cb8"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="co"># In Pi, invoke exactly:</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="ex">/review:change-claude-code</span> <span class="at">--claude-smoke</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="co"># Pass condition:</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a><span class="bu">test</span> <span class="at">-f</span> /tmp/pi-claude-review-smoke.txt <span class="kw">&amp;&amp;</span> <span class="ex">rg</span> <span class="at">-n</span> <span class="st">&quot;CLAUDE_REVIEW_SMOKE_READY|socket|session&quot;</span> /tmp/pi-claude-review-smoke.txt</span></code></pre></div>
+<p>OpenCode source and installed smoke:</p>
+<div class="sourceCode" id="cb9"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="va">CLAUDE_REVIEW_LAUNCHER</span><span class="op">=</span>/Users/anichols/code/ai-configs/skills/claude-code-review/scripts/claude_interactive_review.py <span class="dt">\</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="va">RUN_REAL_CLAUDE_SMOKE</span><span class="op">=</span>1 <span class="ex">python3</span> _opencode/scripts/linear_build_review.py <span class="dt">\</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--reviewer</span> claude <span class="at">--kind</span> plan <span class="at">--issue-key</span> SMOKE <span class="at">--plan</span> /tmp/claude-review-reliability-plan.md <span class="dt">\</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--output</span> /tmp/opencode-claude-review-smoke-source.md <span class="at">--claude-smoke</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> _opencode/scripts/linear_build_review.py <span class="at">--help</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> <span class="st">&quot;</span><span class="va">$HOME</span><span class="st">/.config/opencode/scripts/linear_build_review.py&quot;</span> <span class="at">--help</span></span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a><span class="va">RUN_REAL_CLAUDE_SMOKE</span><span class="op">=</span>1 <span class="ex">python3</span> <span class="st">&quot;</span><span class="va">$HOME</span><span class="st">/.config/opencode/scripts/linear_build_review.py&quot;</span> <span class="dt">\</span></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">--reviewer</span> claude <span class="at">--kind</span> plan <span class="at">--issue-key</span> SMOKE <span class="at">--plan</span> /tmp/claude-review-reliability-plan.md <span class="dt">\</span></span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>  <span class="at">--output</span> /tmp/opencode-claude-review-smoke-installed.md <span class="at">--claude-smoke</span></span></code></pre></div>
+<p>Final guardrail and inventory. The guardrail is the authoritative
+deterministic pass/fail check; the broad <code>rg</code> inventory is
+advisory/manual classification evidence only and must not override a
+passing guardrail without a concrete live transport finding.</p>
+<div class="sourceCode" id="cb10"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py <span class="dt">\</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--root</span> /Users/anichols/code/ai-configs <span class="dt">\</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--root</span> ~/.agents/skills <span class="dt">\</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--root</span> ~/.config/opencode/skills <span class="dt">\</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--root</span> ~/.config/opencode/scripts <span class="dt">\</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--root</span> ~/.config/opencode/commands <span class="dt">\</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--root</span> ~/.config/opencode/agents <span class="dt">\</span></span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">--root</span> ~/.config/opencode/prompts <span class="dt">\</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>  <span class="at">--root</span> ~/.pi/agent/prompts <span class="dt">\</span></span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>  <span class="at">--root</span> ~/.pi/agent/agents</span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a><span class="ex">rg</span> <span class="at">-n</span> <span class="st">&quot;claude -p|claude --print|\|[[:space:]]*claude\b|claude --permission-mode|interactive_shell.*claude|os\.execvp\(.*claude|process.*claude|subprocess.*claude|exec.*claude|bash.*claude|tmux.*claude|claude-opus|opencode-zen/claude|\[[^]]*claude[^]]*\]|ensure_codex_tmux|codex-tmux-bootstrap&quot;</span> <span class="dt">\</span></span>
+<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>  _pi skills _opencode _claude _omp _codex scripts <span class="dv">2</span><span class="op">&gt;</span>/dev/null</span></code></pre></div>
+</section>
+<section id="expected-files-4" class="level3">
+<h3>Expected files</h3>
+<p>No additional source files beyond P1-P3 unless final verification
+exposes missed source/installed fan-out. Installed files under
+<code>~/.agents</code>, <code>~/.config/opencode</code>, and
+<code>~/.pi</code> are expected side effects of
+<code>install.sh</code>.</p>
+</section>
+<section id="verify-4" class="level3">
+<h3>Verify</h3>
+<div class="sourceCode" id="cb11"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> skills/claude-code-review/tests/test_claude_interactive_review.py</span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="ex">python3</span> skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py</span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="va">RUN_REAL_CLAUDE_SMOKE</span><span class="op">=</span>1 <span class="ex">python3</span> skills/claude-code-review/tests/test_claude_interactive_review.py <span class="at">--real-smoke</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="va">RUN_REAL_CLAUDE_E2E</span><span class="op">=</span>1 <span class="ex">python3</span> skills/claude-code-review/tests/test_claude_interactive_review.py <span class="at">--real-e2e-review</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="co"># plus all Pi/OpenCode installed smoke and final guardrail commands listed in Work.</span></span></code></pre></div>
+<p>Final pass condition: tests pass, same-process smoke passes for real
+consumers, install paths resolve, help commands still work, source and
+installed guardrails pass, and final <code>rg</code> is manually
+classified with no unaccepted live direct Claude review transport.</p>
+</section>
+</section>
+<section id="verification-strategy" class="level2">
+<h2>Verification strategy</h2>
+<p>Test coverage matrix:</p>
+<table>
+<thead>
+<tr>
+<th>Acceptance</th>
+<th>Scenarios</th>
+<th>Test or verification layer</th>
+<th>Commands</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>AC1, AC2</td>
+<td>S1, S2, S10</td>
+<td>Guardrail tests and final source/installed scans</td>
+<td><code>python3 skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py ...</code>;
+final <code>rg</code> inventory</td>
+</tr>
+<tr>
+<td>AC3, AC6</td>
+<td>S1, S3, S9</td>
+<td>Launcher mock tests plus real source/Pi/OpenCode smokes, including
+smoke-success and review-success teardown assertions</td>
+<td><code>python3 ...test_claude_interactive_review.py</code>;
+<code>/review:change-claude-code --claude-smoke</code>; OpenCode
+<code>--claude-smoke</code></td>
+</tr>
+<tr>
+<td>AC4, AC5</td>
+<td>S6, S7, S8</td>
+<td>Fake Claude transcript tests for prompt echo, boundary, ANSI/chrome,
+wrapping, output parsing</td>
+<td><code>python3 skills/claude-code-review/tests/test_claude_interactive_review.py</code></td>
+</tr>
+<tr>
+<td>AC7</td>
+<td>S4, S5, S7</td>
+<td>Mock failure tests and real smoke failure transcript inspection if
+applicable</td>
+<td>launcher tests; preserved transcript assertions</td>
+</tr>
+<tr>
+<td>AC8, AC9</td>
+<td>S8, S9</td>
+<td>OpenCode resolver/invocation tests and help/smoke commands</td>
+<td><code>python3 _opencode/scripts/linear_build_review.py --help</code>;
+source/installed <code>--claude-smoke</code></td>
+</tr>
+<tr>
+<td>AC10</td>
+<td>S2, S9</td>
+<td>Installed-root guardrail scans</td>
+<td>guardrail with <code>--root ~/.agents/skills</code>,
+<code>~/.config/opencode/skills</code>,
+<code>~/.config/opencode/scripts</code>,
+<code>~/.config/opencode/commands</code>,
+<code>~/.config/opencode/agents</code>,
+<code>~/.config/opencode/prompts</code>,
+<code>~/.pi/agent/prompts</code>, <code>~/.pi/agent/agents</code></td>
+</tr>
+<tr>
+<td>AC11</td>
+<td>S6, S7, S8</td>
+<td>Live prompt-submitting launcher validation against real Claude
+TUI</td>
+<td><code>RUN_REAL_CLAUDE_E2E=1 python3 skills/claude-code-review/tests/test_claude_interactive_review.py --real-e2e-review</code></td>
+</tr>
+</tbody>
+</table>
+<p>Review gate after implementation: run one bounded
+implementation-stage review loop against the diff using the newly
+canonical Claude review path and Codex review path. The loop must not
+use old <code>claude -p</code>; if the new path fails smoke, stop with
+auth/prerequisite guidance instead of using a fallback.</p>
+</section>
+<section id="delivery-order" class="level2">
+<h2>Delivery order</h2>
+<ol type="1">
+<li>P0 inventory and classification.</li>
+<li>P1 RED tests and guardrail.</li>
+<li>P2 launcher implementation until mock tests pass.</li>
+<li>P3 consumer routing and documentation updates until source
+guardrails pass.</li>
+<li>P4 install, same-process smoke, installed guardrails, and final
+review.</li>
+</ol>
+</section>
+<section id="non-goals" class="level2">
+<h2>Non-goals</h2>
+<ul>
+<li>Do not change Claude authentication storage, account configuration,
+subscription, model selection, or token policy.</li>
+<li>Do not make non-Claude model-provider reviews count as required
+Claude Code review gates.</li>
+<li>Do not build a general-purpose tmux orchestration framework.</li>
+<li>Do not migrate unrelated Claude mentions that are not review
+execution paths except to mark or classify them for guardrail
+clarity.</li>
+<li>Do not preserve backward compatibility for <code>claude -p</code>
+review paths; removing them is the point of the change.</li>
+<li>Do not modify repo files until this plan is approved.</li>
+</ul>
+</section>
+<section id="decisions--deviations-log" class="level2">
+<h2>Decisions / Deviations log</h2>
+<ul>
+<li>Decided not to reuse existing <code>codex</code> tmux because live
+auth evidence showed <code>loggedIn: false</code> there while a private
+tmux server from the current process was authenticated.</li>
+<li>Decided to keep OpenCode verdict parsing in
+<code>_opencode/scripts/linear_build_review.py</code> and delegate only
+Claude transport to the launcher.</li>
+<li>Decided <code>skills/install-matrix.json</code> keeps
+<code>class: 'consumer-specific-installable'</code>; consumer fan-out is
+controlled by <code>allowedConsumers</code>.</li>
+<li>Decided prompt-echo uncertainty is fail-closed as
+<code>CLAUDE_TUI_BOUNDARY_UNCERTAIN</code> after Codex review identified
+pre-Enter baseline ambiguity.</li>
+<li>Decided Claude TUI session/rate-limit messages are fail-closed as
+<code>CLAUDE_SESSION_LIMIT_IN_TUI</code> instead of waiting for the generic
+review timeout.</li>
+<li>Decided the HTML artifact must be a faithful full-plan rendering,
+not a reduced summary, and should use explicit dark styling for
+reviewed-plan readability, including dark-legible syntax-highlight
+overrides or inherited light code colors for every Pandoc
+<code>code span.*</code> token.</li>
+</ul>
+</section>
+</section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add canonical Claude Code review launcher that drives a real interactive Claude TUI inside a private tmux server.
- Route Pi/OpenCode/shared review docs to the launcher and forbid direct/non-interactive Claude review transports.
- Add guardrail + tests for direct Claude launch detection, installed fan-out, auth/readiness/session-limit failures, and prompt-boundary extraction.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 skills/claude-code-review/tests/test_claude_interactive_review.py && python3 skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py && python3 -m py_compile ...` -> PASS (25 tests, 2 skipped real-only)
- `RUN_REAL_CLAUDE_E2E=1 ... --real-e2e-review` -> PASS with active real-Claude session limit detected and skipped as environment
- `./install.sh --pi && ./install.sh --opencode` -> PASS
- installed guardrails across repo, `~/.agents/skills`, OpenCode, and Pi roots -> PASS
- Pi installed launcher smoke -> PASS
- OpenCode source + installed `--claude-smoke` -> PASS
- `git diff --check` / `git diff --cached --check` -> PASS
- Codex implementation review v5 -> `VERDICT: PASS_SCOPED`

## Notes
- Required Claude implementation review was attempted through the new canonical launcher and failed closed with `CLAUDE_SESSION_LIMIT_IN_TUI` because the real Claude account session/rate limit is currently active. No alternate Claude transport was used.
- `_pi/extensions/pi-plan-mode/index.ts` is dirty locally but intentionally excluded from this PR as unrelated scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A canonical interactive Claude review launcher with a smoke-check mode to verify readiness.
  * Plan-mode UI: shows active claim status and blocks execution until claims are acknowledged/resolved.

* **Documentation**
  * Repository-wide Claude review reliability plan and updated workflows requiring the canonical launcher; clarified review gate wording.

* **Tests**
  * New end-to-end tests, fixtures, and a guardrail scanner that detect forbidden direct Claude review launches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->