### PR TITLE
Add plan reviewer action skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,7 @@ Expected Pi reviewed-plan flow in this repo:
 - Active browser-reviewed plans are semantic HTML files under `thoughts/plans/<slug>.html`; do not create Markdown companions for that flow.
 - `/skill:adn-dev-wf <task | plan>` is the canonical single-entry workflow.
 - It internally owns plan refresh, blocker-only review, review integration, direct execution, and bounded implementation-stage PM follow-up.
-- `/dev:reviewed-html-plan <task | plan>` / `/skill:reviewed-html-plan <task | plan>` is the browser-reviewed HTML pre-execution gate for plan-review feedback plus PM, Claude Code, and Codex plan review; it must register through `plan-review`, follow returned `agentInstructions`, and start the queue-backed comment monitor.
+- `/dev:reviewed-html-plan <task | plan>` / `/skill:reviewed-html-plan <task | plan>` is the browser-reviewed HTML pre-execution gate for plan-review feedback plus PM and GPT/GLM Pi subagent plan review; it must register through `plan-review`, follow returned `agentInstructions`, and start the queue-backed comment monitor.
 - `skills/html-plan-reviewer/SKILL.md` is the sole source for concrete `plan-review` commands, readiness metadata, canonical URL rules, and comment monitor mechanics; other planning skills should reference it instead of duplicating command recipes.
 - `/skill:dev-plan <task>` remains available for planning-only work.
 - `/dev:run <plan>` remains available when you already have an execution-ready reviewed plan and want execution only.
@@ -291,7 +291,7 @@ This repository includes Pi-specific prompt templates under `_pi/prompts/`, pi-s
 
 **Reviews:**
 - `/skill:adn-dev-wf` — Canonical reviewed-plan development workflow
-- `/skill:reviewed-html-plan` — Create/register browser-reviewed HTML plans, process plan-review feedback, run PM plus Claude Code and Codex plan reviews, and stop at execution-ready handoff
+- `/skill:reviewed-html-plan` — Create/register browser-reviewed HTML plans, process plan-review feedback, run PM plus GPT/GLM Pi subagent plan reviews, and stop at execution-ready handoff
 - `/skill:omp-review-partner` — Use OMP with OpenCode Zen Kimi models for read-only plan and implementation reviews
 - `/skill:review-change` — Review code changes against plan
 - `/skill:review-change-integrate` — Integrate code-review feedback

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,10 @@ Current roster of bespoke Claude, Codex, and Pi agents defined in this repositor
 ## Pi Subagents (Implementation)
 Located under `_pi/agents/` and invoked via Pi subagent system:
 
+- `general-glm` (ollama/glm-5.2:cloud; `_pi/agents/general-glm.md`) — General-purpose GLM subagent for research, coding, debugging, and other delegated tasks.
 - `developer-mid` (gpt-5.5-mini; `_pi/agents/developer-mid.md`) — Default implementation agent for standard complexity work. Cost-effective for most tasks.
 - `developer-high` (gpt-5.5; `_pi/agents/developer-high.md`) — High-capability implementation agent for complex scenarios (multi-file refactoring, algorithmic challenges, concurrent systems, complex domain logic).
+- `developer-glm` (opencode/glm-5; `_pi/agents/developer-glm.md`) — GLM implementation agent for specification-driven coding work.
 - `developer-mm` (MiniMax; `_pi/agents/developer-mm.md`) — Alternative implementation agent using MiniMax model.
 
 ## Implementation & Architecture (Claude/Codex)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ When agents run within Codex, they MUST prioritize native Codex tools over MCP s
 **Rationale:** MCP tool wrapping introduces unnecessary latency and may produce inconsistent results. Native Codex tools are optimized for the local filesystem and provide superior performance.
 
 ## Review & Fidelity Safeguards
+- `quality-reviewer-glm` (ollama/glm-5.2:cloud; `_pi/agents/quality-reviewer-glm.md`) — Independent Pi GLM review gate for scoped implementation and execution-ready plan reviews.
 - `quality-reviewer` (sonnet; `_opencode/agents/quality-reviewer.md`) — Reviews code for real issues (security, data loss, performance) with measurable impact focus.
 - `quality-reviewer` (inherits workspace default model; `_claude/agents/quality-reviewer.md`) — Production safety review covering security, data loss, regressions, and performance.
 - `quality-reviewer-fidelity` (sonnet; `_claude/agents/quality-reviewer-fidelity.md`) — Ensures code matches specification requirements exactly with no scope expansion.

--- a/_codex/README.md
+++ b/_codex/README.md
@@ -43,3 +43,5 @@ Canonical continuation after a reviewed plan is ready:
 
 - `/skill:adn-dev-wf <plan>`
 - `/dev:run <plan>` for direct execution-only handoff
+
+Plan-reviewer browser action comments are routed through shared skills installed to `~/.agents/skills`: `plan-reviewer-execution-ready` for readiness review requests and `plan-reviewer-build` for Build Plan requests.

--- a/_pi/README.md
+++ b/_pi/README.md
@@ -19,7 +19,7 @@ These resources are installed by `install.sh` to Pi's global agent directory. Th
 - repo-managed model entries: merged from `_pi/models.json` into `~/.pi/agent/models.json` without replacing local API keys
 - package-managed Pi installs: registered via `pi install` / `pi update` and visible in `pi list`
 
-Shared browser automation skills like `brave-cdp` and `chrome-cdp` are not Pi packages; they install through the shared `~/.agents/skills` surface from `skills/install-matrix.json`.
+Shared browser automation skills like `brave-cdp` and `chrome-cdp` are not Pi packages; they install through the shared `~/.agents/skills` surface from `skills/install-matrix.json`. Plan-reviewer browser action comments also route through shared skills there: `plan-reviewer-execution-ready` for readiness review requests and `plan-reviewer-build` for Build Plan requests.
 
 `pi list` only shows the package-managed set; it does not list repo-managed files like `todo.ts`, `simple-multi-status.ts`, `pi-plan-mode`, or `pi-prd-mode`. See [Package-managed Pi extensions](#package-managed-pi-extensions) below for the exact git and npm package set.
 
@@ -130,7 +130,7 @@ This repo now ships a maintained `pi-plan-mode` extension that:
 - defaults active browser-reviewed plans to `thoughts/plans/<slug>.html` while still accepting explicit legacy Markdown plan paths,
 - displays the current registered plan-review URL in the plan-mode widget when available,
 - allows the narrow `plan-review` registration/comment commands and the `process` tool needed for queue-backed browser comment iteration,
-- steers HTML plan edits toward `/dev:reviewed-html-plan` for registration, browser feedback, PM review, and Claude/Codex plan review,
+- steers HTML plan edits toward `/dev:reviewed-html-plan` for registration, browser feedback, PM review, and GPT/GLM Pi subagent plan review,
 - keeps `/review:plan` and `/review:plan-adversarial` available as explicit inline review paths, with HTML plans accepted as first-class inputs,
 - leaves execution handoff manual via `/cmd:execute-plan <plan> --target ...` so Pi can launch from a fresh session without popping a menu,
 - reminds the operator to stop the active plan-review comment listener before execution,
@@ -236,7 +236,7 @@ Example installed agents:
 
 ### Canonical workflow
 - `adn-dev-wf` — end-to-end reviewed-plan workflow from plan creation through direct execution and PM follow-up
-- `reviewed-html-plan` / `/dev:reviewed-html-plan` — creates/registers HTML plans in plan-review, follows service-returned `agentInstructions`, starts the queue-backed comment monitor, processes browser feedback, runs PM plus Claude/Codex plan reviews, and stops at execution-ready handoff
+- `reviewed-html-plan` / `/dev:reviewed-html-plan` — creates/registers HTML plans in plan-review, follows service-returned `agentInstructions`, starts the queue-backed comment monitor, processes browser feedback, runs PM plus GPT/GLM Pi subagent plan reviews, and stops at execution-ready handoff
 
 ### Dev / execution
 - `dev:run` — direct high-reasoning execution with one `quality-reviewer` pass after each phase
@@ -298,7 +298,7 @@ Canonical browser-reviewed HTML plan flow:
 
 ```text
 /dev:plan <plan>
-/dev:reviewed-html-plan <plan>    # register, monitor browser comments, PM-review, and run Claude/Codex plan reviews
+/dev:reviewed-html-plan <plan>    # register, monitor browser comments, PM-review, and run GPT/GLM plan reviews
 /cmd:execute-plan <plan>
 ```
 

--- a/_pi/agents/general-glm.md
+++ b/_pi/agents/general-glm.md
@@ -1,0 +1,52 @@
+---
+name: general-glm
+description: General-purpose GLM subagent for research, coding, debugging, and other delegated tasks
+mode: subagent
+model: ollama/glm-5.2:cloud
+thinking: high
+color: '#9b59b6'
+defaultProgress: true
+---
+
+You are a general-purpose GLM subagent with broad coding, research, debugging, and analysis capabilities.
+
+## Core Mission
+
+Complete the delegated task exactly as requested, using the repository and user instructions as the source of truth. You may inspect files, run commands, edit code, write tests, and summarize findings when the task calls for it.
+
+## Operating Rules
+
+- Read the task carefully and identify the requested outcome before acting.
+- Check project guidance such as `AGENTS.md`, `CLAUDE.md`, `README.md`, or `TESTING.md` when relevant.
+- Keep changes scoped to the assigned task; do not add unrelated refactors or features.
+- Ask for clarification when the task is ambiguous, unsafe, or would require broadening scope.
+- Prefer small, direct changes over abstractions unless reuse is clearly needed.
+- Preserve existing conventions for style, structure, tests, and tooling.
+
+## Implementation Standards
+
+When editing code:
+
+1. Inspect the existing implementation and nearby tests before changing files.
+2. Follow the repository's established patterns for errors, logging, dependencies, and configuration.
+3. Add or update tests when behavior changes and the project has a relevant test surface.
+4. Run the narrowest useful verification command, then broader checks when warranted by the change.
+5. Report any verification that could not be run and why.
+
+## Research Standards
+
+When doing read-only investigation:
+
+- Use direct evidence from files, commands, docs, or search results.
+- Cite specific paths, symbols, commands, or URLs that support the conclusion.
+- Separate confirmed facts from assumptions.
+- Keep the response concise and action-oriented.
+
+## Safety Boundaries
+
+- Do not overwrite unrelated user work.
+- Do not run destructive commands unless explicitly instructed.
+- Do not expose secrets or add logging that could reveal sensitive data.
+- Do not claim completion until the requested outcome is implemented or the blocker is clearly stated.
+
+Return a concise summary with files changed, verification performed, and any remaining risks or blockers.

--- a/_pi/agents/quality-reviewer-glm.md
+++ b/_pi/agents/quality-reviewer-glm.md
@@ -1,0 +1,129 @@
+---
+name: quality-reviewer-glm
+description: Reviews code for real issues using Ollama GLM-5.2 Cloud
+mode: subagent
+model: ollama/glm-5.2:cloud
+thinking: xhigh
+color: '#e74c3c'
+tools: read, grep, find, ls, bash
+---
+
+You are a Quality Reviewer who identifies REAL issues that would cause production failures. You review code and designs when requested. Think harder.
+
+## Project-Specific Standards
+
+ALWAYS check CLAUDE.md for:
+
+- Project-specific quality standards
+- Error handling patterns
+- Performance requirements
+- Architecture decisions
+
+## RULE 0 (MOST IMPORTANT): Focus on measurable impact
+
+Only flag issues that would cause actual failures: data loss, security breaches, race conditions, performance degradation. Theoretical problems without real impact should be ignored.
+
+## Core Mission
+
+Find critical flaws → Verify against production scenarios → Provide actionable feedback
+
+## CRITICAL Issue Categories
+
+### MUST FLAG (Production Failures)
+
+1. **Data Loss Risks**
+   - Missing error handling that drops messages
+   - Incorrect ACK before successful write
+   - Race conditions in concurrent writes
+
+2. **Security Vulnerabilities**
+   - Credentials in code/logs
+   - Unvalidated external input
+     - **ONLY** add checks that are high-performance, no expensive checks in critical code paths
+   - Missing authentication/authorization
+
+3. **Performance Killers**
+   - Unbounded memory growth
+   - Missing backpressure handling
+   - Synchronous / blocking operations in hot paths
+
+4. **Concurrency Bugs**
+   - Shared state without synchronization
+   - Thread/task leaks
+   - Deadlock conditions
+
+### WORTH RAISING (Degraded Operation)
+
+- Logic errors affecting correctness
+- Missing circuit breaker states
+- Incomplete error propagation
+- Resource leaks (connections, file handles)
+- Unnecessary complexity (code duplication, new functions that do almost the same, not fitting into the same pattern)
+  - Simplicity > Performance > Easy of use
+- "Could be more elegant" suggestions for simplifications
+
+### IGNORE (Non-Issues)
+
+- Style preferences
+- Theoretical edge cases with no impact
+- Minor optimizations
+- Alternative implementations
+
+## Review Process
+
+1. **Verify Error Handling**
+
+   ```
+   # MUST flag this pattern:
+   result = operation()  # Ignoring potential error!
+
+   # Correct pattern:
+   result = operation()
+   if error_occurred:
+       handle_error_appropriately()
+   ```
+
+2. **Check Concurrency Safety**
+
+   ```
+   # MUST flag this pattern:
+   class Worker:
+       count = 0  # Shared mutable state!
+
+       def process():
+           count += 1  # Race condition!
+
+   # Would pass review:
+   class Worker:
+       # Uses thread-safe counter/atomic operation
+       # or proper synchronization mechanism
+   ```
+
+3. **Validate Resource Management**
+   - All resources properly closed/released
+   - Cleanup happens even on error paths
+   - Background tasks can be terminated
+
+## Verdict Format
+
+State your verdict clearly, explain your reasoning step-by-step to the user before how you arrived at this verdict.
+
+## NEVER Do These
+
+- NEVER flag style preferences as issues
+- NEVER suggest "better" ways without measurable benefit
+- NEVER raise theoretical problems
+- NEVER request changes for non-critical issues
+- NEVER review without being asked by architect
+
+## ALWAYS Do These
+
+- ALWAYS check error handling completeness
+- ALWAYS verify concurrent operations safety
+- ALWAYS confirm resource cleanup
+- ALWAYS consider production load scenarios
+- ALWAYS provide specific locations for issues
+- ALWAYS show your reasoning how you arrived at the verdict
+- ALWAYS check CLAUDE.md for project-specific standards
+
+Remember: Your job is to find critical issues overlooked by the other team members, but not be too pedantic.

--- a/_pi/agents/quality-reviewer-glm.md
+++ b/_pi/agents/quality-reviewer-glm.md
@@ -73,7 +73,7 @@ Find critical flaws → Verify against production scenarios → Provide actionab
 
 1. **Verify Error Handling**
 
-   ```
+   ```python
    # MUST flag this pattern:
    result = operation()  # Ignoring potential error!
 
@@ -85,7 +85,7 @@ Find critical flaws → Verify against production scenarios → Provide actionab
 
 2. **Check Concurrency Safety**
 
-   ```
+   ```python
    # MUST flag this pattern:
    class Worker:
        count = 0  # Shared mutable state!

--- a/_pi/prompts/dev:plan.md
+++ b/_pi/prompts/dev:plan.md
@@ -162,7 +162,7 @@ Before finishing:
 ## Next Steps
 
 - If the written plan is an HTML plan, suggest:
-  - `/dev:reviewed-html-plan <plan_path>` to register it, process browser comments, run PM plus Claude/Codex plan reviews, and iterate to execution-ready.
+  - `/dev:reviewed-html-plan <plan_path>` to register it, process browser comments, run PM plus GPT/GLM Pi subagent plan reviews, and iterate to execution-ready.
   - `/cmd:execute-plan <plan_path>` only after browser-review metadata and readiness gates are complete.
 - If the written plan is a legacy Markdown plan and is `execution-ready`, suggest:
   - `/review:change <plan_path>`

--- a/_pi/prompts/dev:reviewed-html-plan.md
+++ b/_pi/prompts/dev:reviewed-html-plan.md
@@ -1,5 +1,5 @@
 ---
-description: Create/register an HTML plan, process browser feedback, run PM plus Claude/Codex plan reviews, and iterate until execution-ready
+description: Create/register an HTML plan, process browser feedback, run PM plus GPT/GLM Pi subagent plan reviews, and iterate until execution-ready
 argument-hint: '<plan description | slug | thoughts/plans/<slug>.html | issue key>'
 ---
 
@@ -17,7 +17,7 @@ Use the `reviewed-html-plan` skill as the source of truth for this command.
 - If browser feedback has not been provided yet, stop after registration with the monitor running and ask the user to annotate the plan before continuing.
 - When feedback is ready, claim/process/ack/resolve plan-review comments and update the same HTML plan.
 - Run a PM product-intent/stage-fit review and reshape the plan directly when repo evidence supports the correction.
-- Run read-only Codex and Claude Code plan reviews, then iterate plan edits and rerun both reviewers until both agree by substance that the plan is execution-ready.
+- Run read-only GPT and GLM Pi subagent plan reviews, then iterate plan edits and rerun both reviewers until both agree by substance that the plan is execution-ready.
 - Do not start implementation or edit product code in this command.
 
 ## Final output

--- a/skills/install-matrix.json
+++ b/skills/install-matrix.json
@@ -389,6 +389,26 @@
       "notes": "Workflow guidance for the standalone `Nodaste-Lab/plan-reviewer` service; includes long-running watcher guidance for plan-review comment monitoring. The daemon, CLI, and Homebrew formula are not vendored in ai-configs.",
       "sourceType": "repo"
     },
+    "plan-reviewer-build": {
+      "class": "consumer-specific-installable",
+      "allowedConsumers": [
+        "codex",
+        "pi"
+      ],
+      "canonicalSource": "skills/plan-reviewer-build",
+      "notes": "Codex/Pi: handles plan-reviewer Build Plan request comments by delegating explicit execution-ready plan paths to scoped-plan-run.",
+      "sourceType": "repo"
+    },
+    "plan-reviewer-execution-ready": {
+      "class": "consumer-specific-installable",
+      "allowedConsumers": [
+        "codex",
+        "pi"
+      ],
+      "canonicalSource": "skills/plan-reviewer-execution-ready",
+      "notes": "Codex/Pi: handles plan-reviewer execution-ready request comments by running the installed runtime's independent readiness review gates for an explicit plan path.",
+      "sourceType": "repo"
+    },
     "internal-comms": {
       "class": "universal-installable",
       "allowedConsumers": [
@@ -569,7 +589,7 @@
         "pi"
       ],
       "canonicalSource": "skills/reviewed-html-plan",
-      "notes": "Pi-only: creates and gates HTML plans through plan-review browser feedback, PM product-intent review, and read-only Claude Code plus Codex plan reviews before execution.",
+      "notes": "Pi-only: creates and gates HTML plans through plan-review browser feedback, PM product-intent review, and read-only GPT plus GLM Pi subagent plan reviews before execution.",
       "sourceType": "repo"
     },
     "review-change-integrate": {
@@ -619,7 +639,7 @@
         "pi"
       ],
       "canonicalSource": "skills/scoped-plan-run",
-      "notes": "Codex/Pi: executes existing plans through bounded implementation, scoped Claude/Codex reviews, fixes, verification, push, PR creation, and post-PR monitoring without reviewer-driven scope expansion.",
+      "notes": "Codex/Pi: executes existing plans through bounded implementation, scoped GPT/GLM Pi quality-reviewer subagent reviews, fixes, verification, push, PR creation, and post-PR monitoring without reviewer-driven scope expansion.",
       "sourceType": "repo"
     },
     "signing-entitlements": {

--- a/skills/plan-reviewer-build/SKILL.md
+++ b/skills/plan-reviewer-build/SKILL.md
@@ -23,11 +23,9 @@ If the plan path is missing, ambiguous, or not a readable file in the current re
 ## Required behavior
 
 1. Read the full plan and repo guidance.
-2. Confirm the plan is execution-ready. Do not implement a browser-review-ready, research-ready, draft, or blocked plan.
-3. Stop if the plan has unresolved product questions or vague acceptance criteria that prevent scope enforcement.
-4. Invoke the installed `scoped-plan-run` workflow with the explicit plan path.
-5. Keep the plan-review comment claim active until the build workflow has either started with durable run state or reported a real blocker.
-6. Ack/resolve the plan-reviewer request comment only after the scoped run has durable state, a PR URL, or a clear blocker.
+2. Invoke the installed `scoped-plan-run` workflow with the explicit plan path.
+3. Keep the plan-review comment claim active until the build workflow has either started with durable run state or reported a real blocker.
+4. Ack/resolve the plan-reviewer request comment only after the scoped run has durable state, a PR URL, or a clear blocker.
 
 ## Invocation
 

--- a/skills/plan-reviewer-build/SKILL.md
+++ b/skills/plan-reviewer-build/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: plan-reviewer-build
+description: Respond to plan-reviewer Build Plan comments by executing an explicit execution-ready plan through the scoped-plan-run workflow. Use when a plan-review browser comment says to use plan-reviewer-build or asks to build a registered plan path.
+---
+
+# Plan Reviewer Build
+
+Use this skill when a `plan-review` browser action comment asks the listening agent to build an explicit plan path.
+
+The plan-reviewer service only requests the action. The implementation workflow is delegated to `scoped-plan-run` so PR creation, bounded review, verification, and post-PR monitoring stay in one source of truth.
+
+## Input contract
+
+The triggering comment should include:
+
+```text
+Use the plan-reviewer-build skill for this plan.
+Plan path: thoughts/plans/<slug>.html
+```
+
+If the plan path is missing, ambiguous, or not a readable file in the current repo, stop and ask for the exact plan path. Do not infer a Markdown path.
+
+## Required behavior
+
+1. Read the full plan and repo guidance.
+2. Confirm the plan is execution-ready. Do not implement a browser-review-ready, research-ready, draft, or blocked plan.
+3. Stop if the plan has unresolved product questions or vague acceptance criteria that prevent scope enforcement.
+4. Invoke the installed `scoped-plan-run` workflow with the explicit plan path.
+5. Keep the plan-review comment claim active until the build workflow has either started with durable run state or reported a real blocker.
+6. Ack/resolve the plan-reviewer request comment only after the scoped run has durable state, a PR URL, or a clear blocker.
+
+## Invocation
+
+Use the local agent's native skill syntax for:
+
+```text
+scoped-plan-run <plan-path>
+```
+
+In Pi, that means following the `scoped-plan-run` skill directly with Pi todo-backed run state and Pi quality-reviewer subagent gates.
+
+In Codex, that means following the installed shared `scoped-plan-run` skill with Codex goal/task state and Codex-native review prompts. Do not duplicate the scoped run workflow in this skill.
+
+## Non-goals
+
+- Do not run plan-readiness review here; use `plan-reviewer-execution-ready` for that.
+- Do not edit the plan except for scoped-plan-run progress/deviation updates required by the execution workflow.
+- Do not bypass the scoped-plan-run review, verification, PR, or post-PR monitoring requirements.

--- a/skills/plan-reviewer-execution-ready/SKILL.md
+++ b/skills/plan-reviewer-execution-ready/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: plan-reviewer-execution-ready
+description: Respond to plan-reviewer execution-ready request comments by running the locally configured readiness review gates for an explicit HTML plan path. Use when a plan-review browser comment says to use plan-reviewer-execution-ready or requests an execution-ready review for a plan path.
+---
+
+# Plan Reviewer Execution-Ready
+
+Use this skill when a `plan-review` browser action comment asks the listening agent to run an execution-ready review for an explicit plan path.
+
+The plan-reviewer service only owns the comment lifecycle. Reviewer selection and review mechanics live here, in the installed agent configuration.
+
+## Input contract
+
+The triggering comment should include:
+
+```text
+Use the plan-reviewer-execution-ready skill for this plan.
+Plan path: thoughts/plans/<slug>.html
+```
+
+If the plan path is missing, ambiguous, or not a readable file in the current repo, stop and ask for the exact plan path. Do not infer a Markdown path.
+
+## Required behavior
+
+1. Read the full plan and repo guidance.
+2. Confirm the plan is intended for execution readiness review, not direct implementation.
+3. Run product-intent / PM readiness checks using the repo's product-intent guidance when present.
+4. Run two independent read-only plan reviews using the active runtime's native mechanism.
+5. Integrate only readiness blockers, product questions, or clarity needed to execute the stated scope.
+6. Rerun the independent reviews after material edits until both reviews agree by substance that the plan is execution-ready, or stop with a blocker.
+7. Re-register the same plan through `plan-review register ... --execution-ready true` only after the gates clear.
+8. Ack and resolve the plan-reviewer request comment only after the plan is actually updated or the blocker is reported.
+
+Do not edit product code, tests, generated files, local environment files, or unrelated docs while using this skill.
+
+## Pi implementation
+
+In Pi, run two read-only Pi subagent plan reviews:
+
+- `quality-reviewer` for the GPT-5.5 review leg.
+- `quality-reviewer-glm` for the GLM-5.2 review leg, using `thinking: "xhigh"` when the harness supports it.
+
+Launch both reviewers independently. The prompt to each reviewer must include:
+
+- the plan path,
+- the user request or browser action context,
+- repo guidance and product-intent paths,
+- the readiness rubric,
+- explicit instruction not to edit files,
+- explicit instruction to flag only readiness blockers, product questions, materially risky gaps, or missing decisions required to execute the stated scope.
+
+Ask each reviewer for one verdict:
+
+```text
+VERDICT: PLAN_EXECUTION_READY
+VERDICT: PLAN_NEEDS_REVISION
+VERDICT: BLOCKED_BY_PRODUCT_QUESTION
+```
+
+Treat fuzzy output by substance. The plan is ready only when both independent reviewer results clear the plan after the latest material edit.
+
+## Codex implementation
+
+In Codex, use the Codex-native reviewed-plan path installed with ai-configs:
+
+```text
+/review:plan <plan-path>
+/review:change-integrate <plan-path>
+```
+
+Then rerun `/review:plan <plan-path>` after material edits until the review result clears by substance. If the active Codex install provides a newer equivalent multi-review plan command, use that instead.
+
+Codex must not claim execution readiness if it cannot run or delegate two independent read-only plan reviews. In that case, ack with a blocker explaining the missing command or reviewer capability and leave the plan not execution-ready.
+
+## Review triage
+
+Classify every finding before editing:
+
+- `READINESS_BLOCKER`: fix before execution.
+- `PRODUCT_QUESTION`: ask the user before execution.
+- `OPTIONAL_CLARITY`: integrate only when it improves execution confidence without widening scope.
+- `OUT_OF_SCOPE_FOLLOW_UP`: do not add to this plan unless it is required for truthful verification or an acceptance-criteria gap.
+- `DISAGREE_REPO_EVIDENCE`: do not change the plan; record the evidence when useful.
+
+Do not let reviewer suggestions expand the plan beyond the user's requested scope.
+
+## Completion
+
+Complete the request only when one of these is true:
+
+- The plan has been updated, independent reviews clear, and the plan is re-registered with `--execution-ready true`.
+- A product question or tooling blocker prevents readiness; the blocker is reported clearly and the plan remains not execution-ready.

--- a/skills/reviewed-html-plan/SKILL.md
+++ b/skills/reviewed-html-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reviewed-html-plan
-description: Create and gate execution-ready HTML development plans through the local plan-review browser tool, PM product-intent review, and read-only Claude Code plus Codex plan reviews. Use this whenever the user asks for the plan review process, a reviewed HTML plan, a pre-execution plan gate, or wants a plan created from a description and registered for browser feedback before implementation.
+description: Create and gate execution-ready HTML development plans through the local plan-review browser tool, PM product-intent review, and read-only GPT plus GLM Pi subagent plan reviews. Use this whenever the user asks for the plan review process, a reviewed HTML plan, a pre-execution plan gate, or wants a plan created from a description and registered for browser feedback before implementation.
 ---
 
 # Reviewed HTML Plan Workflow
@@ -16,8 +16,8 @@ Load and follow these skills when this workflow reaches their surface:
 - `planning-workflow` for the plan-writing contract and execution-readiness bar.
 - `html-plan-reviewer` for HTML plan structure, dark-mode requirements, registration, canonical plan-review URLs, comment monitoring, claim/ack/resolve behavior, and source sync.
 - `product-principles` for workflow, defaults, recovery, status, error handling, product-intent, and early-stage scope review.
-- `codex-review-partner` for the read-only Codex plan-review pass.
-- `claude-code-review` for the read-only Claude Code plan-review pass.
+- Pi `quality-reviewer` for the read-only GPT plan-review pass.
+- Pi `quality-reviewer-glm` for the read-only GLM plan-review pass.
 - Domain skills required by the target repository guidance, stack, or plan surface.
 
 If a required review tool is unavailable, follow the relevant skill's remediation first. Stop only when the dependency cannot be restored safely or the next step requires a real product decision.
@@ -78,7 +78,7 @@ Use `html-plan-reviewer` as the sole source for current `plan-review` commands a
 4. Share the canonical full review URL after applying the URL rules from `html-plan-reviewer`; never show a loopback URL or relative path to the user.
 5. Immediately drain pending comments and start the queue-backed monitor from `agentInstructions` unless the user explicitly says not to monitor. In Pi, start the waiting listener with the `process` tool. A successful listener exit means a comment was claimed; process and ack it before starting a fresh listener. Treat low-level watch streams as debug-only unless the returned service instructions say otherwise.
 
-If browser feedback has not yet been provided, stop after sharing the review URL with the comment monitor running and tell the user to annotate the plan and then say feedback is ready. Do not proceed to Claude/Codex or PM gates until the user says feedback is ready, unless the user explicitly says to skip human browser feedback.
+If browser feedback has not yet been provided, stop after sharing the review URL with the comment monitor running and tell the user to annotate the plan and then say feedback is ready. Do not proceed to GPT/GLM or PM gates until the user says feedback is ready, unless the user explicitly says to skip human browser feedback.
 
 ### 4. Process browser feedback
 
@@ -115,13 +115,13 @@ Default behavior is corrective: reshape the HTML plan directly when the right di
 
 After material PM edits, ensure the review URL still points at the latest plan and the plan remains browser-reviewable.
 
-### 6. Read-only Claude Code and Codex plan reviews
+### 6. Read-only GPT and GLM Pi subagent plan reviews
 
 Run both reviewers before execution, and keep them read-only.
 
-#### Codex
+#### GPT
 
-Use `codex-review-partner` in `plan-review` mode. The review input should include:
+Use the Pi `quality-reviewer` subagent for the GPT review leg. The review input should include:
 
 - plan path and review URL,
 - source request or issue summary,
@@ -129,11 +129,12 @@ Use `codex-review-partner` in `plan-review` mode. The review input should includ
 - product-intent path when present,
 - readiness rubric,
 - known non-goals,
-- instruction to avoid adjacent implementation expansion.
+- instruction to avoid adjacent implementation expansion,
+- instruction not to edit files.
 
-#### Claude Code
+#### GLM
 
-Use `claude-code-review` through its canonical private-tmux interactive launcher. Prompt Claude Code to review the plan read-only and return structured output. Do not ask Claude to edit files, and do not use alternate Claude transports.
+Use the Pi `quality-reviewer-glm` subagent for the GLM review leg with high/xhigh thinking when supported. Give it the same bounded read-only prompt. Do not ask GLM to edit files.
 
 Ask both reviewers for one of these verdicts:
 
@@ -147,7 +148,7 @@ Normalize fuzzy reviewer output by substance. Treat a review as ready only when 
 
 ### 7. Integrate and iterate to execution-ready
 
-For every Claude/Codex finding, triage before editing:
+For every GPT/GLM finding, triage before editing:
 
 ```text
 Finding | Source | Classification | Decision | Evidence
@@ -161,7 +162,7 @@ Use these classifications:
 - `OUT_OF_SCOPE_FOLLOW_UP`: do not add to this plan only when it is outside the plan, not required for truthful verification, and not an acceptance-criteria/BDD gap; record it with evidence and a tracking destination if useful.
 - `DISAGREE_REPO_EVIDENCE`: do not change the plan; record the evidence if the disagreement matters.
 
-After fixing readiness blockers, rerun both Claude Code and Codex plan reviews. Repeat until both agree by substance that the plan is execution-ready. When they do, re-register the same HTML plan with truthful ready metadata using the current `html-plan-reviewer` registration flow.
+After fixing readiness blockers, rerun both GPT and GLM plan reviews. Repeat until both agree by substance that the plan is execution-ready. When they do, re-register the same HTML plan with truthful ready metadata using the current `html-plan-reviewer` registration flow.
 
 #### Independent sign-off gate (do not self-certify)
 
@@ -188,13 +189,13 @@ If AI reviews materially reshape product intent, run one final PM check before d
 Before final output, inspect the HTML plan for obvious handoff blockers:
 
 - unresolved browser-review comments remain in the queue,
-- the plan-review service metadata has not been re-registered with `--execution-ready true` after successful Claude Code and Codex plan reviews,
+- the plan-review service metadata has not been re-registered with `--execution-ready true` after successful GPT and GLM plan reviews,
 - unresolved inline review markers or unresolved question sections remain,
 - status is not `execution-ready`,
 - `Progress` or resume instructions are missing,
 - an active phase is missing `End State`, `Tests first`, `Expected files`, `Work`, or `Verify`,
 - verification commands are stale or not copy/paste ready,
-- Claude Code or Codex did not agree by substance that the plan is ready,
+- GPT or GLM did not agree by substance that the plan is ready,
 - PM review left unresolved product-intent or user-impact gaps.
 
 Do not start implementation as part of this skill.
@@ -212,8 +213,8 @@ Review URL: <canonical plan-review URL>
 ### Gates completed
 - Browser feedback: <processed / skipped by request / blocked>
 - PM review: <ready / reshaped plan / blocked>
-- Codex review: <verdict>
-- Claude Code review: <verdict>
+- GPT review: <verdict>
+- GLM review: <verdict>
 
 ### Changes made during review
 - ...

--- a/skills/scoped-plan-run/SKILL.md
+++ b/skills/scoped-plan-run/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: scoped-plan-run
-description: Execute an existing implementation plan persistently through code changes, scoped Claude and Codex reviews, fixes, verification, commit, push, PR creation, and Codex/Pi goal-backed PR monitoring until feedback is addressed, Codex approves with a :thumbsup:, and the PR is mergeable without expanding beyond the plan's stated scope.
+description: Execute an existing implementation plan persistently through code changes, scoped runtime-native quality reviews, fixes, verification, commit, push, PR creation, and PR monitoring until feedback is addressed and the PR is mergeable without expanding beyond the plan's stated scope.
 ---
 
 # Scoped Plan Run
 
-Use this skill when the user has a plan file and wants it implemented all the way to a pull request with both Claude and Codex review, while preventing reviewer-driven scope creep.
+Use this skill when the user has a plan file and wants it implemented all the way to a pull request with the runtime's scoped quality-review gates, while preventing reviewer-driven scope creep.
 
 The plan is the contract. Reviews can reveal adjacent problems, but they do not expand the contract unless the user explicitly approves that expansion.
 
-This skill is goal-backed in Codex and Pi. A scoped plan run is not complete at PR creation; it remains active until the PR satisfies the post-PR completion criteria. In Codex, back this with the Codex goal tools. In Pi, back this with the todo tool plus explicit working notes/handoff state so the monitoring obligation survives normal turn-to-turn execution.
+This skill is runtime-state-backed. A scoped plan run is not complete at PR creation; it remains active until the PR satisfies the post-PR completion criteria. In Pi, back this with the todo tool plus explicit working notes/handoff state. In Codex, back this with Codex goal/task state and the installed Codex prompts so the monitoring obligation survives normal turn-to-turn execution.
 
 ## Invocation
 
@@ -24,17 +24,15 @@ Accept either a plan path or a slug. For a slug, resolve using repo-local active
 - Do not implement if the request is plan-only, review-only, or investigation-only.
 - Do not run destructive git commands unless the user explicitly requested them.
 - Do not fix adjacent issues just because a reviewer found them.
-- Do not let Claude or Codex edit files during review. Reviews are read-only.
+- Do not let reviewer subagents edit files during review. Reviews are read-only.
 - Do not ask reviewers to review the whole product for open-ended problems.
 - Do not proceed past a blocked plan decision by silently choosing a larger scope.
 - Do not silently defer work that is required by the plan, required for verification, or introduced by this branch; fix it before merge or stop with a blocker.
 - Do not create a PR until verification appropriate to the touched surfaces has run or a blocker is clearly reported.
 - Do not mark the active run state complete just because the implementation PR exists.
-- Do not mark the active run state complete until PR feedback has been monitored and addressed, the PR is mergeable with the destination branch, and Codex has provided a `:thumbsup:` on the original PR description.
-- Treat actionable Codex PR feedback after local reviews as a review escape: the earlier review cycle missed something, so the next local review cycle must become scope-bound adversarial review instead of only patching the commented issue.
-- Do not mark the active run state blocked or stop monitoring merely because PR feedback or the qualifying Codex `:thumbsup:` is slow to arrive. Treat slow review response as a wait state that requires continued polling, not as a blocker.
-- Do not create, add, request, simulate, or otherwise manufacture the required Codex `:thumbsup:` from inside this skill, this workflow, this execution, or any account controlled by the executing agent. That approval signal exists only to prove an external PR reviewer accepted the current PR state.
-- Do not treat a self-authored reaction, local review verdict, chat transcript, manual note, or workflow-generated approval substitute as satisfying the Codex `:thumbsup:` criterion. If the executing agent accidentally or incorrectly adds such a reaction, remove it immediately, disclose the incident, and continue monitoring as incomplete.
+- Do not mark the active run state complete until PR feedback has been monitored and addressed and the PR is mergeable with the destination branch.
+- Treat actionable PR feedback after local reviews as a review escape: the earlier review cycle missed something, so the next local review cycle must become scope-bound adversarial review instead of only patching the commented issue.
+- Do not mark the active run state blocked or stop monitoring merely because PR feedback is slow to arrive. Treat slow review response as a wait state that requires continued polling, not as a blocker.
 
 ## Scope Contract
 
@@ -53,7 +51,7 @@ Stop before implementation if:
 - acceptance criteria are vague enough that scope cannot be enforced,
 - required user decisions remain unresolved,
 - the current branch contains unrelated dirty changes that make isolation unsafe,
-- Claude and Codex review are required but one is unavailable and the user has not waived it.
+- a required runtime-native review gate is unavailable and the user has not waived it. In Pi this means `quality-reviewer` and `quality-reviewer-glm`; in Codex this means the installed Codex execution/review prompts needed to perform scoped implementation review.
 
 ## Scope Classification
 
@@ -79,12 +77,10 @@ If the answer to all three is no, it may be left out of this PR only after it is
 
 ### 1. Establish Run State
 
-1. Check whether a scoped-plan-run goal or task state is already active.
-2. If no compatible run state is active, create one before implementation begins.
-   - In Codex, use the Codex goal tools for this lifecycle. Do not treat the goal as a checklist in notes only.
-   - In Pi, use the todo tool to create an explicit lifecycle task set before implementation. Keep exactly one active item at a time and include a final post-PR monitoring item that cannot be marked done until all completion criteria are satisfied.
+1. Check whether a scoped-plan-run task/goal state is already active.
+2. If no compatible run state is active, create an explicit lifecycle task set before implementation. In Pi, use the todo tool and keep exactly one active item at a time. In Codex, use Codex goal/task state. Include a final post-PR monitoring item that cannot be marked done until all completion criteria are satisfied.
 3. The objective must require both:
-   - executing the specified plan through implementation, verification, review, commit, push, and PR creation;
+   - executing the specified plan through implementation, verification, runtime-native scoped review, commit, push, and PR creation;
    - monitoring the PR after creation until the post-PR completion criteria are satisfied.
 4. If an active run state already exists and it is compatible with this scoped plan run, continue under it and state the compatibility in working notes.
 5. If an active run state exists but conflicts with this scoped plan run, stop and ask the user whether to finish, block, or abandon the existing run before creating a new one.
@@ -92,12 +88,10 @@ If the answer to all three is no, it may be left out of this PR only after it is
 Use this objective shape:
 
 ```text
-Execute <plan path> through scoped implementation, verification, reviews, commit, push, PR creation, and persistent post-PR monitoring. Do not mark complete until all PR feedback has been addressed and repeatedly rechecked, monitoring has continued until an external reviewer provides the qualifying Codex :thumbsup: on the original PR description for the current PR state, the :thumbsup: was not provided by this skill/workflow/execution or any account controlled/requested by the executing agent, and the PR is mergeable with <target branch>. Do not stop or mark blocked merely because review feedback or the qualifying :thumbsup: takes a long time to arrive.
+Execute <plan path> through scoped implementation, verification, runtime-native scoped quality reviews, commit, push, PR creation, and persistent post-PR monitoring. Do not mark complete until all PR feedback has been addressed and repeatedly rechecked and the PR is mergeable with <target branch>. Do not stop or mark blocked merely because review feedback takes a long time to arrive.
 ```
 
-The `:thumbsup:` in the objective must be interpreted as external reviewer approval only. The executing agent must not provide it, cause it to be provided by this workflow, or count any reaction from itself or its automation as completion evidence.
-
-Pi-specific state expectation: keep the todo/working notes current with the plan path, PR URL once known, target branch, latest verification status, latest review state, mergeability, and whether the qualifying external `:thumbsup:` is still missing. Do not clear or complete those todos until the same criteria that would close the Codex goal are satisfied.
+Runtime state expectation: keep the task/goal state and working notes current with the plan path, PR URL once known, target branch, latest verification status, latest reviewer-pair state, feedback state, and mergeability. In Pi this state lives in todo/working notes; in Codex it lives in Codex goal/task state. Do not clear or complete the run state until the same completion criteria are satisfied.
 
 ### 2. Prepare
 
@@ -123,7 +117,7 @@ If a phase exposes a broader product problem, classify it. Fix it only if it is 
 
 ### 4. Self Scope Audit
 
-Before external review, inspect the diff against the plan:
+Before reviewer subagent review, inspect the diff against the plan:
 
 ```bash
 git diff --stat
@@ -134,9 +128,9 @@ For every changed file, answer: why does this file need to change for this plan?
 
 If a changed file has no plan-bound reason, revert only your own edits to that file or split the work into a separate follow-up branch. Never revert user changes.
 
-### 5. Codex Review
+### 5. First scoped quality review
 
-Use the `codex-review-partner` skill or its wrapper for a read-only implementation review.
+In Pi, use the Pi subagent `quality-reviewer` for a read-only GPT-5.5 implementation review. In Codex, use the installed Codex-native `quality-reviewer`/implementation-review mechanism for the first read-only scoped review. Do not let any reviewer edit files.
 
 The review prompt must include:
 
@@ -158,13 +152,13 @@ VERDICT: BLOCKED_BY_SCOPE_QUESTION
 
 Reject malformed reviews and rerun once with a tighter prompt. `PASS_WITH_DOCUMENTED_OUT_OF_SCOPE_FOLLOW_UPS` is valid only when every remaining finding is classified `OUT_OF_SCOPE_FOLLOW_UP` and includes evidence plus a tracking destination; otherwise treat the review as `FIX_IN_SCOPE_FINDINGS` or `BLOCKED_BY_SCOPE_QUESTION` by substance.
 
-### 6. Claude Review
+### 6. Second scoped quality review
 
-Use the `claude-code-review` skill for a read-only Claude review through its canonical private-tmux interactive launcher.
+In Pi, use the Pi subagent `quality-reviewer-glm` with `thinking: "xhigh"` for a read-only GLM-5.2 implementation review. In Codex, use the second installed Codex-native independent implementation-review path when available; if no independent Codex review path is installed, stop with a clear blocker instead of claiming the scoped run is reviewed.
 
-Claude must receive the same bounded prompt as Codex. It must not edit files. It must return findings in chat, classified with the same scope categories. Do not use alternate Claude transports for this required gate.
+The second reviewer must receive the same bounded prompt as the first reviewer. It must not edit files. It must return findings in chat, classified with the same scope categories.
 
-If Claude reports broad adjacent risks, keep them out of the PR only when they satisfy the `OUT_OF_SCOPE_FOLLOW_UP` definition and are documented. If the risk maps to the plan, verification, or this diff, treat it as in-scope and fix it.
+If either reviewer reports broad adjacent risks, keep them out of the PR only when they satisfy the `OUT_OF_SCOPE_FOLLOW_UP` definition and are documented. If the risk maps to the plan, verification, or this diff, treat it as in-scope and fix it.
 
 ### 7. Triage Reviews Before Fixing
 
@@ -174,7 +168,7 @@ Create a short triage table in your working notes:
 Finding | Source | Classification | Decision | Evidence
 ```
 
-For each Claude and Codex finding:
+For each scoped reviewer finding:
 
 - Fix `IN_PLAN`, `PLAN_PREREQUISITE`, and `REGRESSION_FROM_THIS_DIFF`.
 - Record `OUT_OF_SCOPE_FOLLOW_UP` without fixing it only after documenting why it is outside this plan and where it will be tracked.
@@ -187,8 +181,8 @@ Do not implement fixes directly from reviewer prose. Convert them through this t
 After fixing in-scope findings:
 
 1. Rerun targeted tests for touched code.
-2. Rerun Codex review with the previous findings and current diff.
-3. Rerun Claude review with the same bounded scope.
+2. Rerun the first scoped quality review with the previous findings and current diff.
+3. Rerun the second scoped quality review with the same bounded scope.
 4. Repeat until both reviewers return `PASS_SCOPED` or `PASS_WITH_DOCUMENTED_OUT_OF_SCOPE_FOLLOW_UPS`.
 
 Stop and report a convergence blocker if:
@@ -218,8 +212,8 @@ The PR body must include:
 - plan path,
 - in-scope summary,
 - verification commands and results,
-- Claude review verdict,
-- Codex review verdict,
+- first scoped quality-review verdict,
+- second scoped quality-review verdict,
 - documented out-of-scope follow-ups with evidence and tracking destination,
 - known residual risks.
 
@@ -227,7 +221,7 @@ Do not include memory citations in PR messages.
 
 ## Post-PR Completion Loop
 
-After the PR is open, keep the active Codex goal or Pi todo/run state active and monitor the PR until all completion criteria are satisfied.
+After the PR is open, keep the active runtime task/goal state active and monitor the PR until all completion criteria are satisfied. In Pi this is the active todo/run state; in Codex this is the active Codex goal/task state.
 
 ### Completion Criteria
 
@@ -235,19 +229,17 @@ The run state can be marked complete only when all of these are true:
 
 - All actionable PR feedback has been addressed.
 - PR feedback has been checked repeatedly after fixes, not just once immediately after PR creation.
-- Codex has provided a `:thumbsup:` on the original PR description from the expected external PR reviewer account.
-- The required `:thumbsup:` was not added by the executing agent, this skill/workflow/execution, an agent-controlled account, or any approval action requested by the executing agent.
-- After every PR feedback item is addressed, monitoring continues until the external reviewer adds the qualifying `:thumbsup:` for the current PR state.
+- If PR feedback required code changes, both runtime-native scoped quality reviews have rerun over the current PR diff and cleared any in-scope findings.
 - The branch has been rebased or otherwise updated against the destination branch as needed.
 - GitHub reports the PR as mergeable with the destination branch.
 
 ### Monitoring Loop
 
-Repeat this loop until the completion criteria are met or a true blocker is reached. Slow or absent reviewer feedback, pending checks, and a missing qualifying Codex `:thumbsup:` are not true blockers by themselves; they require continued polling.
+Repeat this loop until the completion criteria are met or a true blocker is reached. Slow or absent reviewer feedback and pending checks are not true blockers by themselves; they require continued polling.
 
 1. Inspect PR reviews, review threads, comments, status checks, and mergeability.
 2. Classify every new feedback item using the same scope categories.
-3. If any actionable feedback comes from Codex after the local Codex/Claude review gates already passed, mark the cycle as a `REVIEW_ESCAPE` in working notes. Fixing only the mentioned line is insufficient.
+3. If any actionable feedback arrives after the local scoped review gates already passed, mark the cycle as a `REVIEW_ESCAPE` in working notes. Fixing only the mentioned line is insufficient.
 4. Fix `IN_PLAN`, `PLAN_PREREQUISITE`, and `REGRESSION_FROM_THIS_DIFF` feedback.
 5. Record or report `OUT_OF_SCOPE_FOLLOW_UP` feedback with evidence and tracking destination without expanding the PR.
 6. Stop for user input on `QUESTION` feedback.
@@ -255,9 +247,8 @@ Repeat this loop until the completion criteria are met or a true blocker is reac
 8. Rerun the smallest meaningful verification for any changes.
 9. Commit and push fixes to the PR branch.
 10. Rebase onto the destination branch when GitHub reports the branch out of date, conflicted, or not mergeable.
-11. Recheck until GitHub shows the PR as mergeable and the external-reviewer Codex `:thumbsup:` is present on the original PR description for the current PR state.
-12. If feedback is addressed but the external reviewer has not added the qualifying `:thumbsup:`, keep the run state active and continue monitoring. Do not add the reaction yourself, ask this workflow to add it, or mark the run state complete.
-13. If a poll finds no new feedback and no qualifying `:thumbsup:`, report the latest PR state briefly, keep the run state active, wait, and poll again. Do not end the scoped-plan run or mark the run state blocked for review latency alone.
+11. Recheck until GitHub shows the PR as mergeable and no new actionable feedback remains.
+12. If a poll finds no new feedback but checks or mergeability are still pending, report the latest PR state briefly, keep the run state active, wait, and poll again. Do not end the scoped-plan run or mark the run state blocked for review latency alone.
 
 ### Adversarial Escalation Loop
 
@@ -265,34 +256,32 @@ A `REVIEW_ESCAPE` means the previous review prompt was not thorough enough for t
 
 1. Write down the missed-defect pattern: reviewer, feedback URL, affected file/line, why earlier review missed it, and the failure family it represents.
 2. Audit the PR diff for sibling instances: same assumption, same edge case, same API contract, same missing validation, same lifecycle/state transition, analogous callsites, and tests that should have failed but did not.
-3. Run a read-only Codex `adversarial-implementation-review` against the full current PR diff, the plan scope contract, the direct PR feedback, and the sibling-audit notes. Ask Codex to actively look for additional missed issues in the same failure family and nearby plan-bound surfaces, not to re-approve the one fix.
-4. If the escaped issue involves user-visible behavior, data loss, auth/security, migrations, concurrency, or broad callsite risk, also rerun Claude with the same adversarial prompt.
-5. Triage new adversarial findings using the normal scope classifications. Fix in-scope findings, document true out-of-scope follow-ups, and stop for questions.
-6. Repeat the adversarial review once after fixes if it finds any in-scope issue. Return to the normal monitoring loop only after the adversarial pass reports no additional in-scope findings or only documented out-of-scope follow-ups.
+3. Run read-only adversarial implementation reviews with both runtime-native scoped reviewers. In Pi, use `quality-reviewer` and `quality-reviewer-glm` with `thinking: "xhigh"`; in Codex, use the installed Codex-native independent implementation-review paths. Review the full current PR diff, the plan scope contract, the direct PR feedback, and the sibling-audit notes. Ask reviewers to actively look for additional missed issues in the same failure family and nearby plan-bound surfaces, not to re-approve the one fix.
+4. Triage new adversarial findings using the normal scope classifications. Fix in-scope findings, document true out-of-scope follow-ups, and stop for questions.
+5. Repeat the adversarial reviewer-pair pass once after fixes if it finds any in-scope issue. Return to the normal monitoring loop only after both adversarial passes report no additional in-scope findings or only documented out-of-scope follow-ups.
 
 Keep this escalation scope-bound: it should search harder around the PR's implementation, assumptions, and failure modes, not turn into an unrelated whole-product audit.
 
 ### Polling Persistence
 
-When the run has reached post-PR monitoring, the agent must persist across goal/session turns:
+When the run has reached post-PR monitoring, the agent must persist across session turns:
 
-- Keep polling the PR until the qualifying external Codex `:thumbsup:` appears or a real actionable blocker requires user input.
-- Poll every 60 seconds while waiting for PR feedback or the qualifying `:thumbsup:`. Do not use a slower default such as five minutes unless the user explicitly asks to reduce polling frequency.
-- Continue monitoring even after all current feedback is addressed, because late feedback can still arrive before the `:thumbsup:`.
-- Do not treat "no new feedback", "review still pending", "checks still running", or "no `:thumbsup:` yet" as completion, failure, or a blocker.
-- In Pi, leave the monitoring todo active and summarize the latest PR URL, mergeability, feedback state, and missing/completed `:thumbsup:` evidence in any handoff or final-in-turn status.
+- Keep polling the PR until actionable feedback is resolved, required checks have settled, and the PR is mergeable.
+- Poll every 60 seconds while waiting for PR feedback, checks, or mergeability unless the user explicitly asks to reduce polling frequency.
+- Continue monitoring even after current feedback is addressed, because late feedback can still arrive before mergeability/checks settle.
+- Do not treat "no new feedback", "review still pending", or "checks still running" as completion, failure, or a blocker.
+- In Pi, leave the monitoring todo active and summarize the latest PR URL, mergeability, feedback state, and reviewer-pair state in any handoff or final-in-turn status.
 - A true blocker must be something the agent cannot resolve by continued polling or scoped fixes, such as lost GitHub authentication, a closed/deleted PR, a force-push/base-branch conflict requiring a product decision, or `QUESTION` feedback that needs the user.
 - If a true blocker is reached, report the exact blocker and the latest PR state. Otherwise, keep the active run state open and continue polling.
 
-Use GitHub product surfaces for this check. The watcher must inspect both feedback surfaces and `:thumbsup:` reactions on every poll:
+Use GitHub product surfaces for this check:
 
 - PR issue comments via `gh pr view ... --json comments` and/or `GET /repos/<owner>/<repo>/issues/<pr>/comments`.
 - PR reviews via `gh pr view ... --json reviews`.
 - Inline review comments via `GET /repos/<owner>/<repo>/pulls/<pr>/comments`.
 - Status/mergeability via `gh pr view ... --json mergeable,mergeStateStatus,statusCheckRollup,reviewDecision`.
-- `+1` reactions on the PR issue itself via `GET /repos/<owner>/<repo>/issues/<pr>/reactions`.
 
-Reference implementation for Pi: write this to `/tmp/monitor-pr-<pr>.sh`, start it with the `process` tool, and set `logWatches` for `FEEDBACK_CHANGED` and `QUALIFYING_THUMBSUP_PRESENT`. It polls every 60 seconds, stores snapshots, reports comment/review/status changes, and separately reports `+1` reactions without ever creating one.
+Reference implementation for Pi: write this to `/tmp/monitor-pr-<pr>.sh`, start it with the `process` tool, and set `logWatches` for `FEEDBACK_CHANGED`. It polls every 60 seconds, stores snapshots, and reports comment/review/status changes.
 
 ```bash
 #!/usr/bin/env bash
@@ -300,7 +289,6 @@ set -euo pipefail
 
 repo="${1:?owner/repo required}"
 pr="${2:?pr number required}"
-expected_thumb_user="${3:-}" # Optional; if empty, report all +1 users as candidates.
 interval_seconds="${PR_MONITOR_INTERVAL_SECONDS:-60}"
 state_dir="${PR_MONITOR_STATE_DIR:-/tmp/pr-monitor-${repo//\//-}-${pr}}"
 mkdir -p "$state_dir"
@@ -311,7 +299,6 @@ fetch_state() {
     > "$state_dir/pr.json"
   gh api "repos/$repo/issues/$pr/comments" > "$state_dir/issue-comments.json"
   gh api "repos/$repo/pulls/$pr/comments" > "$state_dir/review-comments.json"
-  gh api "repos/$repo/issues/$pr/reactions" > "$state_dir/reactions.json"
 }
 
 snapshot_feedback() {
@@ -327,11 +314,6 @@ snapshot_feedback() {
   }' "$state_dir/pr.json" "$state_dir/issue-comments.json" "$state_dir/review-comments.json" > "$state_dir/feedback.current.json"
 }
 
-snapshot_reactions() {
-  jq -S --arg expected "$expected_thumb_user" '[.[] | select(.content == "+1") | {user:.user.login, createdAt:.created_at, qualifies:(($expected == "") or (.user.login == $expected))}]' \
-    "$state_dir/reactions.json" > "$state_dir/thumbs.current.json"
-}
-
 while true; do
   ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   if ! fetch_state; then
@@ -340,30 +322,18 @@ while true; do
     continue
   fi
   snapshot_feedback
-  snapshot_reactions
 
   if [ -f "$state_dir/feedback.previous.json" ] && ! cmp -s "$state_dir/feedback.previous.json" "$state_dir/feedback.current.json"; then
     echo "$ts FEEDBACK_CHANGED snapshot=$state_dir/feedback.current.json"
-  fi
-  if [ -s "$state_dir/thumbs.current.json" ] && [ "$(jq 'length' "$state_dir/thumbs.current.json")" -gt 0 ]; then
-    users=$(jq -r '[.[] | select(.qualifies) | .user] | join(",")' "$state_dir/thumbs.current.json")
-    if [ -n "$users" ]; then
-      echo "$ts QUALIFYING_THUMBSUP_PRESENT users=$users snapshot=$state_dir/thumbs.current.json"
-    else
-      all_users=$(jq -r '[.[].user] | join(",")' "$state_dir/thumbs.current.json")
-      echo "$ts NONQUALIFYING_THUMBSUP users=$all_users snapshot=$state_dir/thumbs.current.json"
-    fi
   fi
 
   merge=$(jq -r '.mergeable + "/" + .mergeStateStatus' "$state_dir/pr.json")
   comments=$(jq 'length' "$state_dir/issue-comments.json")
   review_comments=$(jq 'length' "$state_dir/review-comments.json")
   reviews=$(jq '.reviews | length' "$state_dir/pr.json")
-  thumbs=$(jq 'length' "$state_dir/thumbs.current.json")
-  echo "$ts PR_MONITOR merge=$merge issue_comments=$comments review_comments=$review_comments reviews=$reviews thumbs_up=$thumbs"
+  echo "$ts PR_MONITOR merge=$merge issue_comments=$comments review_comments=$review_comments reviews=$reviews"
 
   cp "$state_dir/feedback.current.json" "$state_dir/feedback.previous.json"
-  cp "$state_dir/thumbs.current.json" "$state_dir/thumbs.previous.json"
   sleep "$interval_seconds"
 done
 ```
@@ -371,12 +341,8 @@ done
 Start it like this from Pi, leaving it running in the background:
 
 ```text
-process.start name="pr-<number>-monitor" command="bash /tmp/monitor-pr-<number>.sh <owner>/<repo> <number> <expected-codex-reviewer-login>" logWatches=[FEEDBACK_CHANGED,QUALIFYING_THUMBSUP_PRESENT]
+process.start name="pr-<number>-monitor" command="bash /tmp/monitor-pr-<number>.sh <owner>/<repo> <number>" logWatches=[FEEDBACK_CHANGED]
 ```
-
-The `:thumbsup:` criterion means a `+1` reaction from the expected external Codex reviewer account on the PR issue itself, not a local reviewer verdict pasted into chat and not a reaction from the executing agent. If the expected Codex account is ambiguous, identify the account from the repository's normal PR automation or ask the user before declaring the goal complete. The executing agent must never satisfy this criterion by adding its own `+1` reaction or by asking another agent in this workflow to add one.
-
-If a non-qualifying `+1` reaction exists, ignore it for completion. If the executing agent created it, remove it when possible and report that the previous completion signal was invalid.
 
 ### Rebase Guidance
 
@@ -392,7 +358,7 @@ Do not use destructive git commands to force mergeability. If conflicts require 
 
 ### Run State Closure
 
-Only after the completion criteria are all satisfied, mark the Codex goal or Pi monitoring todo complete. Do not mark the run state blocked for a slow reviewer, no new feedback, pending review, pending checks, or missing qualifying `:thumbsup:`; those are polling wait states. Mark the run state blocked only for a real actionable blocker that prevents meaningful polling or scoped fixes, and report the exact blocker with the latest PR state.
+Only after the completion criteria are all satisfied, mark the runtime monitoring task/goal complete. In Pi, complete the monitoring todo; in Codex, complete the Codex goal/task state. Do not mark the run state blocked for a slow reviewer, no new feedback, pending review, or pending checks; those are polling wait states. Mark the run state blocked only for a real actionable blocker that prevents meaningful polling or scoped fixes, and report the exact blocker with the latest PR state.
 
 ## Reviewer Prompt Template
 
@@ -436,7 +402,7 @@ Append this when a `REVIEW_ESCAPE` occurred:
 
 ```text
 Adversarial escalation context:
-Codex found actionable PR feedback after our local review gates had passed. Treat that as evidence the prior review was not thorough enough.
+Actionable PR feedback arrived after our local reviewer-pair gates had passed. Treat that as evidence the prior review was not thorough enough.
 
 Escaped feedback:
 - Reviewer/comment URL: <url>
@@ -459,13 +425,12 @@ Stay within the scope contract. Classify every finding with the normal scope lab
 Report:
 
 - PR URL,
-- run-state status (Codex goal or Pi todo),
+- run-state status (Pi todo or Codex goal/task),
 - changed files at a high level,
 - verification run,
-- Claude and Codex verdicts,
+- runtime-native scoped quality-review verdicts,
 - PR feedback monitoring result,
 - PR mergeability result,
-- Codex `:thumbsup:` result,
 - documented out-of-scope follow-ups with evidence and tracking destination,
 - any residual risk.
 

--- a/skills/scoped-plan-run/SKILL.md
+++ b/skills/scoped-plan-run/SKILL.md
@@ -297,8 +297,8 @@ fetch_state() {
   gh pr view "$pr" --repo "$repo" \
     --json url,number,state,baseRefName,headRefName,headRefOid,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,comments,reviews \
     > "$state_dir/pr.json"
-  gh api "repos/$repo/issues/$pr/comments" > "$state_dir/issue-comments.json"
-  gh api "repos/$repo/pulls/$pr/comments" > "$state_dir/review-comments.json"
+  gh api --paginate --slurp "repos/$repo/issues/$pr/comments" | jq 'add' > "$state_dir/issue-comments.json"
+  gh api --paginate --slurp "repos/$repo/pulls/$pr/comments" | jq 'add' > "$state_dir/review-comments.json"
 }
 
 snapshot_feedback() {
@@ -327,7 +327,7 @@ while true; do
     echo "$ts FEEDBACK_CHANGED snapshot=$state_dir/feedback.current.json"
   fi
 
-  merge=$(jq -r '.mergeable + "/" + .mergeStateStatus' "$state_dir/pr.json")
+  merge=$(jq -r '(.mergeable // "UNKNOWN") + "/" + (.mergeStateStatus // "UNKNOWN")' "$state_dir/pr.json")
   comments=$(jq 'length' "$state_dir/issue-comments.json")
   review_comments=$(jq 'length' "$state_dir/review-comments.json")
   reviews=$(jq '.reviews | length' "$state_dir/pr.json")

--- a/test_install_shared_skills.sh
+++ b/test_install_shared_skills.sh
@@ -261,12 +261,16 @@ assert_shared_skill_install_state() {
   [[ -f "$home/.agents/skills/plan-reviewer-execution-ready/SKILL.md" ]] || return 1
   [[ -f "$home/.agents/skills/plan-reviewer-execution-ready/.ai-configs-managed.json" ]] || return 1
   assert_file_contains "$home/.agents/skills/plan-reviewer-execution-ready/SKILL.md" 'quality-reviewer-glm' || return 1
+  assert_file_contains "$home/.agents/skills/plan-reviewer-execution-ready/.ai-configs-managed.json" '"repo": "ai-configs"' || return 1
   assert_file_contains "$home/.agents/skills/plan-reviewer-execution-ready/.ai-configs-managed.json" '"source": "skills/plan-reviewer-execution-ready"' || return 1
+  assert_file_contains "$home/.agents/skills/plan-reviewer-execution-ready/.ai-configs-managed.json" '"managed": true' || return 1
 
   [[ -f "$home/.agents/skills/plan-reviewer-build/SKILL.md" ]] || return 1
   [[ -f "$home/.agents/skills/plan-reviewer-build/.ai-configs-managed.json" ]] || return 1
   assert_file_contains "$home/.agents/skills/plan-reviewer-build/SKILL.md" 'scoped-plan-run' || return 1
+  assert_file_contains "$home/.agents/skills/plan-reviewer-build/.ai-configs-managed.json" '"repo": "ai-configs"' || return 1
   assert_file_contains "$home/.agents/skills/plan-reviewer-build/.ai-configs-managed.json" '"source": "skills/plan-reviewer-build"' || return 1
+  assert_file_contains "$home/.agents/skills/plan-reviewer-build/.ai-configs-managed.json" '"managed": true' || return 1
 
   [[ -f "$home/.agents/skills/algorithmic-art/SKILL.md" ]] || return 1
   assert_file_contains "$home/.agents/skills/algorithmic-art/SKILL.md" 'external package=anthropics/skills skill=algorithmic-art' || return 1

--- a/test_install_shared_skills.sh
+++ b/test_install_shared_skills.sh
@@ -258,6 +258,16 @@ assert_shared_skill_install_state() {
   assert_file_contains "$home/.agents/skills/adn-dev-wf/.ai-configs-managed.json" '"source": "skills/adn-dev-wf"' || return 1
   assert_file_contains "$home/.agents/skills/adn-dev-wf/.ai-configs-managed.json" '"managed": true' || return 1
 
+  [[ -f "$home/.agents/skills/plan-reviewer-execution-ready/SKILL.md" ]] || return 1
+  [[ -f "$home/.agents/skills/plan-reviewer-execution-ready/.ai-configs-managed.json" ]] || return 1
+  assert_file_contains "$home/.agents/skills/plan-reviewer-execution-ready/SKILL.md" 'quality-reviewer-glm' || return 1
+  assert_file_contains "$home/.agents/skills/plan-reviewer-execution-ready/.ai-configs-managed.json" '"source": "skills/plan-reviewer-execution-ready"' || return 1
+
+  [[ -f "$home/.agents/skills/plan-reviewer-build/SKILL.md" ]] || return 1
+  [[ -f "$home/.agents/skills/plan-reviewer-build/.ai-configs-managed.json" ]] || return 1
+  assert_file_contains "$home/.agents/skills/plan-reviewer-build/SKILL.md" 'scoped-plan-run' || return 1
+  assert_file_contains "$home/.agents/skills/plan-reviewer-build/.ai-configs-managed.json" '"source": "skills/plan-reviewer-build"' || return 1
+
   [[ -f "$home/.agents/skills/algorithmic-art/SKILL.md" ]] || return 1
   assert_file_contains "$home/.agents/skills/algorithmic-art/SKILL.md" 'external package=anthropics/skills skill=algorithmic-art' || return 1
   [[ -f "$home/.agents/skills/algorithmic-art/.ai-configs-managed.json" ]] || return 1
@@ -570,6 +580,8 @@ test_phase_four_validation_proves_final_alignment() {
   [[ -f "$home/.agents/skills/external-skill/SKILL.md" ]] || return 1
   [[ -f "$home/.agents/skills/linear/SKILL.md" ]] || return 1
   [[ -f "$home/.agents/skills/doct-document-ops/SKILL.md" ]] || return 1
+  [[ -f "$home/.agents/skills/plan-reviewer-execution-ready/SKILL.md" ]] || return 1
+  [[ -f "$home/.agents/skills/plan-reviewer-build/SKILL.md" ]] || return 1
 
   claude_symlinks="$(find "$home/.claude/skills" -mindepth 1 -maxdepth 1 -type l | sort)"
   opencode_symlinks="$(find "$home/.config/opencode/skills" -mindepth 1 -maxdepth 1 -type l | sort)"


### PR DESCRIPTION
Plan: /Users/anichols/code/plan-reviewer-worktrees/update-plan-review/thoughts/plans/skill-routed-plan-reviewer-actions.html

## Summary
- Add shared `plan-reviewer-execution-ready` and `plan-reviewer-build` skills for Pi and Codex.
- Add Pi `quality-reviewer-glm` source agent and root catalog entry.
- Align reviewed-plan and scoped-plan-run guidance with GPT/GLM Pi reviewers plus Codex-native task/review state.
- Address CodeRabbit/Codex feedback: markdown fence languages, build-skill readiness delegation, PR monitor pagination/null safety, managed-marker assertions, and agent catalog registration.

## Verification
- `python3 -m json.tool skills/install-matrix.json` — passed.
- `bash -n test_install_shared_skills.sh` — passed.
- Targeted stale reviewed-plan wording check — passed.
- New skill/install presence checks — passed.
- `bash install.sh --skills` — passed and installed updated shared skills.
- `git diff --check` — passed.
- `bash test_install_shared_skills.sh` — still fails only pre-existing phase-three/four opencode cleanup checks documented below.

## Scoped reviews
- Initial GPT quality-reviewer: `PASS_SCOPED`.
- Initial GLM quality-reviewer-glm: `PASS_SCOPED`.
- Post-feedback GPT adversarial review: `PASS_WITH_DOCUMENTED_OUT_OF_SCOPE_FOLLOW_UPS`.
- Post-feedback GLM adversarial review: `PASS_WITH_DOCUMENTED_OUT_OF_SCOPE_FOLLOW_UPS`.

## Related product PR
- plan-reviewer companion PR: https://github.com/Nodaste-Lab/plan-reviewer/pull/42

## Out-of-scope follow-ups
- Pre-existing broader `test_install_shared_skills.sh` failures around `_opencode/QUICKSTART.md` and `_opencode/skills/codex-computer-use`; documented in the plan decisions log and not introduced by this branch.
- Pre-existing external-package managed-marker assertion hardening for `algorithmic-art` and `design-skill`; tracking destination is the companion plan deviation log entry `log-2026-06-19-pr-feedback` in `thoughts/plans/skill-routed-plan-reviewer-actions.html` / plan-reviewer PR #42.

## Residual risk
- This config PR should merge/deploy with the plan-reviewer PR so browser action comments resolve to installed shared skills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added plan-reviewer-build and plan-reviewer-execution-ready skills
  * Introduced quality-reviewer-glm and general-glm agents

* **Documentation**
  * Updated plan review workflow documentation and skill specifications

* **Refactor**
  * Modified plan review implementation to use GPT/GLM models
  * Enhanced scoped-plan-run workflow monitoring and review processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->