### PR TITLE
feat: rename scoped plan run workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,12 +187,13 @@ The `_pi/` directory provides Pi prompt templates, subagents, and extensions. Re
 ### Quick Reference
 
 Pi now supports both:
-- direct prompt-template commands like `/cmd:debug`, `/dev:plan`, `/review:change`
-- skill commands like `/skill:adn-dev-wf`
+- direct prompt-template commands like `/cmd:debug`, `/dev:plan`, `/review:change`, `/run-plan`
+- skill commands like `/skill:run-plan`
 
 ```bash
-# Canonical reviewed-plan workflow
-/skill:adn-dev-wf <task | plan-slug | thoughts/plans/<plan>.html>
+# Full reviewed-plan implementation through PR
+/run-plan <thoughts/plans/<plan>.html | plan-slug>
+/skill:run-plan <thoughts/plans/<plan>.html | plan-slug>
 
 # Browser-reviewed HTML plan gate
 /dev:reviewed-html-plan <task | plan-slug | thoughts/plans/<plan>.html>
@@ -225,12 +226,12 @@ unless it already satisfies that format.
 
 Expected Pi reviewed-plan flow in this repo:
 - Active browser-reviewed plans are semantic HTML files under `thoughts/plans/<slug>.html`; do not create Markdown companions for that flow.
-- `/skill:adn-dev-wf <task | plan>` is the canonical single-entry workflow.
-- It internally owns plan refresh, blocker-only review, review integration, direct execution, and bounded implementation-stage PM follow-up.
+- `/run-plan <plan>` / `/skill:run-plan <plan>` is the full implementation-through-PR workflow for an existing execution-ready reviewed plan.
+- `/skill:adn-dev-wf <task | plan>` remains available for the broader reviewed-plan workflow that owns plan refresh, blocker-only review, review integration, direct execution, and bounded implementation-stage PM follow-up.
 - `/dev:reviewed-html-plan <task | plan>` / `/skill:reviewed-html-plan <task | plan>` is the browser-reviewed HTML pre-execution gate for plan-review feedback plus PM and GPT/GLM Pi subagent plan review; it must register through `plan-review`, follow returned `agentInstructions`, and start the queue-backed comment monitor.
 - `skills/html-plan-reviewer/SKILL.md` is the sole source for concrete `plan-review` commands, readiness metadata, canonical URL rules, and comment monitor mechanics; other planning skills should reference it instead of duplicating command recipes.
 - `/skill:dev-plan <task>` remains available for planning-only work.
-- `/dev:run <plan>` remains available when you already have an execution-ready reviewed plan and want execution only.
+- `/dev:run <plan>` remains available when you already have an execution-ready reviewed plan and want direct execution only.
 
 `/review:change-claude-code` remains an explicit opt-in review command, not a hidden fallback inside plan mode or execution.
 
@@ -295,13 +296,13 @@ This repository includes Pi-specific prompt templates under `_pi/prompts/`, pi-s
 - `/skill:cmd-resume-handoff` — Resume from handoff
 
 **Reviews:**
-- `/skill:adn-dev-wf` — Canonical reviewed-plan development workflow
+- `/skill:adn-dev-wf` — Broader reviewed-plan development workflow
 - `/skill:reviewed-html-plan` — Create/register browser-reviewed HTML plans, process plan-review feedback, run PM plus GPT/GLM Pi subagent plan reviews, and stop at execution-ready handoff
 - `/skill:omp-review-partner` — Use OMP with OpenCode Zen Kimi models for read-only plan and implementation reviews
 - `/skill:review-change` — Review code changes against plan
 - `/skill:review-change-integrate` — Integrate code-review feedback
-- `/skill:pre-pr-implementation-review` — Run GPT-5.5 plus GLM-5 Pi subagent pre-PR implementation review until in-scope P1/P2/P3 findings are addressed; inside `scoped-plan-run` it hands back to mandatory PR creation instead of concluding.
-- `/skill:scoped-plan-run` — Execute an explicit plan through implementation, reviews, full P1/P2/P3 cleanup, verification, PR creation, and post-PR monitoring.
+- `/skill:pre-pr-implementation-review` — Run GPT-5.5 plus GLM-5 Pi subagent pre-PR implementation review until in-scope P1/P2/P3 findings are addressed; inside `run-plan` it hands back to mandatory PR creation instead of concluding.
+- `/skill:run-plan` — Execute an explicit plan through implementation, reviews, full P1/P2/P3 cleanup, verification, PR creation, and post-PR monitoring.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Gemini TOML command definitions plus the `GEMINI.template.md` persona template.
 OMP commands, agents, repo-managed extensions, and OMP-local docs. The repo-managed planning entrypoint is the `/aplan` extension/alias, which is installed under `~/.omp/agent/extensions/`, enters built-in `/plan` mode while queueing repo-managed planning guidance for the next planning turn, preserves native `/plan`, auto-runs `/review:change-integrate` after standard plan review leaves inline comments, supports `/dev:pm-review` as a corrective PM reshaping pass, and hands reviewed plans off through prepared `/cmd:execute-plan ... --target ...` execution choices. This tree also now ships a vendored `pi-vcc` extension for OMP under `_omp/extensions/pi-vcc`, installed to `~/.omp/agent/extensions/pi-vcc`, which provides algorithmic compaction, the `/pi-vcc` manual compaction command, and the `vcc_recall` tool.
 
 ### `_pi/`
-Pi prompts, subagents, repo-managed extensions copied into `~/.pi/agent/extensions/`, and Pi package baseline documentation for the separate `pi list`-visible package set. Notable reviewed-plan commands include `/dev:plan`, `/dev:pm-review`, `/review:plan`, and `/cmd:execute-plan`.
+Pi prompts, subagents, repo-managed extensions copied into `~/.pi/agent/extensions/`, and Pi package baseline documentation for the separate `pi list`-visible package set. Notable reviewed-plan commands include `/dev:plan`, `/dev:pm-review`, `/review:plan`, `/cmd:execute-plan`, and `/run-plan`.
 
 ### `_opencode/`
 OpenCode commands, agents, prompts, repo-local-only skills, onboarding docs, and helper scripts.

--- a/_claude/commands/README.md
+++ b/_claude/commands/README.md
@@ -38,9 +38,10 @@ This directory contains a comprehensive set of commands that support a complete 
 17. **`cmd:review-pr-comments.md`** - Review and address GitHub PR comments since last commit
 
 ### Autopilot Loop Commands
-18. **`adn-dev-wf`** - Canonical reviewed-plan workflow skill that replaces the retired quality-gated execution path
-19. **`ralph:review-gpt5.5.md`** - Run `/review` in a loop (GPT-5.5), apply quick fixes, stop when no straightforward fixes remain
-20. **`ralph:review-opus.md`** - Run `/review` in a loop (Opus), apply quick fixes, stop when no straightforward fixes remain
+18. **`run-plan`** - Full lifecycle reviewed-plan execution through PR creation and monitoring
+19. **`adn-dev-wf`** - Broader reviewed-plan workflow skill for plan refresh, review integration, direct execution, and PM follow-up
+20. **`ralph:review-gpt5.5.md`** - Run `/review` in a loop (GPT-5.5), apply quick fixes, stop when no straightforward fixes remain
+21. **`ralph:review-opus.md`** - Run `/review` in a loop (Opus), apply quick fixes, stop when no straightforward fixes remain
 
 ## Command Workflows
 

--- a/_claude/commands/cmd:execute-plan.md
+++ b/_claude/commands/cmd:execute-plan.md
@@ -1,6 +1,6 @@
 ---
-description: Canonical reviewed-plan handoff that routes an explicit plan into /skill:adn-dev-wf or /dev:run
-argument-hint: '<plan slug | existing-plan-path> [--target skill:adn-dev-wf|dev:run]'
+description: Reviewed-plan handoff that routes an explicit plan into /run-plan or /dev:run
+argument-hint: '<plan slug | existing-plan-path> [--target run-plan|dev:run]'
 ---
 
 # Execute Reviewed Plan
@@ -13,8 +13,8 @@ This command validates an explicit reviewed plan argument, optionally accepts a 
 
 - Accept a plan slug or an explicit existing plan path in the repo's active plan format.
 - Accept workspace-relative input that starts with `@` by stripping the leading `@`.
-- Accept an optional target suffix: `--target skill:adn-dev-wf` or `--target dev:run`.
-- Present exactly two execution choices: `/skill:adn-dev-wf` and `/dev:run`.
+- Accept an optional target suffix: `--target run-plan` or `--target dev:run`.
+- Present exactly two execution choices: `/run-plan` and `/dev:run`.
 - Preserve the same normalized plan argument when dispatching.
 - Refuse handoff when the plan still contains obvious review or readiness blockers.
 
@@ -25,13 +25,13 @@ This command validates an explicit reviewed plan argument, optionally accepts a 
 If no argument is provided, respond with:
 
 ```text
-Usage: /cmd:execute-plan <plan slug | existing-plan-path> [--target skill:adn-dev-wf|dev:run]
+Usage: /cmd:execute-plan <plan slug | existing-plan-path> [--target run-plan|dev:run]
 
 Examples:
   /cmd:execute-plan review-execution-handoff
   /cmd:execute-plan thoughts/plans/review-execution-handoff.html
   /cmd:execute-plan @thoughts/plans/review-execution-handoff.html
-  /cmd:execute-plan thoughts/plans/review-execution-handoff.html --target skill:adn-dev-wf
+  /cmd:execute-plan thoughts/plans/review-execution-handoff.html --target run-plan
 ```
 
 Do not infer “the current plan” from conversation state.
@@ -46,8 +46,8 @@ Do not infer “the current plan” from conversation state.
 4. Normalize `TARGET_OVERRIDE_RAW` only if present:
    - Trim whitespace.
    - Strip one leading `/` if present.
-   - Accept only `skill:adn-dev-wf` or `dev:run`.
-   - If any other target is provided, stop and tell the user the only valid targets are `/skill:adn-dev-wf` and `/dev:run`.
+   - Accept only `run-plan` or `dev:run`.
+   - If any other target is provided, stop and tell the user the only valid targets are `/run-plan` and `/dev:run`.
 5. If `PLAN_ARGUMENT` is empty after trimming, show the usage block and stop.
 6. If `PLAN_ARGUMENT` starts with `@`, strip the leading `@`.
 7. Preserve that normalized string as `PLAN_DISPATCH_ARGUMENT`.
@@ -81,7 +81,7 @@ Determine `TARGET_COMMAND`:
 
 - If `TARGET_OVERRIDE` is set, honor it without asking a follow-up question.
 - Otherwise ask exactly one targeted question with only these two options:
-  1. `/skill:adn-dev-wf <PLAN_DISPATCH_ARGUMENT>` — canonical reviewed-plan continuation that can resume from this reviewed plan.
+  1. `/run-plan <PLAN_DISPATCH_ARGUMENT>` — full implementation-through-PR lifecycle for this reviewed plan.
   2. `/dev:run <PLAN_DISPATCH_ARGUMENT>` — direct execution-only path with one `quality-reviewer` pass after each phase.
 
 Do not offer a planning pass here. Do not offer a third option.
@@ -91,7 +91,7 @@ Do not offer a planning pass here. Do not offer a third option.
 Run exactly one of the following and then stop:
 
 ```text
-/skill:adn-dev-wf <PLAN_DISPATCH_ARGUMENT>
+/run-plan <PLAN_DISPATCH_ARGUMENT>
 ```
 
 ```text

--- a/_claude/commands/cmd:feeling-lucky-pr-os.md
+++ b/_claude/commands/cmd:feeling-lucky-pr-os.md
@@ -206,25 +206,15 @@ Use the plan-k2.5 subagent to create a plan with slug `plan_slug` and ensure the
 /review:change-integrate ${plan_slug}
 ```
 
-### 5) Implement + Validate
+### 5) Implement Through PR
 
 ```text
-/skill:adn-dev-wf ${plan_slug}
-/dev:validate ${plan_slug}
+/run-plan ${plan_slug}
 ```
 
-### 6) Final Code Review
+`/run-plan` owns implementation, validation, final review, commit, push, PR creation, and post-PR monitoring. Do not run `/dev:validate`, `/review`, `/cmd:commit-push`, or `/cmd:create-pr` after it; if it exits with a blocker, stop and report the blocker instead of linking a PR. The PR it creates must start with `${ISSUE_KEY}:` and include the Linear issue title.
 
-Run `/review` against `base_ref...HEAD`, apply fixes, re-run until clean.
-
-### 7) Commit, Push, PR, Link
-
-```text
-/cmd:commit-push
-/cmd:create-pr ${base_ref}
-```
-
-The PR title must start with `${ISSUE_KEY}:` and include the Linear issue title.
+### 6) Link Existing PR to Linear
 
 Link PR back to Linear:
 

--- a/_claude/commands/cmd:feeling-lucky-pr.md
+++ b/_claude/commands/cmd:feeling-lucky-pr.md
@@ -206,25 +206,15 @@ Use the plan-gpt5.5 subagent to create a plann with slug `plan_slug` and ensure 
 /review:change-integrate ${plan_slug}
 ```
 
-### 5) Implement + Validate
+### 5) Implement Through PR
 
 ```text
-/skill:adn-dev-wf ${plan_slug}
-/dev:validate ${plan_slug}
+/run-plan ${plan_slug}
 ```
 
-### 6) Final Code Review
+`/run-plan` owns implementation, validation, final review, commit, push, PR creation, and post-PR monitoring. Do not run `/dev:validate`, `/review`, `/cmd:commit-push`, or `/cmd:create-pr` after it; if it exits with a blocker, stop and report the blocker instead of linking a PR. The PR it creates must start with `${ISSUE_KEY}:` and include the Linear issue title.
 
-Run `/review` against `base_ref...HEAD`, apply fixes, re-run until clean.
-
-### 7) Commit, Push, PR, Link
-
-```text
-/cmd:commit-push
-/cmd:create-pr ${base_ref}
-```
-
-The PR title must start with `${ISSUE_KEY}:` and include the Linear issue title.
+### 6) Link Existing PR to Linear
 
 Link PR back to Linear:
 

--- a/_claude/commands/review:change-integrate.md
+++ b/_claude/commands/review:change-integrate.md
@@ -97,6 +97,6 @@ After successful integration:
 /cmd:execute-plan <plan path | plan slug>
 ```
 
-If the user already knows they want to continue the canonical workflow, `/skill:adn-dev-wf <plan path | plan slug>` is the default next step. `/dev:run <plan path | plan slug>` remains the direct execution-only path.
+If the user already knows they want full lifecycle execution, `/run-plan <plan path | plan slug>` is the default next step. `/dev:run <plan path | plan slug>` remains the direct execution-only path.
 
 Stop there; do not proceed automatically.

--- a/_claude/commands/run-plan.md
+++ b/_claude/commands/run-plan.md
@@ -1,0 +1,14 @@
+---
+description: Execute an explicit plan through the full run-plan lifecycle
+argument-hint: '<plan slug | existing-plan-path>'
+---
+
+# Run Plan
+
+Invoke the installed `run-plan` skill with exactly this argument:
+
+```text
+$ARGUMENTS
+```
+
+This wrapper is only the ergonomic `/run-plan` entry point. Do not run a shortened workflow here. Follow the `run-plan` skill so scoped implementation, verification, implementation review, PR creation, and post-PR monitoring all stay in the single source of truth.

--- a/_codex/README.md
+++ b/_codex/README.md
@@ -41,7 +41,7 @@ Codex mirrors the core reviewed-plan flow used in Pi:
 
 Canonical continuation after a reviewed plan is ready:
 
-- `/skill:adn-dev-wf <plan>`
+- `/run-plan <plan>` for full lifecycle execution through PR creation and monitoring
 - `/dev:run <plan>` for direct execution-only handoff
 
 Plan-reviewer browser action comments are routed through shared skills installed to `~/.agents/skills`: `plan-reviewer-execution-ready` for readiness review requests and `plan-reviewer-build` for Build Plan requests.

--- a/_codex/prompts/README.md
+++ b/_codex/prompts/README.md
@@ -38,7 +38,8 @@ This directory contains a comprehensive set of commands that support a complete 
 17. **`cmd:review-pr-comments.md`** - Review and address GitHub PR comments since last commit
 
 ### Workflow Skills
-18. **`adn-dev-wf`** - Canonical reviewed-plan workflow skill that replaces the retired quality-gated execution path
+18. **`run-plan`** - Full lifecycle reviewed-plan execution through PR creation and monitoring
+19. **`adn-dev-wf`** - Broader reviewed-plan workflow skill for plan refresh, review integration, direct execution, and PM follow-up
 
 ### Codex Compatibility Notes
 - Codex prompts intentionally include only OpenAI-compatible model commands.
@@ -187,8 +188,12 @@ All commands use consistent:
 - Creates/switches branch from a chosen base without creating a worktree
 - Fetches issue metadata and drafts a first-pass plan under `thoughts/plans/`
 
+**`/run-plan`**:
+- Continue a reviewed plan through full lifecycle execution, PR creation, and post-PR monitoring
+- Use this as the default execution handoff after review integration
+
 **`/skill:adn-dev-wf`**:
-- Continue the canonical reviewed-plan workflow from a task request or an existing plan
+- Continue the broader reviewed-plan workflow from a task request or an existing plan
 - Create or reshape the plan as needed, integrate review comments, then execute directly
 - Use `quality-reviewer` once per phase and keep `## Progress` truthful
 

--- a/_codex/prompts/cmd:execute-plan.md
+++ b/_codex/prompts/cmd:execute-plan.md
@@ -1,6 +1,6 @@
 ---
-description: Canonical reviewed-plan handoff that routes an explicit plan into /skill:adn-dev-wf or /dev:run
-argument-hint: '<plan slug | existing-plan-path> [--target skill:adn-dev-wf|dev:run]'
+description: Reviewed-plan handoff that routes an explicit plan into /run-plan or /dev:run
+argument-hint: '<plan slug | existing-plan-path> [--target run-plan|dev:run]'
 ---
 
 # Execute Reviewed Plan
@@ -13,8 +13,8 @@ This command validates an explicit reviewed plan argument, optionally accepts a 
 
 - Accept a plan slug or an explicit existing plan path in the repo's active plan format.
 - Accept workspace-relative input that starts with `@` by stripping the leading `@`.
-- Accept an optional target suffix: `--target skill:adn-dev-wf` or `--target dev:run`.
-- Present exactly two execution choices: `/skill:adn-dev-wf` and `/dev:run`.
+- Accept an optional target suffix: `--target run-plan` or `--target dev:run`.
+- Present exactly two execution choices: `/run-plan` and `/dev:run`.
 - Preserve the same normalized plan argument when dispatching.
 - Refuse handoff when the plan still contains obvious review or readiness blockers.
 
@@ -25,13 +25,13 @@ This command validates an explicit reviewed plan argument, optionally accepts a 
 If no argument is provided, respond with:
 
 ```text
-Usage: /cmd:execute-plan <plan slug | existing-plan-path> [--target skill:adn-dev-wf|dev:run]
+Usage: /cmd:execute-plan <plan slug | existing-plan-path> [--target run-plan|dev:run]
 
 Examples:
   /cmd:execute-plan review-execution-handoff
   /cmd:execute-plan thoughts/plans/review-execution-handoff.html
   /cmd:execute-plan @thoughts/plans/review-execution-handoff.html
-  /cmd:execute-plan thoughts/plans/review-execution-handoff.html --target skill:adn-dev-wf
+  /cmd:execute-plan thoughts/plans/review-execution-handoff.html --target run-plan
 ```
 
 Do not infer “the current plan” from conversation state.
@@ -46,8 +46,8 @@ Do not infer “the current plan” from conversation state.
 4. Normalize `TARGET_OVERRIDE_RAW` only if present:
    - Trim whitespace.
    - Strip one leading `/` if present.
-   - Accept only `skill:adn-dev-wf` or `dev:run`.
-   - If any other target is provided, stop and tell the user the only valid targets are `/skill:adn-dev-wf` and `/dev:run`.
+   - Accept only `run-plan` or `dev:run`.
+   - If any other target is provided, stop and tell the user the only valid targets are `/run-plan` and `/dev:run`.
 5. If `PLAN_ARGUMENT` is empty after trimming, show the usage block and stop.
 6. If `PLAN_ARGUMENT` starts with `@`, strip the leading `@`.
 7. Preserve that normalized string as `PLAN_DISPATCH_ARGUMENT`.
@@ -81,7 +81,7 @@ Determine `TARGET_COMMAND`:
 
 - If `TARGET_OVERRIDE` is set, honor it without asking a follow-up question.
 - Otherwise ask exactly one targeted question with only these two options:
-  1. `/skill:adn-dev-wf <PLAN_DISPATCH_ARGUMENT>` — canonical reviewed-plan continuation that can resume from this reviewed plan.
+  1. `/run-plan <PLAN_DISPATCH_ARGUMENT>` — full implementation-through-PR lifecycle for this reviewed plan.
   2. `/dev:run <PLAN_DISPATCH_ARGUMENT>` — direct execution-only path with one `quality-reviewer` pass after each phase.
 
 Do not offer a planning pass here. Do not offer a third option.
@@ -91,7 +91,7 @@ Do not offer a planning pass here. Do not offer a third option.
 Run exactly one of the following and then stop:
 
 ```text
-/skill:adn-dev-wf <PLAN_DISPATCH_ARGUMENT>
+/run-plan <PLAN_DISPATCH_ARGUMENT>
 ```
 
 ```text

--- a/_codex/prompts/review:change-integrate.md
+++ b/_codex/prompts/review:change-integrate.md
@@ -114,6 +114,6 @@ After successful integration:
 /cmd:execute-plan <plan path | plan slug>
 ```
 
-If the user already knows they want to continue the canonical workflow, `/skill:adn-dev-wf <plan path | plan slug>` is the default next step. `/dev:run <plan path | plan slug>` remains the direct execution-only path.
+If the user already knows they want full lifecycle execution, `/run-plan <plan path | plan slug>` is the default next step. `/dev:run <plan path | plan slug>` remains the direct execution-only path.
 
 Stop there; do not proceed automatically.

--- a/_codex/prompts/run-plan.md
+++ b/_codex/prompts/run-plan.md
@@ -1,0 +1,14 @@
+---
+description: Execute an explicit plan through the full run-plan lifecycle
+argument-hint: '<plan slug | existing-plan-path>'
+---
+
+# Run Plan
+
+Invoke the installed `run-plan` skill with exactly this argument:
+
+```text
+$ARGUMENTS
+```
+
+This wrapper is only the ergonomic `/run-plan` entry point. Do not run a shortened workflow here. Follow the `run-plan` skill so scoped implementation, verification, implementation review, PR creation, and post-PR monitoring all stay in the single source of truth.

--- a/_omp/agents/aplan-legacy.md
+++ b/_omp/agents/aplan-legacy.md
@@ -38,5 +38,5 @@ Behavior for this shim:
 - If the user wants repo-managed OMP planning mode, direct them to `/aplan`, which enters native `/plan` mode and queues the repo-managed planning guidance for the next planning turn.
 - If you are invoked anyway, stay constrained to `thoughts/plans/` and help with plan authoring only.
 - Do not claim to replace or override built-in `/plan`.
-- If asked about reviewed-plan handoff, explain that the runtime `/aplan` flow offers review/exit choices and prepares `/cmd:execute-plan <plan> --target ...` to start fresh `/dev:run` or `/skill:adn-dev-wf` execution outside `/aplan` mode.
+- If asked about reviewed-plan handoff, explain that the runtime `/aplan` flow offers review/exit choices and prepares `/cmd:execute-plan <plan> --target ...` to start fresh `/run-plan` or `/dev:run` execution outside `/aplan` mode.
 </system-reminder>

--- a/_omp/commands/cmd:execute-plan.md
+++ b/_omp/commands/cmd:execute-plan.md
@@ -1,6 +1,6 @@
 ---
-description: Canonical reviewed-plan handoff that routes an explicit plan into /skill:adn-dev-wf or /dev:run
-argument-hint: '<plan slug | existing-plan-path> [--target skill:adn-dev-wf|dev:run]'
+description: Reviewed-plan handoff that routes an explicit plan into /run-plan or /dev:run
+argument-hint: '<plan slug | existing-plan-path> [--target run-plan|dev:run]'
 ---
 
 # Execute Reviewed Plan
@@ -13,8 +13,8 @@ This command validates an explicit reviewed plan argument, optionally accepts a 
 
 - Accept a plan slug or an explicit existing plan path in the repo's active plan format.
 - Accept workspace-relative input that starts with `@` by stripping the leading `@`.
-- Accept an optional target suffix: `--target skill:adn-dev-wf` or `--target dev:run`.
-- Present exactly two execution choices: `/skill:adn-dev-wf` and `/dev:run`.
+- Accept an optional target suffix: `--target run-plan` or `--target dev:run`.
+- Present exactly two execution choices: `/run-plan` and `/dev:run`.
 - Preserve the same normalized plan argument when dispatching.
 - Refuse handoff when the plan still contains obvious review or readiness blockers.
 
@@ -25,13 +25,13 @@ This command validates an explicit reviewed plan argument, optionally accepts a 
 If no argument is provided, respond with:
 
 ```text
-Usage: /cmd:execute-plan <plan slug | existing-plan-path> [--target skill:adn-dev-wf|dev:run]
+Usage: /cmd:execute-plan <plan slug | existing-plan-path> [--target run-plan|dev:run]
 
 Examples:
   /cmd:execute-plan review-execution-handoff
   /cmd:execute-plan thoughts/plans/review-execution-handoff.html
   /cmd:execute-plan @thoughts/plans/review-execution-handoff.html
-  /cmd:execute-plan thoughts/plans/review-execution-handoff.html --target skill:adn-dev-wf
+  /cmd:execute-plan thoughts/plans/review-execution-handoff.html --target run-plan
 ```
 
 Do not infer “the current plan” from conversation state.
@@ -46,8 +46,8 @@ Do not infer “the current plan” from conversation state.
 4. Normalize `TARGET_OVERRIDE_RAW` only if present:
    - Trim whitespace.
    - Strip one leading `/` if present.
-   - Accept only `skill:adn-dev-wf` or `dev:run`.
-   - If any other target is provided, stop and tell the user the only valid targets are `/skill:adn-dev-wf` and `/dev:run`.
+   - Accept only `run-plan` or `dev:run`.
+   - If any other target is provided, stop and tell the user the only valid targets are `/run-plan` and `/dev:run`.
 5. If `PLAN_ARGUMENT` is empty after trimming, show the usage block and stop.
 6. If `PLAN_ARGUMENT` starts with `@`, strip the leading `@`.
 7. Preserve that normalized string as `PLAN_DISPATCH_ARGUMENT`.
@@ -81,7 +81,7 @@ Determine `TARGET_COMMAND`:
 
 - If `TARGET_OVERRIDE` is set, honor it without asking a follow-up question.
 - Otherwise ask exactly one targeted question with only these two options:
-  1. `/skill:adn-dev-wf <PLAN_DISPATCH_ARGUMENT>` — canonical reviewed-plan continuation that can resume from this reviewed plan.
+  1. `/run-plan <PLAN_DISPATCH_ARGUMENT>` — full implementation-through-PR lifecycle for this reviewed plan.
   2. `/dev:run <PLAN_DISPATCH_ARGUMENT>` — direct execution-only path with one `quality-reviewer` pass after each phase.
 
 Do not offer a planning pass here. Do not offer a third option.
@@ -91,7 +91,7 @@ Do not offer a planning pass here. Do not offer a third option.
 Run exactly one of the following and then stop:
 
 ```text
-/skill:adn-dev-wf <PLAN_DISPATCH_ARGUMENT>
+/run-plan <PLAN_DISPATCH_ARGUMENT>
 ```
 
 ```text

--- a/_omp/commands/cmd:feeling-lucky-pr-os.md
+++ b/_omp/commands/cmd:feeling-lucky-pr-os.md
@@ -273,25 +273,15 @@ Use the plan-k2.5 subagent to create a plan with slug `plan_slug` and ensure the
 /review:change-integrate ${plan_slug}
 ```
 
-### 5) Implement + Validate
+### 5) Implement Through PR
 
 ```text
-/skill:adn-dev-wf ${plan_slug}
-/dev:validate ${plan_slug}
+/run-plan ${plan_slug}
 ```
 
-### 6) Final Code Review
+`/run-plan` owns implementation, validation, final review, commit, push, PR creation, and post-PR monitoring. Do not run `/dev:validate`, `/review`, `/cmd:commit-push`, or `/cmd:create-pr` after it; if it exits with a blocker, stop and report the blocker instead of linking a PR. The PR it creates must start with `${ISSUE_KEY}:` and include the Linear issue title.
 
-Run `/review` against `base_ref...HEAD`, apply fixes, re-run until clean.
-
-### 7) Commit, Push, PR, Link
-
-```text
-/cmd:commit-push
-/cmd:create-pr ${base_ref}
-```
-
-The PR title must start with `${ISSUE_KEY}:` and include the Linear issue title.
+### 6) Link Existing PR to Linear
 
 Link PR back to Linear:
 

--- a/_omp/commands/cmd:feeling-lucky-pr.md
+++ b/_omp/commands/cmd:feeling-lucky-pr.md
@@ -206,25 +206,15 @@ Use the plan-gpt5.5 subagent to create a plann with slug `plan_slug` and ensure 
 /review:change-integrate ${plan_slug}
 ```
 
-### 5) Implement + Validate
+### 5) Implement Through PR
 
 ```text
-/skill:adn-dev-wf ${plan_slug}
-/dev:validate ${plan_slug}
+/run-plan ${plan_slug}
 ```
 
-### 6) Final Code Review
+`/run-plan` owns implementation, validation, final review, commit, push, PR creation, and post-PR monitoring. Do not run `/dev:validate`, `/review`, `/cmd:commit-push`, or `/cmd:create-pr` after it; if it exits with a blocker, stop and report the blocker instead of linking a PR. The PR it creates must start with `${ISSUE_KEY}:` and include the Linear issue title.
 
-Run `/review` against `base_ref...HEAD`, apply fixes, re-run until clean.
-
-### 7) Commit, Push, PR, Link
-
-```text
-/cmd:commit-push
-/cmd:create-pr ${base_ref}
-```
-
-The PR title must start with `${ISSUE_KEY}:` and include the Linear issue title.
+### 6) Link Existing PR to Linear
 
 Link PR back to Linear:
 

--- a/_omp/commands/review:change-integrate.md
+++ b/_omp/commands/review:change-integrate.md
@@ -96,6 +96,6 @@ After successful integration:
 /cmd:execute-plan <plan path | plan slug>
 ```
 
-If the user already knows they want to continue the canonical workflow, `/skill:adn-dev-wf <plan path | plan slug>` is the default next step. `/dev:run <plan path | plan slug>` remains the direct execution-only path.
+If the user already knows they want full lifecycle execution, `/run-plan <plan path | plan slug>` is the default next step. `/dev:run <plan path | plan slug>` remains the direct execution-only path.
 
 Stop there; do not proceed automatically.

--- a/_omp/commands/review:plan.md
+++ b/_omp/commands/review:plan.md
@@ -277,7 +277,7 @@ Phase 2: Synthesis (GPT)
 Phase 3: Auto-Integration
   └─ Applies only material feedback → Clean updated plan
     ↓
-Output: Integrated Plan (ready for /cmd:execute-plan or direct /skill:adn-dev-wf or /dev:run)
+Output: Integrated Plan (ready for /cmd:execute-plan, /run-plan, or direct /dev:run)
 ```
 ---
 

--- a/_omp/commands/run-plan.md
+++ b/_omp/commands/run-plan.md
@@ -1,0 +1,14 @@
+---
+description: Execute an explicit plan through the full run-plan lifecycle
+argument-hint: '<plan slug | existing-plan-path>'
+---
+
+# Run Plan
+
+Use the installed shared `run-plan` workflow from `~/.agents/skills/run-plan/SKILL.md` with exactly this argument:
+
+```text
+$ARGUMENTS
+```
+
+This wrapper is only the ergonomic `/run-plan` entry point. Do not run a shortened workflow here. Follow the global shared `run-plan` skill so scoped implementation, verification, implementation review, PR creation, and post-PR monitoring all stay in the single source of truth. If that shared skill is unavailable, stop and tell the operator to run `install.sh --skills`.

--- a/_omp/extensions/aplan/index.ts
+++ b/_omp/extensions/aplan/index.ts
@@ -251,23 +251,23 @@ async function expandSlashCommandPrompt(cwd: string, commandText: string): Promi
 	return undefined;
 }
 
-function normalizeExecuteTarget(target: string | undefined): "dev:run" | "skill:adn-dev-wf" | undefined {
+function normalizeExecuteTarget(target: string | undefined): "dev:run" | "run-plan" | undefined {
 	if (!target) return undefined;
 	const normalized = target.trim().replace(/^\//, "");
-	if (normalized === "dev:run" || normalized === "skill:adn-dev-wf") return normalized;
-	if (normalized === "ralph:run") return "skill:adn-dev-wf";
+	if (normalized === "dev:run") return normalized;
+	if (normalized === "run-plan" || normalized === "skill:run-plan") return "run-plan";
 	return undefined;
 }
 
 function getExecutePlanUsage(): string {
-	return `Usage: /${EXECUTE_PLAN_COMMAND} <plan slug | thoughts/plans/<slug>.md | path/to/plan.md> [--target dev:run|skill:adn-dev-wf]`;
+	return `Usage: /${EXECUTE_PLAN_COMMAND} <plan slug | thoughts/plans/<slug>.md | path/to/plan.md> [--target dev:run|run-plan]`;
 }
 
 async function resolveExecutePlanRequest(
 	cwd: string,
 	rawArgs: string,
 ): Promise<
-	| { planDispatchArgument: string; planPath: string; targetOverride?: "dev:run" | "skill:adn-dev-wf" }
+	| { planDispatchArgument: string; planPath: string; targetOverride?: "dev:run" | "run-plan" }
 	| { error: string }
 > {
 	const tokens = parseCommandArgs(rawArgs.trim());
@@ -277,11 +277,11 @@ async function resolveExecutePlanRequest(
 
 	const targetFlagIndex = tokens.lastIndexOf("--target");
 	let planTokens = tokens;
-	let targetOverride: "dev:run" | "skill:adn-dev-wf" | undefined;
+	let targetOverride: "dev:run" | "run-plan" | undefined;
 
 	if (targetFlagIndex !== -1) {
 		if (targetFlagIndex === tokens.length - 1) {
-			return { error: "Missing value after --target. Valid targets: /dev:run or /skill:adn-dev-wf." };
+			return { error: "Missing value after --target. Valid targets: /dev:run or /run-plan." };
 		}
 		if (targetFlagIndex < tokens.length - 2) {
 			return { error: "Unexpected extra arguments after --target. Use exactly one target value." };
@@ -289,7 +289,7 @@ async function resolveExecutePlanRequest(
 
 		targetOverride = normalizeExecuteTarget(tokens[targetFlagIndex + 1]);
 		if (!targetOverride) {
-			return { error: "Invalid --target value. Valid targets: /dev:run or /skill:adn-dev-wf." };
+			return { error: "Invalid --target value. Valid targets: /dev:run or /run-plan." };
 		}
 		planTokens = tokens.slice(0, targetFlagIndex);
 	}
@@ -365,7 +365,7 @@ function buildAplanBootstrapPrompt(userArgs: string): string {
 		"Use the repo-managed OMP planning workflow for this repository.",
 		`Keep plan files under ${PLAN_DIRECTORY}/ as single markdown plan documents.`,
 		`After materially updating a plan, run /${STANDARD_PLAN_REVIEW_COMMAND} on that file, integrate any inline review comments back into the same plan with /${CHANGE_REVIEW_INTEGRATE_COMMAND}, and optionally run /${ADVERSARIAL_PLAN_REVIEW_COMMAND} for a challenge pass.`,
-		`When the reviewed plan is ready for implementation, hand execution off through /${EXECUTE_PLAN_COMMAND} to /dev:run or /skill:adn-dev-wf.`,
+		`When the reviewed plan is ready for implementation, hand execution off through /${EXECUTE_PLAN_COMMAND} to /run-plan or /dev:run.`,
 	].join(" ");
 
 	if (!userArgs) {
@@ -478,18 +478,18 @@ export default function aplanModeExtension(pi: ExtensionAPI): void {
 		let target = request.targetOverride;
 		if (!target) {
 			if (!ctx.hasUI) {
-				ctx.ui.notify("No UI available. Re-run with --target dev:run or --target skill:adn-dev-wf.", "warning");
+				ctx.ui.notify("No UI available. Re-run with --target dev:run or --target run-plan.", "warning");
 				return;
 			}
 
 			const choice = await ctx.ui.select(`Choose execution path for ${request.planDispatchArgument}.`, [
-				`/skill:adn-dev-wf ${request.planDispatchArgument}`,
+				`/run-plan ${request.planDispatchArgument}`,
 				`/dev:run ${request.planDispatchArgument}`,
 			]);
 			if (!choice) {
 				return;
 			}
-			target = choice.startsWith("/skill:adn-dev-wf") ? "skill:adn-dev-wf" : "dev:run";
+			target = choice.startsWith("/run-plan") ? "run-plan" : "dev:run";
 		}
 
 		const executionPrompt = await expandSlashCommandPrompt(ctx.cwd, `/${target} ${request.planDispatchArgument}`);
@@ -627,7 +627,7 @@ export default function aplanModeExtension(pi: ExtensionAPI): void {
 		}
 		nextSteps.push(
 			`/${EXECUTE_PLAN_COMMAND} ${formatCommandArg(currentPlanPath)} --target dev:run`,
-			`/${EXECUTE_PLAN_COMMAND} ${formatCommandArg(currentPlanPath)} --target skill:adn-dev-wf`,
+			`/${EXECUTE_PLAN_COMMAND} ${formatCommandArg(currentPlanPath)} --target run-plan`,
 		);
 
 		ctx.ui.notify(`Plan review complete (${reason}). Available next steps:\n${formatNextSteps(nextSteps)}`, "info");
@@ -643,7 +643,7 @@ export default function aplanModeExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.registerCommand(EXECUTE_PLAN_COMMAND, {
-		description: "Start /dev:run or /skill:adn-dev-wf in a fresh session from a reviewed plan",
+		description: "Start /run-plan or /dev:run in a fresh session from a reviewed plan",
 		handler: async (args, ctx) => handleExecutePlanCommand(args, ctx),
 	});
 
@@ -685,7 +685,7 @@ export default function aplanModeExtension(pi: ExtensionAPI): void {
 			return {};
 		}
 
-		if (text.startsWith("/dev:run") || text.startsWith("/skill:adn-dev-wf") || text.startsWith("/ralph:run")) {
+		if (text.startsWith("/dev:run") || text.startsWith("/run-plan")) {
 			disablePlanMode(ctx);
 			return {};
 		}
@@ -740,7 +740,7 @@ Constraints:
 - After creating or materially updating a plan, /review:plan <path> is available when you want review.
 - After a standard review writes inline review comments into the plan, /review:change-integrate <path> runs automatically so feedback is resolved back into the same plan before any manual execution handoff.
 - After standard review integration, you may optionally run /review:plan-adversarial <path> for a second-pass challenge review.
-- After an integrated review completes, you may manually run /cmd:execute-plan <path> --target dev:run or --target skill:adn-dev-wf to start a fresh execution session outside /aplan mode.
+- After an integrated review completes, you may manually run /cmd:execute-plan <path> --target dev:run or --target run-plan to start a fresh execution session outside /aplan mode.
 - Review feedback should be integrated back into the same plan file.
 - Automatic review looping is capped at ${MAX_REVIEW_CYCLES} cycles before stopping.
 

--- a/_opencode/commands/README.md
+++ b/_opencode/commands/README.md
@@ -36,27 +36,28 @@ This directory contains a comprehensive set of commands that support a complete 
 15. **`cmd:start-linear-issue.md`** - Bootstrap a Linear issue as an OpenCode workspace-backed build environment
 16. **`cmd:linear-build-workspace.md`** - Deterministic Linear issue build runner using OpenCode workspaces plus the enforced `linear_build_orchestrator.py` run ledger
 17. **`cmd:start-linear-issue-branch.md`** - Start a Linear issue on a new branch (no workspace/worktree) and draft a first-pass plan
-18. **`cmd:execute-plan.md`** - Canonical reviewed-plan handoff that routes into `/skill:adn-dev-wf` or `/dev:run`
+18. **`cmd:execute-plan.md`** - Reviewed-plan handoff that routes into `/run-plan` or `/dev:run`
 19. **`cmd:review-pr-comments.md`** - Review and address GitHub PR comments since last commit
 
 ### Workflow Skills
-20. **`adn-dev-wf`** - Canonical reviewed-plan workflow skill that replaces the retired quality-gated execution path
-21. **`ralph:review-gpt5.5.md`** - Run `/review` in a loop (GPT-5.5), apply quick fixes, stop when no straightforward fixes remain
-22. **`ralph:review-opus.md`** - Run `/review` in a loop (Opus), apply quick fixes, stop when no straightforward fixes remain
+20. **`run-plan`** - Full lifecycle reviewed-plan execution through PR creation and monitoring
+21. **`adn-dev-wf`** - Broader reviewed-plan workflow skill for plan refresh, review integration, direct execution, and PM follow-up
+22. **`ralph:review-gpt5.5.md`** - Run `/review` in a loop (GPT-5.5), apply quick fixes, stop when no straightforward fixes remain
+23. **`ralph:review-opus.md`** - Run `/review` in a loop (Opus), apply quick fixes, stop when no straightforward fixes remain
 
 ## Command Workflows
 
 ### Workflow 0: Plan-First Execution (Shared Default)
-`[plan mode discovery] → /dev:plan → [execution-ready → optional /dev:pm-review <plan> plan → /review:plan <plan> → /review:change-integrate <plan> → /cmd:execute-plan <plan> → choose /skill:adn-dev-wf <plan> or /dev:run <plan>] | [research-ready / blocking question → next research or answer → /dev:plan]`
-```
-[plan mode discovery] → /dev:plan → [execution-ready → optional /dev:pm-review <plan> plan → /review:plan <plan> → /review:change-integrate <plan> → /cmd:execute-plan <plan> → choose /skill:adn-dev-wf <plan> or /dev:run <plan>] | [research-ready / blocking question → next research or answer → /dev:plan]
+`[plan mode discovery] → /dev:plan → [execution-ready → optional /dev:pm-review <plan> plan → /review:plan <plan> → /review:change-integrate <plan> → /cmd:execute-plan <plan> → choose /run-plan <plan> or /dev:run <plan>] | [research-ready / blocking question → next research or answer → /dev:plan]`
+```text
+[plan mode discovery] → /dev:plan → [execution-ready → optional /dev:pm-review <plan> plan → /review:plan <plan> → /review:change-integrate <plan> → /cmd:execute-plan <plan> → choose /run-plan <plan> or /dev:run <plan>] | [research-ready / blocking question → next research or answer → /dev:plan]
 ```
 - Read-only plan mode gathers evidence, resolves `low-confidence` decisions, and prepares inputs for plan materialization.
 - `/dev:plan` fails closed: it only writes an `execution-ready` plan when foundational decisions are resolved; otherwise it asks the user or writes exactly one non-ready `research-ready` artifact with the next research action.
 - `/dev:pm-review` is the optional corrective PM reshaping pass before execution and may also be used after implementation to reopen missing completion work.
 - `/review:plan` is the standard multi-model review pass for plans, and `/review:change-integrate` resolves those inline comments back into the same plan before execution.
-- Only `execution-ready` reviewed plans move into `/cmd:execute-plan`; the handoff preserves the reviewed plan argument and asks whether to continue with `/skill:adn-dev-wf` or `/dev:run`.
-- `/skill:adn-dev-wf` is the canonical reviewed-plan continuation; `/dev:run` remains the direct execution path with one `quality-reviewer` pass after each phase.
+- Only `execution-ready` reviewed plans move into `/cmd:execute-plan`; the handoff preserves the reviewed plan argument and asks whether to continue with `/run-plan` or `/dev:run`.
+- `/run-plan` is the full lifecycle reviewed-plan continuation through PR creation and monitoring; `/dev:run` remains the direct execution path with one `quality-reviewer` pass after each phase.
 - Pi is the only maintained surface that promises context cleanup before dispatch; OpenCode shares the wrapper name and choice flow without claiming Pi-only context behavior.
 
 ### Workflow 0B: Linear Issue Build In OpenCode Workspace
@@ -131,8 +132,8 @@ Plans and specifications should describe behavioral tests in plain terms around 
 - If research is still the next handoff, `/dev:plan` writes one non-ready `research-ready` artifact instead of pretending execution can safely start.
 - `/dev:pm-review <plan> plan` is the optional corrective PM pass before execution; `/dev:pm-review <plan> implementation` is the corrective PM pass after implementation.
 - `/review:plan` is the standard plan review pass, and `/review:change-integrate` should clean those inline comments before `/cmd:execute-plan`.
-- `/dev:run` applies one `quality-reviewer` pass after each phase. A phase only advances after `ralph:run` receives `VERDICT: PASS_NO_ISSUES`, or `VERDICT: PASS_LOW_RISK_ONLY` with each remaining item proven out-of-scope, low-risk, not required for truthful verification, and logged in `thoughts/discoveries/<plan-or-feature>.md` (or the repo's documented equivalent) plus the plan's `## Decisions / Deviations Log`.
-- The canonical workflow skill `/skill:adn-dev-wf` can resume from a reviewed plan, rerun PM follow-up loops when needed, and keep the plan truthfully aligned with execution.
+- `/dev:run` applies one `quality-reviewer` pass after each phase. A phase only advances after review receives `VERDICT: PASS_NO_ISSUES`, or `VERDICT: PASS_LOW_RISK_ONLY` with each remaining item proven out-of-scope, low-risk, not required for truthful verification, and logged in `thoughts/discoveries/<plan-or-feature>.md` (or the repo's documented equivalent) plus the plan's `## Decisions / Deviations Log`.
+- `/run-plan` can resume from a reviewed plan, keep the plan truthfully aligned with execution, run pre-PR review gates, create the PR, and monitor post-PR feedback.
 
 ### Standardized Format
 All commands use consistent:

--- a/_opencode/commands/cmd:execute-plan.md
+++ b/_opencode/commands/cmd:execute-plan.md
@@ -1,11 +1,11 @@
 ---
-description: Canonical reviewed-plan handoff that routes an explicit plan into /dev:run or /ralph:run
-argument-hint: '<plan slug | existing-plan-path> [--target dev:run|ralph:run]'
+description: Canonical reviewed-plan handoff that routes an explicit plan into /dev:run or /run-plan
+argument-hint: '<plan slug | existing-plan-path> [--target dev:run|run-plan]'
 ---
 
 # Execute Reviewed Plan
 
-This command is a reviewed-plan handoff wrapper. It does not replace `/dev:run` or `/ralph:run`; it validates an explicit reviewed plan argument, optionally accepts a target override, asks the user which of those two commands to run when needed, and then dispatches using the same normalized plan argument.
+This command is a reviewed-plan handoff wrapper. It does not replace `/dev:run` or `/run-plan`; it validates an explicit reviewed plan argument, optionally accepts a target override, asks the user which of those two commands to run when needed, and then dispatches using the same normalized plan argument.
 
 **Arguments**: `$ARGUMENTS`
 
@@ -13,8 +13,8 @@ This command is a reviewed-plan handoff wrapper. It does not replace `/dev:run` 
 
 - Accept a plan slug or an explicit existing plan path in the repo's active plan format.
 - Accept workspace-relative input that starts with `@` by stripping the leading `@`.
-- Accept an optional target suffix: `--target dev:run` or `--target ralph:run`.
-- Present exactly two execution choices: `/dev:run` and `/ralph:run`.
+- Accept an optional target suffix: `--target dev:run` or `--target run-plan`.
+- Present exactly two execution choices: `/dev:run` and `/run-plan`.
 - Preserve the same normalized plan argument when dispatching.
 - Do not promise Pi-specific context reset behavior on this surface.
 
@@ -25,7 +25,7 @@ This command is a reviewed-plan handoff wrapper. It does not replace `/dev:run` 
 If no argument is provided, respond with:
 
 ```text
-Usage: /cmd:execute-plan <plan slug | existing-plan-path> [--target dev:run|ralph:run]
+Usage: /cmd:execute-plan <plan slug | existing-plan-path> [--target dev:run|run-plan]
 
 Examples:
   /cmd:execute-plan review-execution-handoff
@@ -46,8 +46,8 @@ Do not infer “the current plan” from conversation state.
 4. Normalize `TARGET_OVERRIDE_RAW` only if present:
    - Trim whitespace.
    - Strip one leading `/` if present.
-   - Accept only `dev:run` or `ralph:run`.
-   - If any other target is provided, stop and tell the user the only valid targets are `/dev:run` and `/ralph:run`.
+   - Accept only `dev:run` or `run-plan`.
+   - If any other target is provided, stop and tell the user the only valid targets are `/dev:run` and `/run-plan`.
 5. If `PLAN_ARGUMENT` is empty after trimming, show the usage block and stop.
 6. If `PLAN_ARGUMENT` starts with `@`, strip the leading `@`.
 7. Preserve that normalized string as `PLAN_DISPATCH_ARGUMENT`.
@@ -66,7 +66,7 @@ Determine `TARGET_COMMAND`:
 
 - If `TARGET_OVERRIDE` is set, honor it without asking a follow-up question.
 - Otherwise ask exactly one targeted question with only these two options:
-  1. `/ralph:run <PLAN_DISPATCH_ARGUMENT>` — quality-gated, review-loop execution for the reviewed plan.
+  1. `/run-plan <PLAN_DISPATCH_ARGUMENT>` — full implementation-through-PR lifecycle for the reviewed plan.
   2. `/dev:run <PLAN_DISPATCH_ARGUMENT>` — direct single-agent execution with resumable plan progress tracking.
 
 Do not offer a planning pass here. Do not offer a third option.
@@ -80,7 +80,7 @@ Run exactly one of the following and then stop:
 ```
 
 ```text
-/ralph:run <PLAN_DISPATCH_ARGUMENT>
+/run-plan <PLAN_DISPATCH_ARGUMENT>
 ```
 
-This command is only the reviewed-plan handoff wrapper; `/dev:run` and `/ralph:run` remain distinct execution paths with different behaviors.
+This command is only the reviewed-plan handoff wrapper; `/run-plan` is the full lifecycle path and `/dev:run` remains direct execution-only.

--- a/_opencode/commands/cmd:feeling-lucky-pr-os.md
+++ b/_opencode/commands/cmd:feeling-lucky-pr-os.md
@@ -207,23 +207,15 @@ Use the plan-k2.5 subagent to create a plan with slug `plan_slug` and ensure the
 /review:change-integrate ${plan_slug}
 ```
 
-### 5) Implement + Validate
+### 5) Implement Through PR
 
 ```text
-/ralph:run-mm ${plan_slug}
-/dev:validate ${plan_slug}
+/run-plan ${plan_slug}
 ```
 
-### 6) Final Code Review
+`/run-plan` owns implementation, validation, final review, commit, push, PR creation, and post-PR monitoring. Do not run `/dev:validate`, `/review`, `/cmd:commit-push`, or `/cmd:create-pr` after it; if it exits with a blocker, stop and report the blocker instead of linking a PR. The PR it creates must start with `${ISSUE_KEY}:` and include the Linear issue title.
 
-Run `/review` against `base_ref...HEAD`, apply fixes, re-run until clean.
-
-### 7) Commit, Push, PR, Link
-
-```text
-/cmd:commit-push
-/cmd:create-pr ${base_ref}
-```
+### 6) Link Existing PR to Linear
 
 Link PR back to Linear:
 

--- a/_opencode/commands/cmd:feeling-lucky-pr.md
+++ b/_opencode/commands/cmd:feeling-lucky-pr.md
@@ -206,25 +206,15 @@ Use the plan-gpt5.5 subagent to create a plann with slug `plan_slug` and ensure 
 /review:change-integrate ${plan_slug}
 ```
 
-### 5) Implement + Validate
+### 5) Implement Through PR
 
 ```text
-/skill:adn-dev-wf ${plan_slug}
-/dev:validate ${plan_slug}
+/run-plan ${plan_slug}
 ```
 
-### 6) Final Code Review
+`/run-plan` owns implementation, validation, final review, commit, push, PR creation, and post-PR monitoring. Do not run `/dev:validate`, `/review`, `/cmd:commit-push`, or `/cmd:create-pr` after it; if it exits with a blocker, stop and report the blocker instead of linking a PR. The PR it creates must start with `${ISSUE_KEY}:` and include the Linear issue title.
 
-Run `/review` against `base_ref...HEAD`, apply fixes, re-run until clean.
-
-### 7) Commit, Push, PR, Link
-
-```text
-/cmd:commit-push
-/cmd:create-pr ${base_ref}
-```
-
-The PR title must start with `${ISSUE_KEY}:` and include the Linear issue title.
+### 6) Link Existing PR to Linear
 
 Link PR back to Linear:
 

--- a/_opencode/commands/dev:plan.md
+++ b/_opencode/commands/dev:plan.md
@@ -53,7 +53,7 @@ Forbidden transitions for this command:
 - Do not switch into build, run, or implementation mode.
 - Do not edit any file except `plan_path` unless the user explicitly broadens scope.
 - Do not run lint, tests, build, e2e, migrations, or other execution-oriented verification.
-- Do not invoke `/review:change`, `/cmd:execute-plan`, `/ralph:run`, or any other follow-up command from this command; only suggest them.
+- Do not invoke `/review:change`, `/cmd:execute-plan`, `/run-plan`, or any other follow-up command from this command; only suggest them.
 
 Legacy bundles:
 

--- a/_opencode/commands/review:change-integrate.md
+++ b/_opencode/commands/review:change-integrate.md
@@ -103,6 +103,6 @@ After successful integration:
 /cmd:execute-plan <plan path | plan slug>
 ```
 
-If the user already knows they want direct execution, both `/dev:run <plan path | plan slug>` and `/ralph:run <plan path | plan slug>` remain valid.
+If the user already knows they want full lifecycle execution, `/run-plan <plan path | plan slug>` is the default next step. `/dev:run <plan path | plan slug>` remains the direct execution-only path.
 
 Stop there; do not proceed automatically.

--- a/_opencode/commands/run-plan.md
+++ b/_opencode/commands/run-plan.md
@@ -1,0 +1,14 @@
+---
+description: Execute an explicit plan through the full run-plan lifecycle
+argument-hint: '<plan slug | existing-plan-path>'
+---
+
+# Run Plan
+
+Invoke the installed `run-plan` skill with exactly this argument:
+
+```text
+$ARGUMENTS
+```
+
+This wrapper is only the ergonomic `/run-plan` entry point. Do not run a shortened workflow here. Follow the `run-plan` skill so scoped implementation, verification, implementation review, PR creation, and post-PR monitoring all stay in the single source of truth.

--- a/_opencode/scripts/check_bootstrap_docs_hardening.py
+++ b/_opencode/scripts/check_bootstrap_docs_hardening.py
@@ -72,7 +72,7 @@ def main() -> None:
             "- Phase advancement only when the latest review returns `VERDICT: PASS_NO_ISSUES`, or `VERDICT: PASS_LOW_RISK_ONLY` after each remaining item is proven out-of-scope, low-risk, not required for truthful verification, and logged in the repo's discovery ledger (for example `thoughts/discoveries/<plan-or-feature>.md`) plus the plan's `## Decisions / Deviations Log`.",
             "- Review loops are hard gates: reviewer narrative alone never clears a phase; only the verdict-based phase-advance rule above can do that.",
             "- Keep planning depth `complexity-aware`: simple tasks stay lightweight, while non-trivial ready plans need complete contracts plus a `test coverage matrix` strong enough to catch partial implementations.",
-            "- `ralph:run` review loops must reassess the `original test scope` and original plan when substantive misses appear; repeated or cross-surface misses widen coverage or plan scope instead of staying local.",
+            "- Execution feedback loops must reassess the `original test scope` and original plan when substantive misses appear; repeated or cross-surface misses widen coverage or plan scope instead of staying local.",
             "- Repo-local planning overrides stay additive: they can tighten the shared defaults, but they must not replace or relax the central doctrine.",
         ],
     )
@@ -93,7 +93,7 @@ def main() -> None:
         [
             "- The shared fail-closed ready bar: only `execution-ready` plans hand off to implementation, while unresolved `low-confidence` decisions stay in discovery or move into a single `research-ready` artifact.",
             "- The shared expectation that non-trivial ready plans include a `test coverage matrix`.",
-            "- The shared `ralph:run` feedback loop: substantive review misses reassess the `original test scope` and original plan, and repeated or cross-surface misses widen coverage before phase advance.",
+            "- The shared execution feedback loop: substantive review misses reassess the `original test scope` and original plan, and repeated or cross-surface misses widen coverage before phase advance.",
             "- The repo's discovery-ledger destination for documented out-of-scope low-risk items (for example `thoughts/discoveries/<plan-or-feature>.md`).",
         ],
     )
@@ -105,7 +105,7 @@ def main() -> None:
         "bootstrap skill override guidance",
         add_overrides,
         [
-            "- Keep repo-local overrides additive to the shared `execution-ready` / `research-ready` readiness model, `low-confidence` decision closure, `test coverage matrix` default, and `ralph:run` reassessment loop.",
+            "- Keep repo-local overrides additive to the shared `execution-ready` / `research-ready` readiness model, `low-confidence` decision closure, `test coverage matrix` default, and execution feedback loop.",
         ],
     )
 
@@ -145,7 +145,7 @@ def main() -> None:
             "- unresolved `low-confidence` foundational decisions stay in read-only discovery or move into a single non-ready `research-ready` plan artifact with the exact next research action",
             "- only `execution-ready` plans should continue into review/execution commands; `research-ready` artifacts should send the agent to the recorded next research action and then back through `dev:plan`",
             "Require non-trivial ready plans to include a `test coverage matrix` that maps acceptance criteria and scenarios to intended tests and verify commands.",
-            "Codify the `ralph:run` feedback loop: substantive review misses must reassess the `original test scope` and original plan, and repeated or cross-surface misses must widen coverage or plan scope before the phase can advance.",
+            "Codify the execution feedback loop: substantive review misses must reassess the `original test scope` and original plan, and repeated or cross-surface misses must widen coverage or plan scope before the phase can advance.",
             "- re-review until the latest verdict is `VERDICT: PASS_NO_ISSUES` or `VERDICT: PASS_LOW_RISK_ONLY` with every remaining item proven out-of-scope, low-risk, not required for truthful verification, and logged in the repo's discovery ledger (for example `thoughts/discoveries/<plan-or-feature>.md`) plus the plan's `## Decisions / Deviations Log`",
             "Require the repo guidance to name the canonical discovery-ledger destination explicitly so documented out-of-scope low-risk findings always have a durable home.",
         ],
@@ -156,7 +156,7 @@ def main() -> None:
         "plan overrides template objective",
         plan_objective,
         [
-            "- Keep repo-local overrides additive to the shared `planning-workflow` doctrine for `execution-ready` versus `research-ready` readiness, `low-confidence` decision handling, the default `test coverage matrix`, and the `ralph:run` review-to-`original test scope` feedback loop.",
+            "- Keep repo-local overrides additive to the shared `planning-workflow` doctrine for `execution-ready` versus `research-ready` readiness, `low-confidence` decision handling, the default `test coverage matrix`, and the execution review-to-`original test scope` feedback loop.",
         ],
     )
 
@@ -167,7 +167,7 @@ def main() -> None:
         "plan overrides template TDD/BDD",
         plan_tdd_bdd,
         [
-            "- Only document repo-local additions here; shared `ralph:run` reassessment of the `original test scope` and shared `test coverage matrix` expectations already come from the global doctrine.",
+            "- Only document repo-local additions here; shared execution-path reassessment of the `original test scope` and shared `test coverage matrix` expectations already come from the global doctrine.",
         ],
     )
 
@@ -187,12 +187,12 @@ def main() -> None:
         "README plan-first workflow",
         planning_workflow,
         [
-            "`[plan mode discovery] → /dev:plan → [execution-ready → /review:change <plan_path> → /ralph:run <plan_path>] | [research-ready / blocking question → next research or answer → /dev:plan]`",
+            "`[plan mode discovery] → /dev:plan → [execution-ready → optional /dev:pm-review <plan> plan → /review:plan <plan> → /review:change-integrate <plan> → /cmd:execute-plan <plan> → choose /run-plan <plan> or /dev:run <plan>] | [research-ready / blocking question → next research or answer → /dev:plan]`",
             "- Read-only plan mode gathers evidence, resolves `low-confidence` decisions, and prepares inputs for plan materialization.",
             "- `/dev:plan` fails closed: it only writes an `execution-ready` plan when foundational decisions are resolved; otherwise it asks the user or writes exactly one non-ready `research-ready` artifact with the next research action.",
-            "- Only `execution-ready` plans move into `/review:change` and `/ralph:run`; `research-ready` artifacts loop back through the recorded next research action and another `/dev:plan` pass.",
+            "- Only `execution-ready` reviewed plans move into `/cmd:execute-plan`; the handoff preserves the reviewed plan argument and asks whether to continue with `/run-plan` or `/dev:run`.",
             "- Keep simple tasks lightweight, but require complete contracts plus a `test coverage matrix` before a non-trivial plan is treated as `execution-ready`.",
-            "- `/ralph:run` uses review findings as feedback on the `original test scope` and original plan; repeated or cross-surface misses widen coverage instead of staying local patches.",
+            "- `/run-plan` is the full lifecycle reviewed-plan continuation through PR creation and monitoring; `/dev:run` remains the direct execution path with one `quality-reviewer` pass after each phase.",
         ],
     )
 
@@ -205,10 +205,10 @@ def main() -> None:
         [
             "- A plan is only `execution-ready` when important questions and `low-confidence` foundational decisions are resolved with evidence.",
             "- If research is still the next handoff, `/dev:plan` writes one non-ready `research-ready` artifact instead of pretending execution can safely start.",
-            "- Only `execution-ready` plans should proceed into `/review:change` and `/ralph:run`; `research-ready` artifacts should send the agent through the recorded next research action and then back to `/dev:plan`.",
+            "- `/review:plan` is the standard plan review pass, and `/review:change-integrate` should clean those inline comments before `/cmd:execute-plan`.",
             "- Non-trivial ready plans should include a `test coverage matrix` that maps acceptance criteria and BDD scenarios to suites/files and `### Verify` commands.",
-            "- `ralph:run` treats substantive review misses as evidence about the `original test scope` and original plan, and repeated or cross-surface misses must widen coverage before phase advance.",
-            "- A phase only advances after `ralph:run` receives `VERDICT: PASS_NO_ISSUES`, or `VERDICT: PASS_LOW_RISK_ONLY` with each remaining item proven out-of-scope, low-risk, not required for truthful verification, and logged in `thoughts/discoveries/<plan-or-feature>.md` (or the repo's documented equivalent) plus the plan's `## Decisions / Deviations Log`.",
+            "- `/run-plan` can resume from a reviewed plan, keep the plan truthfully aligned with execution, run pre-PR review gates, create the PR, and monitor post-PR feedback.",
+            "- `/dev:run` applies one `quality-reviewer` pass after each phase. A phase only advances after review receives `VERDICT: PASS_NO_ISSUES`, or `VERDICT: PASS_LOW_RISK_ONLY` with each remaining item proven out-of-scope, low-risk, not required for truthful verification, and logged in `thoughts/discoveries/<plan-or-feature>.md` (or the repo's documented equivalent) plus the plan's `## Decisions / Deviations Log`.",
         ],
     )
 
@@ -219,7 +219,7 @@ def main() -> None:
             "low-confidence",
             "test coverage matrix",
             "original test scope",
-            "ralph:run",
+            "execution feedback loop",
         ],
         str(ROOT_TEMPLATE_PATH): [
             "execution-ready",
@@ -227,7 +227,7 @@ def main() -> None:
             "low-confidence",
             "test coverage matrix",
             "original test scope",
-            "ralph:run",
+            "execution feedback loop",
             "planning-workflow",
         ],
         str(PLAN_TEMPLATE_PATH): [
@@ -236,7 +236,7 @@ def main() -> None:
             "low-confidence",
             "test coverage matrix",
             "original test scope",
-            "ralph:run",
+            "execution",
             "planning-workflow",
         ],
         str(README_PATH): [
@@ -246,7 +246,7 @@ def main() -> None:
             "low-confidence",
             "test coverage matrix",
             "original test scope",
-            "ralph:run",
+            "run-plan",
             "TDD",
         ],
     }

--- a/_pi/README.md
+++ b/_pi/README.md
@@ -237,12 +237,13 @@ Example installed agents:
 ## Skills Overview
 
 ### Canonical workflow
-- `adn-dev-wf` — end-to-end reviewed-plan workflow from plan creation through direct execution and PM follow-up
+- `adn-dev-wf` — reviewed-plan workflow from plan creation through direct execution and PM follow-up
 - `reviewed-html-plan` / `/dev:reviewed-html-plan` — creates/registers HTML plans in plan-review, follows service-returned `agentInstructions`, starts the queue-backed comment monitor, processes browser feedback, runs PM plus GPT/GLM Pi subagent plan reviews, and stops at execution-ready handoff
 
 ### Dev / execution
+- `run-plan` / `/run-plan` — full lifecycle execution for an explicit reviewed plan: implementation, scoped reviews, GPT/GLM pre-PR review, PR creation, and post-PR monitoring
 - `dev:run` — direct high-reasoning execution with one `quality-reviewer` pass after each phase
-- `pre-pr-implementation-review` — GPT-5.5 plus GLM-5 Pi subagent pre-PR implementation review loop until in-scope P1/P2/P3 findings are addressed; when invoked by `scoped-plan-run`, it returns `OPEN_PR_READY` so the caller continues to PR creation
+- `pre-pr-implementation-review` — GPT-5.5 plus GLM-5 Pi subagent pre-PR implementation review loop until in-scope P1/P2/P3 findings are addressed; when invoked by `run-plan`, it returns `OPEN_PR_READY` so the caller continues to PR creation
 
 ### Git / workflow
 - `cmd-create-pr`
@@ -268,7 +269,7 @@ Example installed agents:
 - `review-change-kimi`
 - `review-change-opus`
 - `review-change-claude-code` — Claude Code review-only pass through the shared private-tmux interactive launcher
-- `pre-pr-implementation-review` — runnable independently or automatically from `scoped-plan-run` before PR creation; it is not a terminal replacement for opening the PR
+- `pre-pr-implementation-review` — runnable independently or automatically from `run-plan` before PR creation; it is not a terminal replacement for opening the PR
 
 ## Usage
 
@@ -290,14 +291,14 @@ Prompt templates:
 /review:change-opus thoughts/plans/my-plan.html
 /review:change-claude-code thoughts/plans/my-plan.html
 /skill:pre-pr-implementation-review thoughts/plans/my-plan.html
-/skill:adn-dev-wf thoughts/plans/my-plan.html
+/run-plan thoughts/plans/my-plan.html
 /dev:plan-from-prd thoughts/plans/prd-my-feature.md
 /cmd:send-plan-to-doct thoughts/plans/my-plan.md
 ```
 
 ## Reviewed-plan handoff
 
-Use `/skill:adn-dev-wf <plan>` after a reviewed plan is ready to continue. For browser-reviewed plans, the active artifact is `thoughts/plans/<slug>.html`, and `skills/html-plan-reviewer/SKILL.md` is the sole source for concrete `plan-review` commands, readiness metadata, canonical URL rules, and comment monitor mechanics.
+Use `/run-plan <plan>` after a reviewed plan is ready for full implementation-through-PR execution. Use `/dev:run <plan>` only for direct execution without the full PR lifecycle. For browser-reviewed plans, the active artifact is `thoughts/plans/<slug>.html`, and `skills/html-plan-reviewer/SKILL.md` is the sole source for concrete `plan-review` commands, readiness metadata, canonical URL rules, and comment monitor mechanics.
 
 Canonical browser-reviewed HTML plan flow:
 
@@ -320,9 +321,9 @@ Optional second pass: run `/review:plan-adversarial <plan>` after `/review:chang
 
 Use `/dev:pm-review <plan> implementation` after execution when you want a corrective PM pass that checks whether the intended user outcome was actually realized and, if not, reshapes the plan with the missing completion work instead of stopping at findings.
 
-- It is the canonical wrapper for choosing between `/skill:adn-dev-wf <plan>` and `/dev:run <plan>`.
-- `/skill:adn-dev-wf` is the canonical reviewed-plan continuation and can resume from an existing reviewed plan; `/dev:run` remains the direct execution-only path with one `quality-reviewer` pass after each phase.
-- `/skill:pre-pr-implementation-review` can be run independently before opening a PR and is also invoked automatically by `scoped-plan-run` after scoped implementation reviews. In a scoped run, clean GPT/GLM consensus over all in-scope P1/P2/P3 findings means `OPEN_PR_READY`; the runner must then rerun final verification if needed, commit, push, open the PR, and continue monitoring.
+- `/cmd:execute-plan` is the canonical wrapper for choosing between `/run-plan <plan>` and `/dev:run <plan>`.
+- `/run-plan` is the full lifecycle reviewed-plan continuation through PR creation and monitoring; `/dev:run` remains the direct execution-only path with one `quality-reviewer` pass after each phase.
+- `/skill:pre-pr-implementation-review` can be run independently before opening a PR and is also invoked automatically by `run-plan` after scoped implementation reviews. In a scoped run, clean GPT/GLM consensus over all in-scope P1/P2/P3 findings means `OPEN_PR_READY`; the runner must then rerun final verification if needed, commit, push, open the PR, and continue monitoring.
 - In Pi `/plan` mode, the extension offers both execution paths as post-review exit choices and stages this handoff command for the selected target.
 - When that extension path is used, `/plan` mode is disabled before execution so planning-only tool restrictions do not leak into implementation.
 - In Pi, the handoff command starts a fresh session and then launches the selected execution flow from that clean context.
@@ -353,7 +354,7 @@ The sequence below is the end-to-end reviewed-PRD path from PRD entry through ha
 Skills:
 
 ```text
-/skill:adn-dev-wf user-profile-redesign
+/run-plan thoughts/plans/user-profile-redesign.html
 /skill:reviewed-html-plan user-profile-redesign
 /skill:cmd-start-linear-issue-branch ENG-123
 /skill:doct-document-ops

--- a/_pi/extensions/pi-plan-mode/index.ts
+++ b/_pi/extensions/pi-plan-mode/index.ts
@@ -270,11 +270,11 @@ async function expandSlashCommandPrompt(cwd: string, commandText: string): Promi
 	return undefined;
 }
 
-function normalizeExecuteTarget(target: string | undefined): "dev:run" | "skill:adn-dev-wf" | undefined {
+function normalizeExecuteTarget(target: string | undefined): "dev:run" | "run-plan" | undefined {
 	if (!target) return undefined;
 	const normalized = target.trim().replace(/^\//, "");
 	if (normalized === "dev:run") return normalized;
-	if (normalized === "skill:adn-dev-wf" || normalized === "ralph:run") return "skill:adn-dev-wf";
+	if (normalized === "run-plan" || normalized === "skill:run-plan") return "run-plan";
 	return undefined;
 }
 
@@ -291,14 +291,14 @@ function isStandardReviewCommand(command: string | undefined): command is typeof
 }
 
 function getExecutePlanUsage(): string {
-	return `Usage: /${EXECUTE_PLAN_COMMAND} <plan slug | thoughts/plans/<slug>.html | path/to/plan.html | legacy path/to/plan.md> [--target dev:run|skill:adn-dev-wf]`;
+	return `Usage: /${EXECUTE_PLAN_COMMAND} <plan slug | thoughts/plans/<slug>.html | path/to/plan.html | legacy path/to/plan.md> [--target dev:run|run-plan]`;
 }
 
 async function resolveExecutePlanRequest(
 	cwd: string,
 	rawArgs: string,
 ): Promise<
-	| { planDispatchArgument: string; planPath: string; targetOverride?: "dev:run" | "skill:adn-dev-wf" }
+	| { planDispatchArgument: string; planPath: string; targetOverride?: "dev:run" | "run-plan" }
 	| { error: string }
 > {
 	const tokens = parseCommandArgs(rawArgs.trim());
@@ -308,11 +308,11 @@ async function resolveExecutePlanRequest(
 
 	const targetFlagIndex = tokens.lastIndexOf("--target");
 	let planTokens = tokens;
-	let targetOverride: "dev:run" | "skill:adn-dev-wf" | undefined;
+	let targetOverride: "dev:run" | "run-plan" | undefined;
 
 	if (targetFlagIndex !== -1) {
 		if (targetFlagIndex === tokens.length - 1) {
-			return { error: "Missing value after --target. Valid targets: /dev:run or /skill:adn-dev-wf." };
+			return { error: "Missing value after --target. Valid targets: /dev:run or /run-plan." };
 		}
 		if (targetFlagIndex < tokens.length - 2) {
 			return { error: "Unexpected extra arguments after --target. Use exactly one target value." };
@@ -320,7 +320,7 @@ async function resolveExecutePlanRequest(
 
 		targetOverride = normalizeExecuteTarget(tokens[targetFlagIndex + 1]);
 		if (!targetOverride) {
-			return { error: "Invalid --target value. Valid targets: /dev:run or /skill:adn-dev-wf." };
+			return { error: "Invalid --target value. Valid targets: /dev:run or /run-plan." };
 		}
 		planTokens = tokens.slice(0, targetFlagIndex);
 	}
@@ -942,18 +942,18 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		let target = request.targetOverride;
 		if (!target) {
 			if (!ctx.hasUI) {
-				ctx.ui.notify("No UI available. Re-run with --target dev:run or --target skill:adn-dev-wf.", "warning");
+				ctx.ui.notify("No UI available. Re-run with --target dev:run or --target run-plan.", "warning");
 				return;
 			}
 
 			const choice = await ctx.ui.select(`Choose execution path for ${request.planDispatchArgument}.`, [
-				`/skill:adn-dev-wf ${request.planDispatchArgument}`,
+				`/run-plan ${request.planDispatchArgument}`,
 				`/dev:run ${request.planDispatchArgument}`,
 			]);
 			if (!choice) {
 				return;
 			}
-			target = choice.startsWith("/skill:adn-dev-wf") ? "skill:adn-dev-wf" : "dev:run";
+			target = choice.startsWith("/run-plan") ? "run-plan" : "dev:run";
 		}
 
 		const commandText = `/${target} ${formatCommandArg(request.planDispatchArgument)}`;
@@ -1139,7 +1139,7 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 
 		nextSteps.push(
 			`/${EXECUTE_PLAN_COMMAND} ${formatCommandArg(currentPlanPath)} --target dev:run`,
-			`/${EXECUTE_PLAN_COMMAND} ${formatCommandArg(currentPlanPath)} --target skill:adn-dev-wf`,
+			`/${EXECUTE_PLAN_COMMAND} ${formatCommandArg(currentPlanPath)} --target run-plan`,
 		);
 
 		ctx.ui.notify(`Plan review complete (${reason}). Available next steps:\n${formatNextSteps(nextSteps)}`, "info");
@@ -1157,7 +1157,7 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.registerCommand(EXECUTE_PLAN_COMMAND, {
-		description: "Start /dev:run or /skill:adn-dev-wf in a fresh session from a reviewed plan",
+		description: "Start /run-plan or /dev:run in a fresh session from a reviewed plan",
 		handler: async (args, ctx) => handleExecutePlanCommand(args, ctx),
 	});
 
@@ -1179,7 +1179,7 @@ export default function planModeExtension(pi: ExtensionAPI): void {
 		const text = event.text.trim();
 		if (!planModeEnabled) return { action: "continue" };
 
-		if (text.startsWith(`/${EXECUTE_PLAN_COMMAND}`) || text.startsWith("/dev:run") || text.startsWith("/skill:adn-dev-wf") || text.startsWith("/ralph:run")) {
+		if (text.startsWith(`/${EXECUTE_PLAN_COMMAND}`) || text.startsWith("/dev:run") || text.startsWith("/run-plan") || text.startsWith("/skill:run-plan")) {
 			const executionBlockReason = getExecutionBlockReason();
 			if (executionBlockReason) {
 				ctx.ui.notify(executionBlockReason, "warning");
@@ -1265,7 +1265,7 @@ Constraints:
 - After creating or materially updating an HTML plan, /dev:reviewed-html-plan <path> is the deterministic registration, browser-feedback, PM-review, and Claude/Codex plan-review path. /review:plan <path> remains available only as an explicit inline review.
 - After a standard inline review completes with comments, /review:change-integrate <path> runs automatically so review feedback is resolved back into the same plan file before any manual execution handoff.
 - After standard inline review integration, you may optionally run /review:plan-adversarial <path> for a second-pass challenge review.
-- Before execution, stop any active plan-review comment listener, then run /cmd:execute-plan <path> --target dev:run or --target skill:adn-dev-wf to start a fresh execution session.
+- Before execution, stop any active plan-review comment listener, then run /cmd:execute-plan <path> --target dev:run or --target run-plan to start a fresh execution session.
 - Review feedback should be integrated back into the same plan file.
 - Automatic inline review looping is capped at ${MAX_REVIEW_CYCLES} cycles before stopping.
 

--- a/_pi/prompts/cmd:execute-plan.md
+++ b/_pi/prompts/cmd:execute-plan.md
@@ -1,6 +1,6 @@
 ---
-description: Canonical reviewed-plan handoff that routes an explicit plan into /skill:adn-dev-wf or /dev:run
-argument-hint: '<plan slug | existing-plan-path> [--target skill:adn-dev-wf|dev:run]'
+description: Reviewed-plan handoff that routes an explicit plan into /run-plan or /dev:run
+argument-hint: '<plan slug | existing-plan-path> [--target dev:run|run-plan]'
 ---
 
 # Execute Reviewed Plan
@@ -13,8 +13,8 @@ This command validates an explicit reviewed plan argument, optionally accepts a 
 
 - Accept a plan slug or an explicit existing plan path in the repo's active plan format.
 - Accept workspace-relative input that starts with `@` by stripping the leading `@`.
-- Accept an optional target suffix: `--target skill:adn-dev-wf` or `--target dev:run`.
-- Present exactly two execution choices: `/skill:adn-dev-wf` and `/dev:run`.
+- Accept an optional target suffix: `--target run-plan` or `--target dev:run`.
+- Present exactly two execution choices: `/run-plan` and `/dev:run`.
 - Preserve the same normalized plan argument when dispatching.
 - Refuse handoff when the plan still contains obvious review or readiness blockers.
 
@@ -25,13 +25,13 @@ This command validates an explicit reviewed plan argument, optionally accepts a 
 If no argument is provided, respond with:
 
 ```text
-Usage: /cmd:execute-plan <plan slug | existing-plan-path> [--target skill:adn-dev-wf|dev:run]
+Usage: /cmd:execute-plan <plan slug | existing-plan-path> [--target run-plan|dev:run]
 
 Examples:
   /cmd:execute-plan review-execution-handoff
   /cmd:execute-plan thoughts/plans/review-execution-handoff.html
   /cmd:execute-plan @thoughts/plans/review-execution-handoff.html
-  /cmd:execute-plan thoughts/plans/review-execution-handoff.html --target skill:adn-dev-wf
+  /cmd:execute-plan thoughts/plans/review-execution-handoff.html --target run-plan
 ```
 
 Do not infer “the current plan” from conversation state.
@@ -46,8 +46,8 @@ Do not infer “the current plan” from conversation state.
 4. Normalize `TARGET_OVERRIDE_RAW` only if present:
    - Trim whitespace.
    - Strip one leading `/` if present.
-   - Accept only `skill:adn-dev-wf` or `dev:run`.
-   - If any other target is provided, stop and tell the user the only valid targets are `/skill:adn-dev-wf` and `/dev:run`.
+   - Accept only `run-plan` or `dev:run`.
+   - If any other target is provided, stop and tell the user the only valid targets are `/run-plan` and `/dev:run`.
 5. If `PLAN_ARGUMENT` is empty after trimming, show the usage block and stop.
 6. If `PLAN_ARGUMENT` starts with `@`, strip the leading `@`.
 7. Preserve that normalized string as `PLAN_DISPATCH_ARGUMENT`.
@@ -82,7 +82,7 @@ Determine `TARGET_COMMAND`:
 
 - If `TARGET_OVERRIDE` is set, honor it without asking a follow-up question.
 - Otherwise ask exactly one targeted question with only these two options:
-  1. `/skill:adn-dev-wf <PLAN_DISPATCH_ARGUMENT>` — canonical reviewed-plan continuation that can resume from this reviewed plan.
+  1. `/run-plan <PLAN_DISPATCH_ARGUMENT>` — full implementation-through-PR lifecycle for this reviewed plan.
   2. `/dev:run <PLAN_DISPATCH_ARGUMENT>` — direct execution-only path with one `quality-reviewer` pass after each phase.
 
 Do not offer a planning pass here. Do not offer a third option.
@@ -92,7 +92,7 @@ Do not offer a planning pass here. Do not offer a third option.
 Run exactly one of the following and then stop:
 
 ```text
-/skill:adn-dev-wf <PLAN_DISPATCH_ARGUMENT>
+/run-plan <PLAN_DISPATCH_ARGUMENT>
 ```
 
 ```text

--- a/_pi/prompts/cmd:feeling-lucky-pr-os.md
+++ b/_pi/prompts/cmd:feeling-lucky-pr-os.md
@@ -272,41 +272,15 @@ Use the plan-k2.5 subagent to create a plan with slug `plan_slug` and ensure the
 /review:change-integrate ${plan_slug}
 ```
 
-### 5) Implement + Validate
+### 5) Implement Through PR
 
 ```text
-/skill:adn-dev-wf ${plan_slug}
-/dev:validate ${plan_slug}
+/run-plan ${plan_slug}
 ```
 
-### 6) Final Code Review
+`/run-plan` owns implementation, validation, final review, commit, push, PR creation, and post-PR monitoring. Do not run `/dev:validate`, `/review`, `/cmd:commit-push`, or `/cmd:create-pr` after it; if it exits with a blocker, stop and report the blocker instead of linking a PR. The PR it creates must start with `${ISSUE_KEY}:` and include the Linear issue title.
 
-Run `/review` against `base_ref...HEAD`, apply fixes, re-run until clean.
-
-### 7) Commit, Push, PR, Link
-
-Commit and push directly:
-
-```bash
-if [ -z "$(git status --porcelain=v1)" ]; then
-  echo "STOP: nothing to commit"
-  exit 2
-fi
-
-git add -A
-git diff --cached --stat
-
-COMMIT_SUBJECT="feat: ${ISSUE_KEY} ${branch_name}"
-git commit -m "$COMMIT_SUBJECT"
-
-git push -u origin "${branch_name}"
-```
-
-Then create the PR:
-
-```text
-/cmd:create-pr ${base_ref}
-```
+### 6) Link Existing PR to Linear
 
 Link PR back to Linear:
 

--- a/_pi/prompts/cmd:feeling-lucky-pr.md
+++ b/_pi/prompts/cmd:feeling-lucky-pr.md
@@ -206,41 +206,15 @@ Use the plan-gpt5.5 subagent to create a plann with slug `plan_slug` and ensure 
 /review:change-integrate ${plan_slug}
 ```
 
-### 5) Implement + Validate
+### 5) Implement Through PR
 
 ```text
-/skill:adn-dev-wf ${plan_slug}
-/dev:validate ${plan_slug}
+/run-plan ${plan_slug}
 ```
 
-### 6) Final Code Review
+`/run-plan` owns implementation, validation, final review, commit, push, PR creation, and post-PR monitoring. Do not run `/dev:validate`, `/review`, `/cmd:commit-push`, or `/cmd:create-pr` after it; if it exits with a blocker, stop and report the blocker instead of linking a PR. The PR it creates must start with `${ISSUE_KEY}:` and include the Linear issue title.
 
-Run `/review` against `base_ref...HEAD`, apply fixes, re-run until clean.
-
-### 7) Commit, Push, PR, Link
-
-Commit and push directly:
-
-```bash
-if [ -z "$(git status --porcelain=v1)" ]; then
-  echo "STOP: nothing to commit"
-  exit 2
-fi
-
-git add -A
-git diff --cached --stat
-
-COMMIT_SUBJECT="feat: ${ISSUE_KEY} ${branch_name}"
-git commit -m "$COMMIT_SUBJECT"
-
-git push -u origin "${branch_name}"
-```
-
-Then create the PR:
-
-```text
-/cmd:create-pr ${base_ref}
-```
+### 6) Link Existing PR to Linear
 
 Link PR back to Linear:
 

--- a/_pi/prompts/review:change-integrate.md
+++ b/_pi/prompts/review:change-integrate.md
@@ -115,6 +115,6 @@ After successful integration:
 /cmd:execute-plan <plan path | plan slug>
 ```
 
-If the user already knows they want to continue the canonical workflow, `/skill:adn-dev-wf <plan path | plan slug>` is the default next step. `/dev:run <plan path | plan slug>` remains the direct execution-only path.
+If the user already knows they want full lifecycle execution, `/run-plan <plan path | plan slug>` is the default next step. `/dev:run <plan path | plan slug>` remains the direct execution-only path.
 
 Stop there; do not proceed automatically.

--- a/_pi/prompts/run-plan.md
+++ b/_pi/prompts/run-plan.md
@@ -1,0 +1,15 @@
+---
+description: Execute an explicit plan through the full run-plan lifecycle
+argument-hint: '<plan slug | existing-plan-path>'
+model: openai/gpt-5.5
+---
+
+# Run Plan
+
+Invoke the installed `run-plan` skill with exactly this argument:
+
+```text
+$ARGUMENTS
+```
+
+This wrapper is only the ergonomic `/run-plan` entry point. Do not run a shortened workflow here. Follow the `run-plan` skill so scoped implementation, verification, GPT/GLM pre-PR review, PR creation, and post-PR monitoring all stay in the single source of truth.

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ AI_CONFIGS_BACKUP_RUN_ID="$(date +"%Y%m%d-%H%M%S")"
 AI_CONFIGS_REPO_NAME='ai-configs'
 AI_CONFIGS_REPO_COMMIT="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
 CENTRAL_ONLY_PROJECT_SKILLS=(ccore todoist-cli brave-cdp chrome-cdp)
-DEPRECATED_SHARED_SKILLS=(agent-browser)
+DEPRECATED_SHARED_SKILLS=(agent-browser scoped-plan-run)
 
 # Colors for output
 RED='\033[0;31m'

--- a/skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py
+++ b/skills/claude-code-review/scripts/check_no_direct_claude_review_launches.py
@@ -10,7 +10,7 @@ import sys
 from pathlib import Path
 
 DEFAULT_ROOTS = ["_pi", "skills", "_opencode", "_claude", "_omp", "_codex", "scripts"]
-REVIEW_HINT_RE = re.compile(r"claude-code-review|review|reviewed-html-plan|scoped-plan-run|codex-full-build|linear_build|linear-build|review:change-claude-code|review:plan-adversarial|_pi/README\.md", re.I)
+REVIEW_HINT_RE = re.compile(r"claude-code-review|review|reviewed-html-plan|run-plan|codex-full-build|linear_build|linear-build|review:change-claude-code|review:plan-adversarial|_pi/README\.md", re.I)
 FORBIDDEN_MARKER = "[FORBIDDEN-EXAMPLE]"
 FORBIDDEN_FENCE = "forbidden-claude-launch"
 CANONICAL_LAUNCHER_SUFFIX = "claude-code-review/scripts/claude_interactive_review.py"

--- a/skills/codex-full-build/SKILL.md
+++ b/skills/codex-full-build/SKILL.md
@@ -5,7 +5,7 @@ description: Run the full Codex development lifecycle from a Linear issue, exist
 
 # Codex Full Build
 
-Use this skill when the user wants an end-to-end software change driven from a Linear issue, an existing plan, or a natural-language plan description. This skill is the lifecycle controller. It prepares and validates the plan, gets independent plan review from Codex and Claude Code, then delegates implementation, scoped review, verification, commit, push, and PR creation to `$scoped-plan-run`.
+Use this skill when the user wants an end-to-end software change driven from a Linear issue, an existing plan, or a natural-language plan description. This skill is the lifecycle controller. It prepares and validates the plan, gets independent plan review from Codex and Claude Code, then delegates implementation, scoped review, verification, commit, push, and PR creation to `$run-plan`.
 
 The goal is autonomous execution with explicit gates. Ask the user only when product intent or scope is genuinely unclear enough that a correct execution-ready plan cannot be written.
 
@@ -28,7 +28,7 @@ Load and follow these skills as needed:
 - Repo-recommended planning skills from `AGENTS.md`, usually `product-principles` and `tdd-test-writer` for this repo.
 - `codex-review-partner` for Codex plan review.
 - `claude-code-review` for Claude Code plan review.
-- `scoped-plan-run` for execution, implementation review, verification, commit, push, and PR.
+- `run-plan` for execution, implementation review, verification, commit, push, and PR.
 
 If a required reviewer or `ltui` is unavailable, try the documented remediation in the relevant skill first. Stop only when the required dependency cannot be restored safely.
 
@@ -41,7 +41,7 @@ If a required reviewer or `ltui` is unavailable, try the documented remediation 
 - Do not let reviewers edit files. All Codex and Claude reviews are read-only.
 - Do not silently choose product behavior when the input is too vague and repo evidence does not resolve it.
 - Do not expand scope because a reviewer found adjacent work.
-- Delegate implementation to `$scoped-plan-run`; do not duplicate its phase execution and PR workflow in this skill.
+- Delegate implementation to `$run-plan`; do not duplicate its phase execution and PR workflow in this skill.
 
 ## Lifecycle
 
@@ -186,9 +186,9 @@ Stop and report a plan convergence blocker if:
 - the plan would require a product decision the user has not answered,
 - three full plan review cycles do not converge.
 
-### 6. Execute with Scoped Plan Run
+### 6. Execute with Run Plan
 
-Once both plan reviewers agree by substance that the plan is execution-ready, invoke `$scoped-plan-run` with the finalized plan path.
+Once both plan reviewers agree by substance that the plan is execution-ready, invoke `$run-plan` with the finalized plan path.
 
 The handoff must state:
 
@@ -199,7 +199,7 @@ The handoff must state:
 - any documented out-of-scope plan review notes with evidence and tracking destination,
 - instruction to proceed through scoped implementation, bounded Codex and Claude implementation reviews, verification, commit, push, and ready-for-review PR.
 
-Do not reimplement the scoped runner's workflow here. `$scoped-plan-run` owns:
+Do not reimplement the scoped runner's workflow here. `$run-plan` owns:
 
 - scope extraction,
 - phase-by-phase implementation,
@@ -210,7 +210,7 @@ Do not reimplement the scoped runner's workflow here. `$scoped-plan-run` owns:
 - push,
 - ready-for-review PR creation.
 
-If `$scoped-plan-run` stops with a blocker, handle only blockers that are part of this lifecycle:
+If `$run-plan` stops with a blocker, handle only blockers that are part of this lifecycle:
 
 - If the blocker is plan ambiguity, return to plan clarification/review.
 - If the blocker is reviewer/tool unavailability, remediate using the relevant skill.
@@ -225,7 +225,7 @@ Return a concise handoff with:
 - Plan path.
 - Source input or Linear issue.
 - Codex and Claude plan review verdicts.
-- Codex and Claude implementation review verdicts from `$scoped-plan-run`.
+- Codex and Claude implementation review verdicts from `$run-plan`.
 - Verification commands and results.
 - Changed files at a high level.
 - Documented out-of-scope follow-ups with evidence and tracking destination.
@@ -272,10 +272,10 @@ For each blocking finding include:
 - the smallest plan change or question needed
 ```
 
-## Scoped Plan Run Handoff Template
+## Run Plan Handoff Template
 
 ```text
-Use $scoped-plan-run to execute <plan path>.
+Use $run-plan to execute <plan path>.
 
 Source input: <Linear issue key/path/description summary>
 Plan review status:
@@ -284,7 +284,7 @@ Plan review status:
 
 Both reviewers agree by substance that the plan is execution-ready.
 
-Proceed through the scoped-plan-run workflow:
+Proceed through the run-plan workflow:
 - preserve the plan as the scope contract
 - implement phase by phase
 - run bounded Codex and Claude implementation reviews

--- a/skills/install-matrix.json
+++ b/skills/install-matrix.json
@@ -408,7 +408,7 @@
         "pi"
       ],
       "canonicalSource": "skills/plan-reviewer-build",
-      "notes": "Codex/Pi: handles plan-reviewer Build Plan request comments by delegating explicit execution-ready plan paths to scoped-plan-run.",
+      "notes": "Codex/Pi: handles plan-reviewer Build Plan request comments by delegating explicit execution-ready plan paths to run-plan.",
       "sourceType": "repo"
     },
     "plan-reviewer-execution-ready": {
@@ -575,7 +575,7 @@
         "pi"
       ],
       "canonicalSource": "skills/pre-pr-implementation-review",
-      "notes": "Pi-only: runs GPT-5.5 plus GLM-5 Pi subagent implementation review loops until all in-scope P1/P2/P3 findings are addressed before PR creation; inside scoped-plan-run it returns OPEN_PR_READY rather than concluding the workflow.",
+      "notes": "Pi-only: runs GPT-5.5 plus GLM-5 Pi subagent implementation review loops until all in-scope P1/P2/P3 findings are addressed before PR creation; inside run-plan it returns OPEN_PR_READY rather than concluding the workflow.",
       "sourceType": "repo"
     },
     "repo-agents-bootstrap": {
@@ -653,14 +653,16 @@
       "notes": "Repo-owned local skill retained in ai-configs.",
       "sourceType": "repo"
     },
-    "scoped-plan-run": {
+    "run-plan": {
       "class": "consumer-specific-installable",
       "allowedConsumers": [
         "codex",
+        "claude",
+        "opencode",
         "pi"
       ],
-      "canonicalSource": "skills/scoped-plan-run",
-      "notes": "Codex/Pi: executes existing plans through bounded implementation, runtime-native scoped reviews, Pi GPT/GLM pre-PR implementation review when applicable, fixes through full P1/P2/P3 consensus, verification, push, mandatory PR creation, and post-PR monitoring without reviewer-driven scope expansion.",
+      "canonicalSource": "skills/run-plan",
+      "notes": "Codex/Claude/OpenCode/Pi: executes existing plans through bounded implementation, runtime-native scoped reviews, Pi GPT/GLM pre-PR implementation review when applicable, fixes through full P1/P2/P3 consensus, verification, push, mandatory PR creation, and post-PR monitoring without reviewer-driven scope expansion.",
       "sourceType": "repo"
     },
     "signing-entitlements": {

--- a/skills/plan-reviewer-build/SKILL.md
+++ b/skills/plan-reviewer-build/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: plan-reviewer-build
-description: Respond to plan-reviewer Build Plan comments by executing an explicit execution-ready plan through the scoped-plan-run workflow. Use when a plan-review browser comment says to use plan-reviewer-build or asks to build a registered plan path.
+description: Respond to plan-reviewer Build Plan comments by executing an explicit execution-ready plan through the run-plan workflow. Use when a plan-review browser comment says to use plan-reviewer-build or asks to build a registered plan path.
 ---
 
 # Plan Reviewer Build
 
 Use this skill when a `plan-review` browser action comment asks the listening agent to build an explicit plan path.
 
-The plan-reviewer service only requests the action. The implementation workflow is delegated to `scoped-plan-run` so PR creation, bounded review, verification, and post-PR monitoring stay in one source of truth.
+The plan-reviewer service only requests the action. The implementation workflow is delegated to `run-plan` so PR creation, bounded review, verification, and post-PR monitoring stay in one source of truth.
 
 ## Input contract
 
@@ -23,7 +23,7 @@ If the plan path is missing, ambiguous, or not a readable file in the current re
 ## Required behavior
 
 1. Read the full plan and repo guidance.
-2. Invoke the installed `scoped-plan-run` workflow with the explicit plan path.
+2. Invoke the installed `run-plan` workflow with the explicit plan path.
 3. Keep the plan-review comment claim active until the build workflow has either started with durable run state or reported a real blocker.
 4. Ack/resolve the plan-reviewer request comment only after the scoped run has durable state, a PR URL, or a clear blocker.
 
@@ -32,15 +32,15 @@ If the plan path is missing, ambiguous, or not a readable file in the current re
 Use the local agent's native skill syntax for:
 
 ```text
-scoped-plan-run <plan-path>
+run-plan <plan-path>
 ```
 
-In Pi, that means following the `scoped-plan-run` skill directly with Pi todo-backed run state and Pi quality-reviewer subagent gates.
+In Pi, that means following the `run-plan` skill directly with Pi todo-backed run state and Pi quality-reviewer subagent gates.
 
-In Codex, that means following the installed shared `scoped-plan-run` skill with Codex goal/task state and Codex-native review prompts. Do not duplicate the scoped run workflow in this skill.
+In Codex, that means following the installed shared `run-plan` skill with Codex goal/task state and Codex-native review prompts. Do not duplicate the scoped run workflow in this skill.
 
 ## Non-goals
 
 - Do not run plan-readiness review here; use `plan-reviewer-execution-ready` for that.
-- Do not edit the plan except for scoped-plan-run progress/deviation updates required by the execution workflow.
-- Do not bypass the scoped-plan-run review, verification, PR, or post-PR monitoring requirements.
+- Do not edit the plan except for run-plan progress/deviation updates required by the execution workflow.
+- Do not bypass the run-plan review, verification, PR, or post-PR monitoring requirements.

--- a/skills/pre-pr-implementation-review/SKILL.md
+++ b/skills/pre-pr-implementation-review/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: pre-pr-implementation-review
-description: Run Pi's pre-PR implementation review loop with both GPT-5.5 and GLM-5 quality reviewers, then continue fixing and rereviewing until every in-scope P1/P2/P3 finding is addressed. Use this before opening pull requests, after an implementation is complete, inside scoped-plan-run, or whenever the user asks for GPT plus GLM code review of a branch/diff; inside scoped-plan-run this gate hands back to PR creation rather than concluding the workflow.
+description: Run Pi's pre-PR implementation review loop with both GPT-5.5 and GLM-5 quality reviewers, then continue fixing and rereviewing until every in-scope P1/P2/P3 finding is addressed. Use this before opening pull requests, after an implementation is complete, inside run-plan, or whenever the user asks for GPT plus GLM code review of a branch/diff; inside run-plan this gate hands back to PR creation rather than concluding the workflow.
 ---
 
 # Pre-PR Implementation Review
 
-Use this skill to catch implementation issues that would otherwise appear during pull request review. It is a code-review-and-fix loop, not a plan review, not a general cleanup pass, and not the end of a scoped plan run.
+Use this skill to catch implementation issues that would otherwise appear during pull request review. It is a code-review-and-fix loop, not a plan review, not a general cleanup pass, and not the end of `run-plan`.
 
 The gate passes only when both reviewers agree by substance that the current implementation has no unresolved in-scope P1/P2/P3 findings. Lower-severity P3 findings still need an explicit disposition before merge readiness: fix them when they are in scope, reject false positives with evidence, or document true out-of-scope follow-ups with a tracking destination.
 
-When invoked from `scoped-plan-run`, a passing result means `OPEN_PR_READY`, not `DONE`. Return the final gate status and artifact path to the scoped runner so it can rerun final verification if needed, commit, push, open the PR, and continue post-PR monitoring.
+When invoked from `run-plan`, a passing result means `OPEN_PR_READY`, not `DONE`. Return the final gate status and artifact path to the `run-plan` caller so it can rerun final verification if needed, commit, push, open the PR, and continue post-PR monitoring.
 
 ## Inputs
 
@@ -22,7 +22,7 @@ Accept any of:
 /skill:pre-pr-implementation-review <plan path> --base <branch-or-range>
 ```
 
-If invoked from `scoped-plan-run`, use that plan path, target branch/base branch, scope contract, changed files, and latest verification results.
+If invoked from `run-plan`, use that plan path, target branch/base branch, scope contract, changed files, and latest verification results.
 
 If invoked independently, resolve the comparison in this order:
 
@@ -41,7 +41,7 @@ Reviewers must use these severities:
 - `P2`: PR-blocking correctness/reliability risk: user-visible regression, missing required edge-case handling, important error-handling gap, significant performance issue, API/contract mismatch, or tests that would allow a materially incomplete implementation to pass.
 - `P3`: lower-severity improvement, maintainability concern, or minor gap. In-scope P3 findings are not allowed to disappear into the summary; fix them, reject them with evidence, or document them as true out-of-scope follow-ups before declaring the branch merge-ready.
 
-Also classify every finding with the scoped-plan-run labels when a plan is present:
+Also classify every finding with the run-plan labels when a plan is present:
 
 - `IN_PLAN`
 - `PLAN_PREREQUISITE`
@@ -159,7 +159,7 @@ After applying any in-scope fix:
 3. Rerun both GPT-5.5 and GLM-5 Pi subagent reviewers against the current diff.
 4. Repeat until both reviewers return `CLEAN_FOR_PR` by substance with no unresolved in-scope P1/P2/P3 findings.
 
-Do not stop after a single reviewer is clean. Do not open or proceed to a PR while either reviewer has an unresolved in-scope P1/P2/P3 finding. If invoked from `scoped-plan-run`, do not end the workflow at `CLEAN_FOR_PR`; hand control back for final verification, commit, push, PR creation, and post-PR monitoring.
+Do not stop after a single reviewer is clean. Do not open or proceed to a PR while either reviewer has an unresolved in-scope P1/P2/P3 finding. If invoked from `run-plan`, do not end the workflow at `CLEAN_FOR_PR`; hand control back for final verification, commit, push, PR creation, and post-PR monitoring.
 
 Stop with a blocker only when:
 
@@ -185,7 +185,7 @@ Include:
 - fixes applied for P1/P2/P3 issues,
 - verification commands and results after fixes,
 - remaining out-of-scope follow-ups with evidence and tracking destination,
-- final gate result and whether it is `OPEN_PR_READY` for a caller such as `scoped-plan-run`.
+- final gate result and whether it is `OPEN_PR_READY` for a caller such as `run-plan`.
 
 If the repo has a different validation-artifact convention, use that convention and keep the same information.
 
@@ -198,4 +198,4 @@ The final summary must include:
 - verification rerun after the last fix,
 - artifact path,
 - any remaining non-blocking out-of-scope follow-ups with evidence and tracking destination,
-- `Next step: OPEN_PR_READY` when invoked from `scoped-plan-run`, so the caller continues to final verification, commit, push, PR creation, and post-PR monitoring instead of concluding.
+- `Next step: OPEN_PR_READY` when invoked from `run-plan`, so the caller continues to final verification, commit, push, PR creation, and post-PR monitoring instead of concluding.

--- a/skills/repo-agents-bootstrap/references/root_agents_template.md
+++ b/skills/repo-agents-bootstrap/references/root_agents_template.md
@@ -41,7 +41,7 @@ Codify the planning and execution boundaries:
 - `plan mode` is for read-only discovery and research.
 - `dev:plan` is the plan-materialization step and may write the plan artifact only.
 - The repo's canonical execution workflow executes the plan with the repo's real quality gates.
-- If the repo uses Pi-style reviewed-plan handoff, codify it explicitly and name the canonical continuation. In this repo that is `/skill:adn-dev-wf <plan>` after review integration, with `/dev:run <plan>` reserved for direct execution-only handoff.
+- If the repo uses Pi-style reviewed-plan handoff, codify it explicitly and name the canonical continuation. In this repo that is `/run-plan <plan>` after review integration for full lifecycle execution through PR creation and monitoring, with `/dev:run <plan>` reserved for direct execution-only handoff.
 - Keep alternate reviewers such as Claude Code explicit and manual; do not describe them as hidden fallbacks inside plan mode or execution.
 
 Add the shared fail-closed ready bar:

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: scoped-plan-run
+name: run-plan
 description: Execute an existing implementation plan persistently through code changes, scoped runtime-native quality reviews, the applicable Pi GPT/GLM pre-PR implementation review, fixes through full P1/P2/P3 consensus, verification, commit, push, PR creation, and PR monitoring until feedback is addressed and the PR is mergeable without expanding beyond the plan's stated scope.
 ---
 
-# Scoped Plan Run
+# Run Plan
 
 Use this skill when the user has a plan file and wants it implemented all the way to a pull request with the runtime's scoped quality-review gates and, in Pi, the GPT/GLM pre-PR review gate, while preventing reviewer-driven scope creep.
 
@@ -16,7 +16,7 @@ This skill is runtime-state-backed. A scoped plan run is not complete at PR crea
 ## Invocation
 
 ```text
-Use $scoped-plan-run to execute an explicit plan path or a slug resolvable by repo-local active plan guidance
+Use $run-plan to execute an explicit plan path or a slug resolvable by repo-local active plan guidance
 ```
 
 Accept either a plan path or a slug. For a slug, resolve using repo-local active plan guidance; do not infer a markdown path.
@@ -88,7 +88,7 @@ A finding may be deferred as `OUT_OF_SCOPE_FOLLOW_UP` only when you can cite an 
 
 ### 1. Establish Run State
 
-1. Check whether a scoped-plan-run task/goal state is already active.
+1. Check whether a run-plan task/goal state is already active.
 2. If no compatible run state is active, create an explicit lifecycle task set before implementation. In Pi, use the todo tool and keep exactly one active item at a time. In Codex, use Codex goal/task state. Include a final post-PR monitoring item that cannot be marked done until all completion criteria are satisfied.
 3. The objective must require both:
    - executing the specified plan through implementation, verification, runtime-native scoped review, the applicable Pi GPT/GLM pre-PR review with no unresolved in-scope P1/P2/P3 findings, commit, push, and PR creation;
@@ -205,7 +205,7 @@ Stop and report a convergence blocker if:
 
 ### 9. GPT/GLM Pre-PR Review Gate
 
-After phase implementation and the runtime-native scoped quality-review loop has no unresolved in-scope findings, run the GPT/GLM pre-PR gate before final PR preparation when this `scoped-plan-run` is executing in Pi.
+After phase implementation and the runtime-native scoped quality-review loop has no unresolved in-scope findings, run the GPT/GLM pre-PR gate before final PR preparation when this `run-plan` is executing in Pi.
 
 In Pi, run `$pre-pr-implementation-review <plan path>`. That gate must use both:
 
@@ -220,7 +220,7 @@ Treat every in-scope P1/P2/P3 finding as blocking a clean ready-for-PR conclusio
 
 If the gate applies fixes after final verification has already run, rerun final verification before commit/PR. In Pi executions, if the GLM-5 Pi subagent or GPT-5.5 review infrastructure is unavailable, stop unless the user explicitly waives this pre-PR gate.
 
-When the gate reports `OPEN_PR_READY` or equivalent clean consensus, continue immediately to final verification, commit, push, and PR creation. Do not return a final scoped-plan-run response at this point.
+When the gate reports `OPEN_PR_READY` or equivalent clean consensus, continue immediately to final verification, commit, push, and PR creation. Do not return a final run-plan response at this point.
 
 Record the GPT verdict, GLM verdict, artifact path, waived/not-run status, and any documented non-blocking follow-ups for the PR body.
 
@@ -465,7 +465,7 @@ Stay within the scope contract. Classify every finding with the normal scope lab
 
 ## Final Response
 
-Only give the scoped-plan-run final response after a PR exists or a concrete PR-creation blocker has been reported. If the run reached clean P1/P2/P3 review consensus and final verification passed, a final response without a PR URL is invalid.
+Only give the run-plan final response after a PR exists or a concrete PR-creation blocker has been reported. If the run reached clean P1/P2/P3 review consensus and final verification passed, a final response without a PR URL is invalid.
 
 Report:
 

--- a/skills/run-plan/agents/openai.yaml
+++ b/skills/run-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Run Plan"
+  short_description: "Execute plans without scope creep"
+  default_prompt: "Use $run-plan to execute an explicit plan path through implementation, scoped reviews, Pi GPT/GLM pre-PR review when applicable, fixes through full P1/P2/P3 consensus, mandatory PR creation, and post-PR monitoring until the completion criteria are met."

--- a/skills/scoped-plan-run/agents/openai.yaml
+++ b/skills/scoped-plan-run/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Scoped Plan Run"
-  short_description: "Execute plans without scope creep"
-  default_prompt: "Use $scoped-plan-run to execute an explicit plan path through implementation, scoped reviews, Pi GPT/GLM pre-PR review when applicable, fixes through full P1/P2/P3 consensus, mandatory PR creation, and post-PR monitoring until the completion criteria are met."

--- a/test_install_shared_skills.sh
+++ b/test_install_shared_skills.sh
@@ -165,21 +165,32 @@ EOF
 
 seed_phase_two_home() {
   local home="$1"
+  # Split the retired skill name so stale-name greps can still guard active surfaces.
+  local old_skill="scoped""-plan-run"
 
   mkdir -p \
     "$home/.claude/skills/custom-local" \
     "$home/.config/opencode/skills/custom-local" \
     "$home/.config/opencode/skills/cmd-debug" \
-    "$home/.pi/agent" \
+    "$home/.config/opencode/skills/$old_skill" \
+    "$home/.pi/agent/skills/$old_skill" \
     "$home/.omp/agent" \
     "$home/.agents/skills/external-skill" \
     "$home/.agents/skills/linear" \
-    "$home/.claude/skills/linear"
+    "$home/.agents/skills/$old_skill" \
+    "$home/.claude/skills/linear" \
+    "$home/.claude/skills/$old_skill"
 
   printf 'external\n' > "$home/.agents/skills/external-skill/SKILL.md"
   printf 'foreign-linear\n' > "$home/.agents/skills/linear/SKILL.md"
+  printf 'old-%s\n' "$old_skill" > "$home/.agents/skills/$old_skill/SKILL.md"
   printf 'old-claude-linear\n' > "$home/.claude/skills/linear/SKILL.md"
+  printf 'old-claude-%s\n' "$old_skill" > "$home/.claude/skills/$old_skill/SKILL.md"
   printf 'foreign-opencode-cmd-debug\n' > "$home/.config/opencode/skills/cmd-debug/SKILL.md"
+  printf 'old-opencode-%s\n' "$old_skill" > "$home/.config/opencode/skills/$old_skill/SKILL.md"
+  printf 'old-pi-%s\n' "$old_skill" > "$home/.pi/agent/skills/$old_skill/SKILL.md"
+  mkdir -p "$home/.agents"
+  printf '{"skills":{"%s":{"source":"old"},"linear":{"source":"old"}}}\n' "$old_skill" > "$home/.agents/.skill-lock.json"
 }
 
 assert_file_contains() {
@@ -246,6 +257,8 @@ assert_shared_skill_install_state() {
   local backup_dir
   local claude_backup_dir
   local opencode_backup_dir
+  # Split the retired skill name so stale-name greps can still guard active surfaces.
+  local old_skill="scoped""-plan-run"
 
   [[ -d "$home/.agents/skills" ]] || return 1
   [[ -f "$home/.agents/skills/external-skill/SKILL.md" ]] || return 1
@@ -276,10 +289,23 @@ assert_shared_skill_install_state() {
 
   [[ -f "$home/.agents/skills/plan-reviewer-build/SKILL.md" ]] || return 1
   [[ -f "$home/.agents/skills/plan-reviewer-build/.ai-configs-managed.json" ]] || return 1
-  assert_file_contains "$home/.agents/skills/plan-reviewer-build/SKILL.md" 'scoped-plan-run' || return 1
+  assert_file_contains "$home/.agents/skills/plan-reviewer-build/SKILL.md" 'run-plan' || return 1
+  assert_file_not_contains "$home/.agents/skills/plan-reviewer-build/SKILL.md" "$old_skill" || return 1
   assert_file_contains "$home/.agents/skills/plan-reviewer-build/.ai-configs-managed.json" '"repo": "ai-configs"' || return 1
   assert_file_contains "$home/.agents/skills/plan-reviewer-build/.ai-configs-managed.json" '"source": "skills/plan-reviewer-build"' || return 1
   assert_file_contains "$home/.agents/skills/plan-reviewer-build/.ai-configs-managed.json" '"managed": true' || return 1
+
+  [[ -f "$home/.agents/skills/run-plan/SKILL.md" ]] || return 1
+  [[ -f "$home/.agents/skills/run-plan/.ai-configs-managed.json" ]] || return 1
+  assert_file_contains "$home/.agents/skills/run-plan/SKILL.md" 'name: run-plan' || return 1
+  assert_file_contains "$home/.agents/skills/run-plan/.ai-configs-managed.json" '"repo": "ai-configs"' || return 1
+  assert_file_contains "$home/.agents/skills/run-plan/.ai-configs-managed.json" '"source": "skills/run-plan"' || return 1
+  assert_file_contains "$home/.agents/skills/run-plan/.ai-configs-managed.json" '"managed": true' || return 1
+  [[ ! -e "$home/.agents/skills/$old_skill" ]] || return 1
+  [[ ! -e "$home/.claude/skills/$old_skill" ]] || return 1
+  [[ ! -e "$home/.config/opencode/skills/$old_skill" ]] || return 1
+  [[ ! -e "$home/.pi/agent/skills/$old_skill" ]] || return 1
+  assert_file_not_contains "$home/.agents/.skill-lock.json" "$old_skill" || return 1
 
   [[ -f "$home/.agents/skills/algorithmic-art/SKILL.md" ]] || return 1
   assert_file_contains "$home/.agents/skills/algorithmic-art/SKILL.md" 'external package=anthropics/skills skill=algorithmic-art' || return 1
@@ -311,6 +337,8 @@ assert_shared_skill_install_state() {
   assert_symlink_target "$home/.config/opencode/skills/linear" "$home/.agents/skills/linear" || return 1
   assert_symlink_target "$home/.claude/skills/adn-dev-wf" "$home/.agents/skills/adn-dev-wf" || return 1
   assert_symlink_target "$home/.config/opencode/skills/adn-dev-wf" "$home/.agents/skills/adn-dev-wf" || return 1
+  assert_symlink_target "$home/.claude/skills/run-plan" "$home/.agents/skills/run-plan" || return 1
+  assert_symlink_target "$home/.config/opencode/skills/run-plan" "$home/.agents/skills/run-plan" || return 1
   assert_symlink_target "$home/.claude/skills/algorithmic-art" "$home/.agents/skills/algorithmic-art" || return 1
   assert_symlink_target "$home/.config/opencode/skills/algorithmic-art" "$home/.agents/skills/algorithmic-art" || return 1
   assert_symlink_target "$home/.claude/skills/design-skill" "$home/.agents/skills/design-skill" || return 1
@@ -631,11 +659,15 @@ test_phase_four_validation_proves_final_alignment() {
   [[ -f "$home/.agents/skills/doct-document-ops/SKILL.md" ]] || return 1
   [[ -f "$home/.agents/skills/plan-reviewer-execution-ready/SKILL.md" ]] || return 1
   [[ -f "$home/.agents/skills/plan-reviewer-build/SKILL.md" ]] || return 1
+  [[ -f "$home/.agents/skills/run-plan/SKILL.md" ]] || return 1
+  [[ ! -e "$home/.agents/skills/scoped""-plan-run" ]] || return 1
 
   claude_symlinks="$(find "$home/.claude/skills" -mindepth 1 -maxdepth 1 -type l | sort)"
   opencode_symlinks="$(find "$home/.config/opencode/skills" -mindepth 1 -maxdepth 1 -type l | sort)"
   assert_command_output_contains "$claude_symlinks" "$home/.claude/skills/linear" || return 1
   assert_command_output_contains "$opencode_symlinks" "$home/.config/opencode/skills/linear" || return 1
+  assert_command_output_contains "$claude_symlinks" "$home/.claude/skills/run-plan" || return 1
+  assert_command_output_contains "$opencode_symlinks" "$home/.config/opencode/skills/run-plan" || return 1
   assert_command_output_not_contains "$claude_symlinks" "$home/.claude/skills/cmd-debug" || return 1
   assert_command_output_not_contains "$opencode_symlinks" "$home/.config/opencode/skills/cmd-debug" || return 1
 

--- a/thoughts/plans/run-plan-command-surface-cleanup.html
+++ b/thoughts/plans/run-plan-command-surface-cleanup.html
@@ -1,0 +1,455 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Run Plan Command Surface Cleanup</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b1020;
+      --panel: #111827;
+      --panel-2: #172033;
+      --text: #e5e7eb;
+      --muted: #a7b0c2;
+      --border: #2c364f;
+      --accent: #7dd3fc;
+      --accent-2: #a78bfa;
+      --warn: #fbbf24;
+      --good: #34d399;
+      --bad: #fb7185;
+      --code: #0f172a;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: radial-gradient(circle at top left, rgba(125, 211, 252, 0.10), transparent 28rem), var(--bg);
+      color: var(--text);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+    a { color: var(--accent); }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+    code { background: rgba(15, 23, 42, 0.88); border: 1px solid var(--border); border-radius: 0.35rem; padding: 0.05rem 0.28rem; }
+    pre { overflow-x: auto; background: var(--code); border: 1px solid var(--border); border-radius: 0.75rem; padding: 1rem; }
+    table { width: 100%; border-collapse: collapse; margin: 1rem 0; }
+    th, td { border: 1px solid var(--border); padding: 0.65rem; vertical-align: top; }
+    th { background: rgba(125, 211, 252, 0.10); color: #f8fafc; text-align: left; }
+    .layout { display: grid; grid-template-columns: 18rem minmax(0, 1fr); gap: 1.25rem; max-width: 1260px; margin: 0 auto; padding: 1.25rem; }
+    .sidebar { position: sticky; top: 1rem; max-height: calc(100vh - 2rem); overflow-y: auto; align-self: start; background: rgba(17, 24, 39, 0.92); border: 1px solid var(--border); border-radius: 1rem; padding: 1rem; }
+    .sidebar h2 { margin-top: 0; font-size: 1rem; }
+    .sidebar a { display: block; color: var(--muted); text-decoration: none; padding: 0.25rem 0; font-size: 0.92rem; }
+    .sidebar a:hover { color: var(--text); }
+    main { min-width: 0; }
+    section, article { background: rgba(17, 24, 39, 0.82); border: 1px solid var(--border); border-radius: 1rem; padding: 1.2rem; margin-bottom: 1rem; }
+    header.hero { background: linear-gradient(135deg, rgba(125, 211, 252, 0.14), rgba(167, 139, 250, 0.12)); border: 1px solid var(--border); border-radius: 1.2rem; padding: 1.4rem; margin-bottom: 1rem; }
+    h1, h2, h3 { line-height: 1.2; }
+    h1 { margin: 0 0 0.6rem; font-size: clamp(2rem, 4vw, 3.2rem); }
+    h2 { margin-top: 0; }
+    .pill-row { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.8rem; }
+    .pill { display: inline-flex; gap: 0.35rem; align-items: center; border: 1px solid var(--border); border-radius: 999px; padding: 0.25rem 0.65rem; color: var(--muted); background: rgba(15, 23, 42, 0.74); font-size: 0.88rem; }
+    .pill.warn { color: var(--warn); border-color: rgba(251, 191, 36, 0.55); }
+    .pill.good { color: var(--good); border-color: rgba(52, 211, 153, 0.55); }
+    .muted { color: var(--muted); }
+    .callout { border-left: 4px solid var(--accent); background: rgba(125, 211, 252, 0.08); padding: 0.8rem 1rem; border-radius: 0.5rem; }
+    .warnbox { border-left: 4px solid var(--warn); background: rgba(251, 191, 36, 0.08); padding: 0.8rem 1rem; border-radius: 0.5rem; }
+    .goodbox { border-left: 4px solid var(--good); background: rgba(52, 211, 153, 0.08); padding: 0.8rem 1rem; border-radius: 0.5rem; }
+    .phase { border-left: 4px solid var(--accent-2); }
+    .nowrap { white-space: nowrap; }
+    @media (max-width: 860px) {
+      .layout { grid-template-columns: 1fr; padding: 0.75rem; }
+      .sidebar { position: static; max-height: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <nav class="sidebar" aria-label="Plan sections">
+      <h2>Sections</h2>
+      <a href="#status">Status</a>
+      <a href="#goal">Goal</a>
+      <a href="#decision-attention">Decision Attention</a>
+      <a href="#why">Why this plan exists</a>
+      <a href="#authority-inputs">Authority and inputs</a>
+      <a href="#current-reality">Current implementation reality</a>
+      <a href="#usage-audit">Recent usage audit</a>
+      <a href="#archive-inventory">Archive inventory</a>
+      <a href="#naming-strategy">Naming strategy</a>
+      <a href="#progress">Progress</a>
+      <a href="#resume">Resume instructions</a>
+      <a href="#product-intent">Product intent alignment</a>
+      <a href="#locked-decisions">Locked decisions</a>
+      <a href="#acceptance-criteria">Acceptance criteria</a>
+      <a href="#bdd">BDD scenarios</a>
+      <a href="#phase-p1">P1 Inventory and decisions</a>
+      <a href="#phase-p2">P2 Rename runner</a>
+      <a href="#phase-p3">P3 Align dispatch surfaces</a>
+      <a href="#phase-p4">P4 Record archive follow-up</a>
+      <a href="#phase-p5">P5 Plan-reviewer smoke</a>
+      <a href="#verification">Verification strategy</a>
+      <a href="#delivery-order">Delivery order</a>
+      <a href="#non-goals">Non-goals</a>
+      <a href="#deviations-log">Decisions / Deviations log</a>
+    </nav>
+
+    <main>
+      <header class="hero" id="title">
+        <h1>Run Plan Command Surface Cleanup</h1>
+        <p class="muted">Rename the current scoped plan execution skill to an ergonomic non-conflicting command, preserve plan-reviewer button behavior, and explicitly inventory low/no-use commands and skills for archive recommendations.</p>
+        <div class="pill-row" id="status">
+          <span class="pill good">Status: execution-ready (GPT and GLM cleared)</span>
+          <span class="pill">Plan path: <code>thoughts/plans/run-plan-command-surface-cleanup.html</code></span>
+          <span class="pill">Repo: ai-configs</span>
+          <span class="pill">UI impact: text-only command/docs surface</span>
+        </div>
+      </header>
+
+      <section id="goal">
+        <h2>Goal</h2>
+        <p>Replace the user-facing <code>scoped-plan-run</code> skill name with the shorter, unique <code>run-plan</code> naming family so it no longer collides with Pi's built-in <code>/scoped-models</code> command. Keep existing plan-reviewer action buttons working by preserving their bridge skills while updating the bridge implementation to call the renamed runner.</p>
+        <p>The plan must also make the command/skill archive inventory explicit enough for a reviewer to approve, reject, or reclassify each candidate later. The default implementation does not delete or move detritus commands beyond the requested <code>scoped-plan-run</code> rename/deprecation cleanup.</p>
+      </section>
+
+      <section id="decision-attention">
+        <h2>Decision Attention / Low-confidence Areas</h2>
+        <div class="warnbox">
+          <p><strong>D1 — Archive deletion is deferred by default.</strong> The inventory below ranks archive candidates and recommends disposition, but this execution plan only removes the old <code>scoped-plan-run</code> installed surface as part of the requested rename. Other detritus commands/skills stay in place unless a browser-review comment or explicit user message approves an exact per-item archive/delete/rename action.</p>
+          <p><strong>D2 — No compatibility alias for <code>scoped-plan-run</code>.</strong> Keeping an alias preserves the autocomplete collision. This plan therefore removes the old installed skill surface after migration rather than keeping a long-lived alias.</p>
+          <p><strong>D3 — Existing plan-reviewer local config may override defaults.</strong> The source default uses <code>plan-reviewer-build</code>, but a local database could be configured to emit another skill name. Verification must inspect or reset the local Build Plan skill setting if needed.</p>
+        </div>
+      </section>
+
+      <section id="why">
+        <h2>Why this plan exists</h2>
+        <p>The current full-PR scoped execution workflow is installed as <code>/skill:scoped-plan-run</code>. In Pi, typing <code>/scoped...</code> also surfaces the built-in <code>/scoped-models</code> command, which makes the command hard to invoke quickly. A rename is safe only if the surrounding command surfaces, installer cleanup, plan-reviewer browser action comments, and documentation all agree on the new name.</p>
+      </section>
+
+      <section id="authority-inputs">
+        <h2>Authority and inputs</h2>
+        <ul>
+          <li>User request: rename <code>@skills/scoped-plan-run/</code> to a unique shorter command such as <code>/run-plan</code>, inspect command usage, identify detritus to archive, choose a non-conflicting naming strategy, and protect plan-reviewer button behavior.</li>
+          <li>Pi docs: skills invoke as <code>/skill:name</code>; direct slash commands come from prompt-template filenames or extensions.</li>
+          <li>Plan-reviewer source evidence: <code>src/schemas.ts</code> defaults action button comments to <code>plan-reviewer-execution-ready</code> and <code>plan-reviewer-build</code>; <code>src/server/app.ts</code> emits <code>Use the ${skillName} skill for this plan.</code></li>
+          <li>Recent Pi session audit: 445 session files newer than 2026-05-25, filtered against known installed/repo prompt templates and skills to avoid false positives from paths and GitHub API routes.</li>
+        </ul>
+      </section>
+
+      <section id="current-reality">
+        <h2>Current implementation reality</h2>
+        <table>
+          <thead><tr><th>Surface</th><th>Current state</th><th>Required change</th></tr></thead>
+          <tbody>
+            <tr><td>Runner skill</td><td><code>skills/scoped-plan-run/SKILL.md</code> with <code>name: scoped-plan-run</code> and <code>$scoped-plan-run</code> prompt references.</td><td>Rename to <code>skills/run-plan/</code>, <code>name: run-plan</code>, and update prompt references.</td></tr>
+            <tr><td>Easy Pi command</td><td>No <code>/run-plan</code> prompt template exists.</td><td>Add <code>_pi/prompts/run-plan.md</code> as a thin wrapper over <code>/skill:run-plan</code>.</td></tr>
+            <tr><td>Plan-reviewer Build Plan button</td><td>Button emits <code>Use the plan-reviewer-build skill...</code> by default.</td><td>Keep this bridge name; update the bridge skill to delegate to <code>run-plan</code>.</td></tr>
+            <tr><td>Installer cleanup</td><td><code>install.sh</code> can remove deprecated shared skills via <code>DEPRECATED_SHARED_SKILLS</code>.</td><td>Add <code>scoped-plan-run</code> to the deprecated list so the old installed surface disappears.</td></tr>
+            <tr><td>Dispatch docs/extensions</td><td>Plan-mode and execute-plan surfaces mention <code>/skill:adn-dev-wf</code> and <code>/dev:run</code>; some docs mention <code>scoped-plan-run</code>.</td><td>Update references so full implementation-through-PR uses <code>/run-plan</code> or <code>/skill:run-plan</code>; keep <code>/dev:run</code> as direct execution-only.</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="usage-audit">
+        <h2>Recent usage audit</h2>
+        <p>Audit window: Pi session JSONL files newer than 2026-05-25. The strict filtered pass counted only known prompt-template, skill, and built-in command names, avoiding false positives such as <code>/repos</code>, <code>/issues</code>, <code>/usr</code>, and file paths.</p>
+        <table>
+          <thead><tr><th>Command / skill</th><th>User count</th><th>Total mentions</th><th>Sessions</th><th>Interpretation</th></tr></thead>
+          <tbody>
+            <tr><td><code>/skill:pre-pr-implementation-review</code></td><td>76</td><td>77</td><td>17</td><td>Keep. Regularly used review gate.</td></tr>
+            <tr><td><code>/review:plan</code></td><td>5</td><td>23</td><td>18</td><td>Keep. Often appears in assistant-guided workflows.</td></tr>
+            <tr><td><code>/cmd:execute-plan</code></td><td>4</td><td>7</td><td>4</td><td>Keep but update target naming.</td></tr>
+            <tr><td><code>/review:change-integrate</code></td><td>6</td><td>6</td><td>3</td><td>Keep. Used for review-comment cleanup.</td></tr>
+            <tr><td><code>/review:plan-adversarial</code></td><td>4</td><td>4</td><td>2</td><td>Keep. Low volume but deliberate gate.</td></tr>
+            <tr><td><code>/review:change-claude-code</code></td><td>2</td><td>7</td><td>4</td><td>Keep as explicit opt-in review surface.</td></tr>
+            <tr><td><code>/skill:scoped-plan-run</code></td><td>1</td><td>9</td><td>4</td><td>Rename to <code>/skill:run-plan</code>; no alias.</td></tr>
+            <tr><td><code>/skill:adn-dev-wf</code></td><td>0</td><td>2</td><td>1</td><td>Review after <code>run-plan</code> migration; do not archive in first pass because docs still call it canonical.</td></tr>
+            <tr><td><code>/dev:reviewed-html-plan</code></td><td>0</td><td>2</td><td>2</td><td>Keep. Plan-reviewer workflow surface even if assistant-suggested more than user-typed.</td></tr>
+            <tr><td><code>/scoped-models</code></td><td>1</td><td>1</td><td>1</td><td>Built-in Pi command; collision source, not repo-owned.</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="archive-inventory">
+        <h2>Inventory of old unused commands / skills to archive</h2>
+        <h3 id="archive-high-confidence">High-confidence archive or rename candidates</h3>
+        <table>
+          <thead><tr><th>Candidate</th><th>Evidence</th><th>Proposed action</th><th>Reasoning</th></tr></thead>
+          <tbody>
+            <tr><td><code>_pi/prompts/functional-review.md</code> plus mirrored consumer copies</td><td>0 strict recent direct uses.</td><td>Archive after approval.</td><td>Older spec/openspec systemic review prompt; overlaps newer plan/PM/product review workflows and is not part of current reviewed HTML plan path.</td></tr>
+            <tr><td><code>_pi/prompts/lean-functional-review.md</code> plus mirrored consumer copies</td><td>0 strict recent direct uses.</td><td>Archive after approval.</td><td>Older increment review prompt; overlaps product-principles and plan-review readiness checks.</td></tr>
+            <tr><td><code>_pi/prompts/cmd:local-review.md</code></td><td>0 strict recent direct uses.</td><td>Archive after approval.</td><td>Creates isolated review worktrees manually; current workflows prefer dedicated review skills/agents and explicit PR review commands.</td></tr>
+            <tr><td><code>_pi/prompts/dev:reflect.md</code></td><td>0 strict recent direct uses.</td><td>Archive after approval.</td><td>Phase reflection is not in the current reviewed-plan golden path; plan progress/deviation updates are now owned by execution workflows.</td></tr>
+            <tr><td><code>skills/ccore_DONOTUSE/</code></td><td>0 strict recent skill invocations and directory name says <code>DONOTUSE</code> while frontmatter says <code>name: ccore</code>.</td><td>Do not leave as-is. Either rename to <code>skills/ccore/</code> if still wanted, or remove from install matrix if obsolete.</td><td>The current name is confusing and undermines discoverability even if the content is valid.</td></tr>
+            <tr><td><code>skills/scoped-plan-run/</code></td><td>Collision with built-in <code>/scoped-models</code>; only one direct user invocation in audit window.</td><td>Rename to <code>skills/run-plan/</code>; add old name to deprecated installer cleanup.</td><td>This is the primary requested cleanup.</td></tr>
+          </tbody>
+        </table>
+
+        <h3 id="archive-medium-confidence">Medium-confidence candidates requiring review</h3>
+        <table>
+          <thead><tr><th>Candidate</th><th>Evidence</th><th>Proposed action</th><th>Review question</th></tr></thead>
+          <tbody>
+            <tr><td><code>_pi/prompts/cmd:review-pr-comments.md</code></td><td>0 strict recent direct uses.</td><td>Review before archiving.</td><td>Is this superseded by <code>run-plan</code> post-PR monitoring, or should it remain a standalone emergency command?</td></tr>
+            <tr><td><code>_pi/prompts/cmd:feeling-lucky-pr.md</code> and <code>cmd:feeling-lucky-pr-os.md</code></td><td>0 strict recent direct uses.</td><td>Review before archiving.</td><td>Are these experimental one-shot PR flows still wanted now that reviewed plans and <code>run-plan</code> exist?</td></tr>
+            <tr><td><code>_pi/prompts/dev:plan-from-prd.md</code>, <code>prd:clarify-round.md</code>, <code>review:prd.md</code></td><td>0 strict recent direct uses.</td><td>Review as a PRD bundle.</td><td>Is the PRD flow still active, or has reviewed HTML planning replaced it?</td></tr>
+            <tr><td><code>_pi/prompts/cmd:send-plan-to-doct.md</code></td><td>0 strict recent direct uses.</td><td>Review before archiving.</td><td>Do plan-reviewer/browser plans now replace Doct plan publishing?</td></tr>
+            <tr><td><code>_pi/prompts/doc:fetch.md</code> and <code>doc:update.md</code></td><td>0 strict recent direct uses.</td><td>Review before archiving.</td><td>Are these still useful outside this repo's normal coding workflow?</td></tr>
+          </tbody>
+        </table>
+
+        <h3 id="archive-keep-zero-use">Zero-use but keep for now</h3>
+        <table>
+          <thead><tr><th>Surface</th><th>Why keep despite zero strict direct uses</th></tr></thead>
+          <tbody>
+            <tr><td><code>/dev:plan</code>, <code>/dev:run</code>, <code>/dev:reviewed-html-plan</code></td><td>Core plan lifecycle commands; usage may be assistant-suggested or extension-dispatched rather than user-typed.</td></tr>
+            <tr><td><code>plan-reviewer-build</code>, <code>plan-reviewer-execution-ready</code></td><td>Browser action bridge skills are invoked by plan-reviewer comments, not necessarily typed by users.</td></tr>
+            <tr><td><code>review-change*</code> provider-specific prompts</td><td>Explicit opt-in review surfaces; low frequency is expected.</td></tr>
+            <tr><td>Domain commands such as <code>macos:*</code>, <code>test:run-playwright*</code>, <code>qa:run</code></td><td>Specialized commands should not be archived solely because this month did not include that domain.</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="naming-strategy">
+        <h2>Non-conflicting naming strategy</h2>
+        <div class="goodbox">
+          <p><strong>Canonical full lifecycle:</strong> <code>/run-plan &lt;plan&gt;</code> for ergonomic Pi use and <code>/skill:run-plan &lt;plan&gt;</code> for explicit skill use.</p>
+          <p><strong>Browser action bridge:</strong> keep <code>plan-reviewer-build</code> and <code>plan-reviewer-execution-ready</code> because those names describe service-originated comments, not the underlying runner.</p>
+          <p><strong>Direct execution-only:</strong> keep <code>/dev:run &lt;plan&gt;</code> for the narrower phase execution path.</p>
+          <p><strong>Handoff wrapper:</strong> update <code>/cmd:execute-plan</code> and plan-mode prompts to offer <code>/run-plan</code> for full implementation-through-PR and <code>/dev:run</code> for direct execution-only.</p>
+          <p><strong>Avoid:</strong> new user-facing names beginning with <code>scoped-</code>, because Pi already owns <code>/scoped-models</code>.</p>
+        </div>
+      </section>
+
+      <section id="progress">
+        <h2>Progress</h2>
+        <ul>
+          <li><input type="checkbox" checked disabled> P1 — Inventory and archive decisions</li>
+          <li><input type="checkbox" checked disabled> P2 — Rename runner skill and installer cleanup</li>
+          <li><input type="checkbox" checked disabled> P3 — Align dispatch surfaces and docs</li>
+          <li><input type="checkbox" checked disabled> P4 — Record archive follow-up decisions</li>
+          <li><input type="checkbox" checked disabled> P5 — Plan-reviewer button smoke and registration verification</li>
+        </ul>
+      </section>
+
+      <section id="resume">
+        <h2>Resume instructions (agent)</h2>
+        <p>Read this document fully, then start with the first unchecked item in <a href="#progress">Progress</a>. Preserve the distinction between ergonomic user commands, skill names, and plan-reviewer browser-comment bridge names. Do not delete or move any detritus command/skill candidate other than the requested <code>scoped-plan-run</code> rename/deprecated-install cleanup unless an explicit approval comment lists the exact item and action.</p>
+      </section>
+
+      <section id="product-intent">
+        <h2>Product intent alignment</h2>
+        <p>This is an operator/agent workflow cleanup. The expected golden path is that a user can type <code>/run-plan thoughts/plans/foo.html</code> without colliding with built-in model commands, and browser Build Plan comments continue to reach the same full implementation-through-PR workflow without the user knowing the internal skill was renamed.</p>
+      </section>
+
+      <section id="locked-decisions">
+        <h2>Locked decisions</h2>
+        <ul>
+          <li id="decision-run-plan-name"><strong>Use <code>run-plan</code> as the new runner name.</strong> It is short, verb-first, and currently free across checked Pi prompt, shared skill, and installed skill surfaces.</li>
+          <li id="decision-no-alias"><strong>Do not keep <code>scoped-plan-run</code> as an installed alias.</strong> The old name should be cleaned by installer deprecation logic to remove the autocomplete conflict.</li>
+          <li id="decision-plan-reviewer-bridge"><strong>Keep <code>plan-reviewer-build</code> as the Build Plan button skill.</strong> The service button should remain stable and delegate to <code>run-plan</code>.</li>
+          <li id="decision-archive-default"><strong>Default archive behavior is documentation-only.</strong> The first pass records archive recommendations and follow-up decisions, but does not remove old low/no-use commands unless explicitly approved.</li>
+        </ul>
+      </section>
+
+      <section id="acceptance-criteria">
+        <h2>Acceptance criteria</h2>
+        <ol>
+          <li id="ac-1">Typing <code>/run-plan &lt;plan&gt;</code> in Pi starts the renamed full lifecycle workflow instructions without requiring the user to type <code>/skill:scoped-plan-run</code>.</li>
+          <li id="ac-2"><code>/skill:run-plan</code> exists, <code>/skill:scoped-plan-run</code> is no longer installed after running the repo installer, and repo references to the old skill are gone except historical plan logs.</li>
+          <li id="ac-3">Plan-reviewer Build Plan action comments still say to use <code>plan-reviewer-build</code>, and that skill delegates to <code>run-plan</code>.</li>
+          <li id="ac-4">The archive inventory is committed in docs or an archival manifest with high-confidence, medium-confidence, and keep categories, so future agents do not need to rediscover the same usage data.</li>
+          <li id="ac-5">No low/no-use detritus command or skill is deleted in the first pass without explicit approval; high-confidence, medium-confidence, and keep candidates remain visible in a durable follow-up inventory.</li>
+          <li id="ac-6"><code>/cmd:execute-plan</code>, Pi plan-mode prompts, and README guidance present non-conflicting choices: <code>/run-plan</code> for full lifecycle and <code>/dev:run</code> for direct execution-only.</li>
+        </ol>
+      </section>
+
+      <section id="bdd">
+        <h2>BDD scenarios</h2>
+        <article id="bdd-run-plan-pi">
+          <h3>Scenario: Pi user invokes the renamed runner</h3>
+          <p><strong>Given</strong> the shared skills and Pi prompt templates have been installed, <strong>when</strong> the user types <code>/run-plan thoughts/plans/example.html</code>, <strong>then</strong> Pi loads the <code>run-plan</code> workflow and does not require selecting through <code>/scoped-models</code>-adjacent autocomplete results.</p>
+        </article>
+        <article id="bdd-old-skill-removed">
+          <h3>Scenario: old skill is removed after install</h3>
+          <p><strong>Given</strong> a workstation previously has <code>~/.agents/skills/scoped-plan-run</code>, <strong>when</strong> the updated installer runs, <strong>then</strong> it backs up/removes that old skill and installs <code>~/.agents/skills/run-plan</code>.</p>
+        </article>
+        <article id="bdd-plan-reviewer-build">
+          <h3>Scenario: Build Plan button still works</h3>
+          <p><strong>Given</strong> a registered plan is open in plan-reviewer, <strong>when</strong> the reviewer clicks Build Plan, <strong>then</strong> the generated browser comment requests <code>plan-reviewer-build</code>, and the listening agent follows that bridge into <code>run-plan</code> for the explicit plan path.</p>
+        </article>
+        <article id="bdd-archive-approval">
+          <h3>Scenario: archive candidates are not deleted blindly</h3>
+          <p><strong>Given</strong> a candidate command has zero recent direct usage, <strong>when</strong> no explicit browser-review or user approval names that exact item and action, <strong>then</strong> the cleanup leaves it in place and records the recommended disposition in the inventory rather than deleting it solely based on count.</p>
+        </article>
+      </section>
+
+      <section class="phase" id="phase-p1">
+        <h2>P1 — Inventory and archive recommendation manifest</h2>
+        <h3>End State</h3>
+        <p>The repo contains a durable command/skill inventory with high-confidence, medium-confidence, and keep categories. The manifest records recommended archive actions but does not authorize deletion by itself.</p>
+        <h3>Tests first</h3>
+        <ul><li>Add or update a lightweight script/check only if the repo already has a suitable install-doc checker; otherwise use diff-backed inspection.</li></ul>
+        <h3>Work</h3>
+        <ul>
+          <li>Create <code>thoughts/research/run-plan-command-surface-inventory.md</code> with the strict session audit method, counts, and candidate tables from this plan.</li>
+          <li>Record that no low/no-use command or skill is archived in this run unless an explicit approval comment names the exact item and action.</li>
+          <li>Move medium-confidence candidates into a follow-up section rather than deleting them.</li>
+        </ul>
+        <h3>Expected files</h3>
+        <p><code>thoughts/research/run-plan-command-surface-inventory.md</code> and this plan.</p>
+        <h3>Open questions / decision dependencies</h3>
+        <p>None for rename execution. Archive/delete work beyond <code>scoped-plan-run</code> remains deferred until explicitly approved.</p>
+        <h3>Verify</h3>
+        <pre><code>test -f thoughts/research/run-plan-command-surface-inventory.md
+rg -n "High-confidence|Medium-confidence|Zero-use but keep|scoped-plan-run" thoughts/research/run-plan-command-surface-inventory.md</code></pre>
+      </section>
+
+      <section class="phase" id="phase-p2">
+        <h2>P2 — Rename runner skill and installer cleanup</h2>
+        <h3>End State</h3>
+        <p><code>run-plan</code> is the installed skill and direct Pi prompt wrapper; the old <code>scoped-plan-run</code> installed surface is removed by the installer.</p>
+        <h3>Tests first</h3>
+        <ul><li>Update <code>test_install_shared_skills.sh</code> assertions from <code>scoped-plan-run</code> to <code>run-plan</code>, including deprecated cleanup behavior.</li></ul>
+        <h3>Work</h3>
+        <ul>
+          <li>Move <code>skills/scoped-plan-run/</code> to <code>skills/run-plan/</code>.</li>
+          <li>Update frontmatter, headings, invocation examples, and <code>agents/openai.yaml</code>.</li>
+          <li>Add <code>_pi/prompts/run-plan.md</code> wrapper.</li>
+          <li>Update <code>skills/install-matrix.json</code> and <code>install.sh</code> deprecated skill cleanup.</li>
+        </ul>
+        <h3>Expected files</h3>
+        <p><code>skills/run-plan/SKILL.md</code>, <code>skills/run-plan/agents/openai.yaml</code>, <code>_pi/prompts/run-plan.md</code>, <code>skills/install-matrix.json</code>, <code>install.sh</code>, <code>test_install_shared_skills.sh</code>.</p>
+        <h3>Open questions / decision dependencies</h3>
+        <p>None after D2 remains accepted.</p>
+        <h3>Verify</h3>
+        <pre><code>test -d skills/run-plan
+! test -d skills/scoped-plan-run
+rg -n "name: run-plan|\$run-plan|/run-plan" skills/run-plan _pi/prompts/run-plan.md
+bash test_install_shared_skills.sh</code></pre>
+      </section>
+
+      <section class="phase" id="phase-p3">
+        <h2>P3 — Align dispatch surfaces and docs</h2>
+        <h3>End State</h3>
+        <p>Command handoff surfaces describe <code>/run-plan</code> as the full implementation-through-PR path and <code>/dev:run</code> as direct execution-only.</p>
+        <h3>Tests first</h3>
+        <ul><li>Update any existing prompt/doc hardening checks that assert old handoff text.</li></ul>
+        <h3>Work</h3>
+        <ul>
+          <li>Update <code>_pi/prompts/cmd:execute-plan.md</code> and Pi plan-mode extension text/target parsing if it dispatches old full-workflow names.</li>
+          <li>Update <code>_codex</code>, <code>_claude</code>, <code>_opencode</code>, and <code>_omp</code> mirrors only where this repo maintains cross-consumer prompt parity.</li>
+          <li>Update shared-skill references that currently point at <code>scoped-plan-run</code>, including <code>skills/codex-full-build/SKILL.md</code>, <code>skills/pre-pr-implementation-review/SKILL.md</code>, <code>skills/plan-reviewer-build/SKILL.md</code>, <code>skills/install-matrix.json</code> notes, and review-check scripts that whitelist the old name.</li>
+          <li>Update README/AGENTS guidance for the new naming strategy.</li>
+        </ul>
+        <h3>Expected files</h3>
+        <p><code>_pi/prompts/cmd:execute-plan.md</code>, <code>_pi/extensions/pi-plan-mode/index.ts</code>, <code>_pi/README.md</code>, <code>AGENTS.md</code>, <code>skills/codex-full-build/SKILL.md</code>, <code>skills/pre-pr-implementation-review/SKILL.md</code>, <code>skills/plan-reviewer-build/SKILL.md</code>, <code>skills/install-matrix.json</code>, review-check scripts, plus mirrored prompt trees as needed.</p>
+        <h3>Open questions / decision dependencies</h3>
+        <p>Whether <code>adn-dev-wf</code> remains a separate canonical workflow or becomes a later archive candidate must be decided separately; this phase should not delete it.</p>
+        <h3>Verify</h3>
+        <pre><code>rg -n "/run-plan|/skill:run-plan|/dev:run|cmd:execute-plan" _pi/prompts/cmd:execute-plan.md _pi/extensions/pi-plan-mode/index.ts _pi/README.md AGENTS.md skills/codex-full-build/SKILL.md skills/plan-reviewer-build/SKILL.md skills/pre-pr-implementation-review/SKILL.md
+! rg -n "scoped-plan-run|\$scoped-plan-run" skills _pi _codex _claude _opencode _omp README.md AGENTS.md test_install_shared_skills.sh --glob '!thoughts/plans/**'</code></pre>
+      </section>
+
+      <section class="phase" id="phase-p4">
+        <h2>P4 — Record archive follow-up decisions</h2>
+        <h3>End State</h3>
+        <p>The archive candidates remain visible as recommendations, and no detritus prompt/skill is removed from active install surfaces unless an explicit approval names the exact item and action. The only default removal is the old <code>scoped-plan-run</code> installed surface via the rename/deprecated-skill cleanup.</p>
+        <h3>Tests first</h3>
+        <ul><li>If command inventory docs exist, add/update a check that candidate commands remain classified as recommendation-only unless explicit approval is recorded.</li></ul>
+        <h3>Work</h3>
+        <ul>
+          <li>Update <code>thoughts/research/run-plan-command-surface-inventory.md</code> with final recommended dispositions for high-confidence, medium-confidence, and keep categories.</li>
+          <li>Do not delete, move, or rename <code>functional-review</code>, <code>lean-functional-review</code>, <code>cmd:local-review</code>, <code>dev:reflect</code>, <code>cmd:review-pr-comments</code>, <code>ccore_DONOTUSE</code>, or other detritus candidates unless explicit approval is present.</li>
+          <li>If explicit approval is present, remove approved files from active install roots with <code>git rm</code>, or move historical copies to <code>thoughts/archive/pi-command-detritus/&lt;date&gt;/</code>. Never archive under <code>_pi/prompts</code>, <code>skills</code>, <code>_codex/prompts</code>, <code>_claude/commands</code>, <code>_opencode/commands</code>, or <code>_omp/commands</code>, because those roots are active install or mirrored command surfaces.</li>
+        </ul>
+        <h3>Expected files</h3>
+        <p><code>thoughts/research/run-plan-command-surface-inventory.md</code>. Approved prompt/skill files change only if the approval is explicit.</p>
+        <h3>Open questions / decision dependencies</h3>
+        <p>None for default execution. Any future archive/delete action must name the exact item and safe destination or deletion mechanism.</p>
+        <h3>Verify</h3>
+        <pre><code>rg -n "High-confidence|Medium-confidence|Zero-use but keep|functional-review|lean-functional-review|cmd:local-review|dev:reflect|ccore_DONOTUSE" thoughts/research/run-plan-command-surface-inventory.md
+find thoughts/archive -maxdepth 3 -type f 2&gt;/dev/null | sort || true
+! find _pi/prompts -path '*/archive/*' -print | rg .</code></pre>
+      </section>
+
+      <section class="phase" id="phase-p5">
+        <h2>P5 — Plan-reviewer button smoke and registration verification</h2>
+        <h3>End State</h3>
+        <p>The plan-reviewer Build Plan button still creates a valid <code>plan-reviewer-build</code> comment and the bridge skill points to <code>run-plan</code>.</p>
+        <h3>Tests first</h3>
+        <ul><li>No plan-reviewer source tests are required if defaults remain unchanged; use smoke verification against the installed service and local configuration.</li></ul>
+        <h3>Work</h3>
+        <ul>
+          <li>Check local plan-reviewer configuration for <code>buildPlanSkillName</code> in <code>~/.plan-reviewer/plan-reviewer.sqlite</code>.</li>
+          <li>If the local config was manually set to <code>scoped-plan-run</code>, reset it to <code>plan-reviewer-build</code>.</li>
+          <li>Register or re-register this plan and confirm action comments still use the bridge skill.</li>
+          <li>Smoke the Build Plan contract by clicking the browser Build Plan action when available, then claiming the queued comment and verifying the payload names <code>plan-reviewer-build</code> and the explicit plan path. If browser automation is unavailable, add a temporary CLI comment with the exact Build Plan body and verify the same queue/claim payload.</li>
+        </ul>
+        <h3>Expected files</h3>
+        <p><code>skills/plan-reviewer-build/SKILL.md</code>; no plan-reviewer repo source change expected unless config inspection proves the service default has drifted.</p>
+        <h3>Open questions / decision dependencies</h3>
+        <p>D3 local configuration check.</p>
+        <h3>Verify</h3>
+        <pre><code>curl -fsS http://127.0.0.1:4317/health
+sqlite3 ~/.plan-reviewer/plan-reviewer.sqlite "select key,value_json from app_configuration where key in ('buildPlanSkillName','executionReadySkillName');"
+PLAN_JSON=$(plan-review register thoughts/plans/run-plan-command-surface-cleanup.html --repo auto --branch auto --commit auto --execution-ready false --json)
+PLAN_ID=$(jq -r '.plan.id // .planId // .id' &lt;&lt;&lt;"$PLAN_JSON")
+test -n "$PLAN_ID"
+rg -n "plan-reviewer-build|run-plan" skills/plan-reviewer-build/SKILL.md
+! rg -n "scoped-plan-run|\$scoped-plan-run" skills/plan-reviewer-build/SKILL.md
+COMMENT_JSON=$(plan-review comments add "$PLAN_ID" --url http://mbp.braid-python.ts.net:4317 --selector '#goal' --agent plan-reviewer-build-smoke --body $'Use the plan-reviewer-build skill for this plan.\nPlan path: thoughts/plans/run-plan-command-surface-cleanup.html' --json)
+COMMENT_ID=$(jq -r '.comment.id // .commentId // .id' &lt;&lt;&lt;"$COMMENT_JSON")
+test -n "$COMMENT_ID"
+plan-review agent next "$PLAN_ID" --url http://mbp.braid-python.ts.net:4317 --no-wait --json | tee /tmp/build-plan-smoke.json
+CLAIM_ID=$(jq -r '.claimId' /tmp/build-plan-smoke.json)
+jq -e --arg commentId "$COMMENT_ID" '.commentId == $commentId and .conversationPayload.commentId == $commentId and (.conversationPayload.body | contains("plan-reviewer-build") and contains("thoughts/plans/run-plan-command-surface-cleanup.html"))' /tmp/build-plan-smoke.json
+plan-review ack "$COMMENT_ID" --claim "$CLAIM_ID" --summary "Build Plan smoke verified; no product files changed" --changed-files skills/plan-reviewer-build/SKILL.md --json --url http://mbp.braid-python.ts.net:4317
+plan-review resolve "$COMMENT_ID" --note "Build Plan smoke verified" --json --url http://mbp.braid-python.ts.net:4317</code></pre>
+      </section>
+
+      <section id="verification">
+        <h2>Verification strategy</h2>
+        <table>
+          <thead><tr><th>Acceptance</th><th>Evidence</th><th>Command</th></tr></thead>
+          <tbody>
+            <tr><td>AC1, AC2</td><td>Skill rename and wrapper present; old name absent from active surfaces.</td><td><code>rg -n "run-plan|/run-plan|/skill:run-plan" skills/run-plan _pi/prompts/run-plan.md skills/install-matrix.json test_install_shared_skills.sh &amp;&amp; ! rg -n "scoped-plan-run|\$scoped-plan-run" skills _pi _codex _claude _opencode _omp README.md AGENTS.md test_install_shared_skills.sh --glob '!thoughts/plans/**'</code></td></tr>
+            <tr><td>AC3</td><td>Plan-reviewer bridge delegates correctly, queued action payload names the bridge, and the temporary smoke comment is resolved.</td><td><code>sqlite3 ~/.plan-reviewer/plan-reviewer.sqlite "select key,value_json from app_configuration where key='buildPlanSkillName';" &amp;&amp; rg -n "plan-reviewer-build|run-plan" skills/plan-reviewer-build/SKILL.md &amp;&amp; jq -e '.conversationPayload.body | contains("plan-reviewer-build") and contains("thoughts/plans/run-plan-command-surface-cleanup.html")' /tmp/build-plan-smoke.json</code></td></tr>
+            <tr><td>AC4, AC5</td><td>Archive inventory and recommendation-only policy are visible.</td><td><code>rg -n "High-confidence|Medium-confidence|Zero-use but keep|recommendation-only|explicit approval" thoughts/research/run-plan-command-surface-inventory.md</code></td></tr>
+            <tr><td>AC6</td><td>Dispatch docs show non-conflicting names.</td><td><code>rg -n "/run-plan|/dev:run|/cmd:execute-plan" _pi _codex _claude _opencode _omp README.md AGENTS.md</code></td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="delivery-order">
+        <h2>Delivery order</h2>
+        <ol>
+          <li>Create the durable inventory manifest and record that archive/delete actions are recommendation-only unless explicitly approved.</li>
+          <li>Implement the rename and wrapper first so the requested command conflict is solved before optional archive cleanup.</li>
+          <li>Update dispatch surfaces, shared-skill references, installer tests, and docs. Stay on this repo's current branch/worktree; do not create a new branch/worktree unless the user asks.</li>
+          <li>Record archive follow-up dispositions without deleting detritus candidates unless an approval comment names exact items and actions.</li>
+          <li>Run installer and plan-reviewer Build Plan smoke verification.</li>
+        </ol>
+      </section>
+
+      <section id="non-goals">
+        <h2>Non-goals</h2>
+        <ul>
+          <li>Do not redesign Pi's built-in <code>/scoped-models</code> command.</li>
+          <li>Do not change plan-reviewer source defaults unless verification proves the service is currently configured to emit the wrong skill name.</li>
+          <li>Do not archive domain-specific commands solely because they had zero direct usage in the last month.</li>
+          <li>Do not delete or move any low/no-use detritus candidate in this first pass unless explicit approval names the exact item and action.</li>
+          <li>Do not merge <code>adn-dev-wf</code> into <code>run-plan</code> in this first pass; classify it after the rename lands.</li>
+        </ul>
+      </section>
+
+      <section id="deviations-log">
+        <h2>Decisions / Deviations log</h2>
+        <ul>
+          <li id="log-2026-06-25-created">2026-06-25: Initial browser-review plan created with explicit command/skill archive inventory after user noted the prior proposal did not include one.</li>
+          <li id="log-2026-06-26-readiness-fixes">2026-06-26: GPT/GLM execution-ready review found unresolved archive approval, stale-reference negative-check gaps, and weak Build Plan smoke coverage. Plan updated to defer destructive archive work by default, add explicit negative checks, require queue-payload verification for plan-reviewer Build Plan behavior, and make the smoke deterministic by matching, acknowledging, and resolving the temporary comment by ID.</li>
+          <li id="log-2026-06-26-ready">2026-06-26: Final GPT and GLM rereviews both returned <code>VERDICT: PLAN_EXECUTION_READY</code>.</li>
+          <li id="log-2026-06-26-implementation">2026-06-26: Implemented the <code>run-plan</code> rename, preserved <code>plan-reviewer-build</code>, recorded archive candidates as recommendation-only, fixed scoped-review findings for consumer install parity and <code>/skill:run-plan</code> plan-mode handoff, and completed the pre-PR GPT/GLM gate with <code>CLEAN_FOR_PR</code> from both reviewers.</li>
+        </ul>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/thoughts/research/run-plan-command-surface-inventory.md
+++ b/thoughts/research/run-plan-command-surface-inventory.md
@@ -1,0 +1,83 @@
+# Run Plan Command Surface Inventory
+
+Date: 2026-06-26
+Plan: `thoughts/plans/run-plan-command-surface-cleanup.html`
+
+## Scope
+
+This inventory records command and skill usage evidence for the `scoped-plan-run` to `run-plan` rename. It is a recommendation manifest, not approval to delete detritus surfaces. The only removal approved by the current plan is the old installed `scoped-plan-run` surface as part of the rename/deprecated-skill cleanup.
+
+## Audit method
+
+- Source: Pi session JSONL files newer than 2026-05-25.
+- Sample size from the planning audit: 445 session files.
+- Counting rule: strict filtered pass over known prompt-template, skill, and built-in command names.
+- False-positive exclusions: path fragments and API route fragments such as `/repos`, `/issues`, `/usr`, and file paths.
+
+## Recent usage summary
+
+| Command / skill | User count | Total mentions | Sessions | Disposition |
+| --- | ---: | ---: | ---: | --- |
+| `/skill:pre-pr-implementation-review` | 76 | 77 | 17 | Keep. Regularly used pre-PR review gate. |
+| `/review:plan` | 5 | 23 | 18 | Keep. Active plan-review workflow surface. |
+| `/cmd:execute-plan` | 4 | 7 | 4 | Keep, but update target naming to `run-plan` / `dev:run`. |
+| `/review:change-integrate` | 6 | 6 | 3 | Keep. Used for review-comment cleanup. |
+| `/review:plan-adversarial` | 4 | 4 | 2 | Keep. Low-volume but deliberate plan gate. |
+| `/review:change-claude-code` | 2 | 7 | 4 | Keep as explicit opt-in review surface. |
+| `/skill:scoped-plan-run` | 1 | 9 | 4 | Renamed to `/skill:run-plan`; no alias retained. |
+| `/skill:adn-dev-wf` | 0 | 2 | 1 | Keep for now as a broader reviewed-plan workflow. Reassess after `run-plan` usage settles. |
+| `/dev:reviewed-html-plan` | 0 | 2 | 2 | Keep. Browser-reviewed plan workflow surface. |
+| `/scoped-models` | 1 | 1 | 1 | Built-in Pi command; collision source, not repo-owned. |
+
+## High-confidence archive or rename candidates
+
+These are recommendations only unless an explicit future approval names the exact item and action.
+
+| Candidate | Evidence | Recommended action | Reasoning |
+| --- | --- | --- | --- |
+| `_pi/prompts/functional-review.md` plus mirrored consumer copies | 0 strict recent direct uses. | Archive after approval. | Older spec/openspec systemic review prompt; overlaps current plan/PM/product review workflows. |
+| `_pi/prompts/lean-functional-review.md` plus mirrored consumer copies | 0 strict recent direct uses. | Archive after approval. | Older increment review prompt; overlaps product-principles and plan-review readiness checks. |
+| `_pi/prompts/cmd:local-review.md` | 0 strict recent direct uses. | Archive after approval. | Manual isolated review worktrees are superseded by dedicated review skills/agents and explicit PR review commands. |
+| `_pi/prompts/dev:reflect.md` | 0 strict recent direct uses. | Archive after approval. | Phase reflection is no longer in the current reviewed-plan golden path. |
+| `skills/ccore_DONOTUSE/` | 0 strict recent skill invocations and directory name says `DONOTUSE` while frontmatter says `name: ccore`. | Do not leave as-is. Rename to `skills/ccore/` if wanted, or remove from install matrix if obsolete, after approval. | Current naming is confusing and undermines discoverability. |
+| `skills/scoped-plan-run/` | Collision with built-in `/scoped-models`; one direct user invocation in audit window. | Completed: renamed to `skills/run-plan/`; old name added to deprecated installer cleanup. | Primary approved cleanup for this plan. |
+
+## Medium-confidence candidates requiring review
+
+| Candidate | Evidence | Recommended action | Review question |
+| --- | --- | --- | --- |
+| `_pi/prompts/cmd:review-pr-comments.md` | 0 strict recent direct uses. | Review before archiving. | Is this superseded by `run-plan` post-PR monitoring, or still useful as an emergency command? |
+| `_pi/prompts/cmd:feeling-lucky-pr.md` and `_pi/prompts/cmd:feeling-lucky-pr-os.md` | 0 strict recent direct uses. | Review before archiving. | Are these experimental one-shot PR flows still wanted now that reviewed plans and `run-plan` exist? |
+| `_pi/prompts/dev:plan-from-prd.md`, `_pi/prompts/prd:clarify-round.md`, `_pi/prompts/review:prd.md` | 0 strict recent direct uses. | Review as a PRD bundle. | Is the PRD flow still active, or has reviewed HTML planning replaced it? |
+| `_pi/prompts/cmd:send-plan-to-doct.md` | 0 strict recent direct uses. | Review before archiving. | Do plan-reviewer/browser plans now replace Doct plan publishing? |
+| `_pi/prompts/doc:fetch.md` and `_pi/prompts/doc:update.md` | 0 strict recent direct uses. | Review before archiving. | Are these still useful outside this repo's normal coding workflow? |
+
+## Zero-use but keep for now
+
+| Surface | Reason to keep |
+| --- | --- |
+| `/dev:plan`, `/dev:run`, `/dev:reviewed-html-plan` | Core plan lifecycle commands; usage may be assistant-suggested or extension-dispatched rather than user-typed. |
+| `plan-reviewer-build`, `plan-reviewer-execution-ready` | Browser action bridge skills are invoked by plan-reviewer comments, not necessarily typed by users. |
+| `review-change*` provider-specific prompts | Explicit opt-in review surfaces; low frequency is expected. |
+| Domain commands such as `macos:*`, `test:run-playwright*`, `qa:run` | Specialized commands should not be archived solely because this month did not include that domain. |
+
+## Recommendation-only policy
+
+- Do not delete, move, or rename any low/no-use command or skill from this inventory unless a later user message or plan-review browser comment explicitly names the exact item and action.
+- Approved archive destinations must be outside active install roots such as `_pi/prompts`, `skills`, `_codex/prompts`, `_claude/commands`, `_opencode/commands`, and `_omp/commands`.
+- If archive approval is later granted, prefer `thoughts/archive/pi-command-detritus/<date>/` for historical copies or `git rm` for explicitly approved deletion.
+
+## Current approved rename
+
+- New canonical full lifecycle command: `/run-plan <plan>`.
+- Explicit Pi skill invocation: `/skill:run-plan <plan>`; it is equivalent to `/run-plan` for the full lifecycle runner, while `/run-plan` is the ergonomic cross-surface wrapper name.
+- Removed installed alias: `/skill:scoped-plan-run` after installer cleanup.
+- Stable browser bridge: `plan-reviewer-build`, which delegates to `run-plan`.
+- Direct execution-only path remains: `/dev:run <plan>`.
+
+## Archive follow-up status
+
+- No detritus prompts, mirrored commands, or low/no-use skills were archived or deleted in this run.
+- The only approved removal behavior is installer cleanup of stale installed `scoped-plan-run` copies after the rename.
+- `functional-review`, `lean-functional-review`, `cmd:local-review`, `dev:reflect`, `cmd:review-pr-comments`, `cmd:feeling-lucky-pr*`, PRD flow prompts, Doct plan publishing, doc fetch/update prompts, and `ccore_DONOTUSE` remain recommendation-only follow-ups pending explicit approval.
+- Future cleanup should first decide whether `/skill:adn-dev-wf` remains a broader reviewed-plan workflow or becomes a later archive candidate after `run-plan` usage is established.

--- a/thoughts/validation/pre-pr-reviews/2026-06-26-worktree-rapid-forest-d41e.md
+++ b/thoughts/validation/pre-pr-reviews/2026-06-26-worktree-rapid-forest-d41e.md
@@ -1,0 +1,96 @@
+# Pre-PR Implementation Review — run-plan command surface cleanup
+
+Date: 2026-06-26
+Branch: `worktree/rapid-forest-d41e`
+Plan: `thoughts/plans/run-plan-command-surface-cleanup.html`
+Base/comparison: initial cycles reviewed the then-uncommitted working-tree diff against `origin/main`; after commit and rebase, post-rebase cycles review `origin/main..HEAD` / `origin/main...HEAD` plus the current uncommitted validation-artifact update. No staged changes at review start.
+
+## Scope summary
+
+Rename the `scoped-plan-run` shared skill/surface to `run-plan`, add ergonomic `/run-plan` wrappers, preserve `plan-reviewer-build` as the browser Build Plan bridge, align dispatch/docs, record archive candidates without deleting unrelated detritus, and verify installer cleanup plus plan-reviewer smoke behavior.
+
+## Changed files summary
+
+See `/tmp/run-plan-pre-pr-changed-files.txt` for the exact launch-time file list. Major groups:
+
+- Runner rename: `skills/run-plan/**` added, `skills/scoped-plan-run/**` removed.
+- Installer/matrix/tests: `skills/install-matrix.json`, `install.sh`, `test_install_shared_skills.sh`.
+- Dispatch/wrappers: `_pi/prompts/run-plan.md`, `_codex/prompts/run-plan.md`, `_claude/commands/run-plan.md`, `_opencode/commands/run-plan.md`, `_omp/commands/run-plan.md`, `cmd:execute-plan` mirrors, Pi/OMP plan-mode extensions.
+- Bridge/docs: `skills/plan-reviewer-build/SKILL.md`, `skills/codex-full-build/SKILL.md`, `skills/pre-pr-implementation-review/SKILL.md`, README/AGENTS/catalog docs.
+- Planning artifacts: `thoughts/plans/run-plan-command-surface-cleanup.html`, `thoughts/research/run-plan-command-surface-inventory.md`.
+
+## Verification before pre-PR gate
+
+- `python3 -m json.tool skills/install-matrix.json` — passed.
+- Python assertion: `run-plan.allowedConsumers` includes `codex`, `claude`, `opencode`, and `pi` — passed.
+- `bash test_install_shared_skills.sh` — 13 passed, 0 failed.
+- Active-surface stale grep for `scoped-plan-run|$scoped-plan-run` excluding `thoughts/plans/**` — passed.
+- Dispatch/docs grep for `/run-plan`, `/skill:run-plan`, `/dev:run`, and `/cmd:execute-plan` — passed.
+- Plan-reviewer Build Plan smoke: `buildPlanSkillName` is `plan-reviewer-build`; queued payload contained `plan-reviewer-build` and `thoughts/plans/run-plan-command-surface-cleanup.html`; temporary smoke comment was acked and resolved.
+- Scoped quality rereviews after parity fixes: GPT and GLM both returned `PASS_NO_ISSUES`.
+
+## Review cycle 1
+
+| Reviewer | Verdict | Notes |
+| --- | --- | --- |
+| GPT-5.5 quality-reviewer | `CLEAN_FOR_PR` | Agent `a3bbaed8-56b3-4c6`; no findings. Reran `git diff --check` and `bash test_install_shared_skills.sh` (13 passed, 0 failed). |
+| GLM-5 quality-reviewer-glm | `FINDINGS_TO_RESOLVE` | Agent `495c69e1-dbf4-4af`; one blocking P3 against this validation artifact because it still contained pending placeholders. |
+
+## Triage table
+
+| Finding | Reviewer | Severity | Scope | Decision | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| Validation artifact still showed placeholder review status after reviews completed. | GLM-5 quality-reviewer-glm | P3 | REGRESSION_FROM_THIS_DIFF | Fixed by replacing placeholders with actual cycle-1 verdicts, triage, and fix notes. | Artifact lines for cycle 1, triage, fixes, and final gate result still contained placeholder text, making readiness evidence contradictory. |
+
+## Fixes applied during pre-PR gate
+
+- Updated this artifact to replace placeholder cycle-1 review status with the actual GPT clean verdict and GLM P3 finding.
+- Recorded the GLM finding in the triage table with its fix disposition.
+
+## Review cycle 2
+
+| Reviewer | Verdict | Notes |
+| --- | --- | --- |
+| GPT-5.5 quality-reviewer | `CLEAN_FOR_PR` | Agent `c592415c-b5a4-4fb`; no unresolved in-scope P1/P2/P3 findings. Reran `json.tool`, allowedConsumers check, `git diff --check`, stale active-reference grep, and `bash test_install_shared_skills.sh` (13 passed, 0 failed). |
+| GLM-5 quality-reviewer-glm | `CLEAN_FOR_PR` | Agent `da7ca116-3f63-477`; no unresolved in-scope P1/P2/P3 findings. Reran `git diff --check`, `python3 -m json.tool skills/install-matrix.json`, run-plan matrix assertions, and `bash test_install_shared_skills.sh` (13 passed, 0 failed). |
+
+## Post-rebase review cycle 3
+
+After cycle 2 passed, the branch was rebased onto current `origin/main`. Conflicts in `AGENTS.md`, `_pi/README.md`, `skills/install-matrix.json`, and `skills/pre-pr-implementation-review/SKILL.md` were resolved by preserving current-main GLM-5 Pi subagent wording while keeping the `run-plan` rename.
+
+| Reviewer | Verdict | Notes |
+| --- | --- | --- |
+| GPT-5.5 quality-reviewer | `FINDINGS_TO_RESOLVE` | Agent `851f50d0-dc72-418`; one P3 validation evidence finding because the base/comparison line still claimed `git diff origin/main...HEAD` was empty after the rebase. |
+| GLM-5 quality-reviewer-glm | `FINDINGS_TO_RESOLVE` | Agent `c683cf7f-adf4-45a`; same P3 validation evidence finding. |
+
+### Cycle-3 triage
+
+| Finding | Reviewer | Severity | Scope | Decision | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| Base/comparison line falsely said `git diff origin/main...HEAD` was empty after the branch was rebased and committed. | GPT-5.5 and GLM-5 | P3 | REGRESSION_FROM_THIS_DIFF | Fixed by updating the line to describe the initial uncommitted review cycles and the post-rebase `origin/main..HEAD` / `origin/main...HEAD` review scope. | Current branch is one commit ahead of `origin/main` and the PR diff contains the committed implementation files. |
+
+## Post-rebase review cycle 4
+
+| Reviewer | Verdict | Notes |
+| --- | --- | --- |
+| GPT-5.5 quality-reviewer | `CLEAN_FOR_PR` | Agent `b4e7dd96-0b84-4cc`; no unresolved in-scope P1/P2/P3 findings after the cycle-3 artifact-scope fix. |
+| GLM-5 quality-reviewer-glm | `CLEAN_FOR_PR` | Agent `d2427b89-7e00-4cc`; no unresolved in-scope P1/P2/P3 findings after the cycle-3 artifact-scope fix. |
+
+## PR feedback disposition
+
+CodeRabbit completed successfully on PR #25 and left four trivial nitpicks. Disposition: fixed all four with minimal doc/test clarity edits: added a plain-text fence label, aligned Pi execute-plan argument-hint ordering, renamed remaining "scoped runner" narrative phrasing to `run-plan` caller, and documented why the retired skill name is split in tests.
+
+Codex reviewed the pre-nitpick-fix commit and left one P2 on `_pi/prompts/cmd:feeling-lucky-pr.md`: `/run-plan` now owns validation, final review, commit, push, PR creation, and monitoring, but the feeling-lucky PR flow still continued into `/dev:validate`, review, commit/push, and PR creation. Disposition: fixed across the mirrored normal and `-os` feeling-lucky PR prompts for Pi, Claude, OpenCode, and OMP by making `/run-plan ${plan_slug}` the terminal implementation-through-PR step and leaving only Linear linking/reporting after it.
+
+CodeRabbit completed again after the Codex fix and left two trivial nitpicks. Disposition: fixed by making `_pi/README.md` explicitly say `/cmd:execute-plan` is the wrapper that chooses between `/run-plan` and `/dev:run`, and by clarifying in the command-surface inventory that `/skill:run-plan` is the explicit Pi skill invocation equivalent to the ergonomic cross-surface `/run-plan` wrapper.
+
+## Final gate result
+
+- GPT verdict: `CLEAN_FOR_PR`.
+- GLM verdict: `CLEAN_FOR_PR`.
+- Verification after rebase and before final cycle: `bash -n install.sh`; `bash -n test_install_shared_skills.sh`; `python3 -m json.tool skills/install-matrix.json`; run-plan/pre-pr matrix assertions; narrow conflict-marker grep; active stale-reference grep; `git diff --check`; `bash test_install_shared_skills.sh` with 13 passed, 0 failed.
+- PR-feedback verification after CodeRabbit nitpick fixes: `bash -n test_install_shared_skills.sh`; `python3 -m json.tool skills/install-matrix.json`; run-plan/pre-pr matrix assertions; targeted grep for all four fixes; active stale-reference grep; `git diff --check`; `bash test_install_shared_skills.sh` with 13 passed, 0 failed.
+- PR-feedback verification after Codex P2 fix: targeted grep proved all eight mirrored feeling-lucky PR prompts now use `### 5) Implement Through PR`, contain `/run-plan ${plan_slug}`, contain `### 6) Link Existing PR to Linear`, and no longer contain standalone `/dev:validate ${plan_slug}`, `/cmd:commit-push`, `/cmd:create-pr ${base_ref}`, `Final Code Review`, or `Commit, Push, PR` steps; `bash -n test_install_shared_skills.sh`; `python3 -m json.tool skills/install-matrix.json`; `git diff --check`; `bash test_install_shared_skills.sh` with 13 passed, 0 failed.
+- PR-feedback verification after final CodeRabbit nitpick fixes: targeted grep confirmed `_pi/README.md` now names `/cmd:execute-plan` as the wrapper and the inventory clarifies `/skill:run-plan` as the explicit Pi skill invocation equivalent to `/run-plan`; `python3 -m json.tool skills/install-matrix.json`; `git diff --check`; `bash test_install_shared_skills.sh` with 13 passed, 0 failed.
+- Remaining non-blocking out-of-scope follow-ups: none.
+- Next step: `OPEN_PR_READY` for the scoped run; continue to push, PR creation, and post-PR monitoring.


### PR DESCRIPTION
## Summary
- Rename the full lifecycle runner skill from `scoped-plan-run` to `run-plan` and add `/run-plan` wrappers across Pi, Codex, Claude, OpenCode, and OMP.
- Preserve `plan-reviewer-build` as the browser Build Plan bridge while delegating execution to `run-plan`.
- Update installer cleanup, install matrix parity, docs, dispatchers, and command-surface inventory without deleting recommendation-only archive candidates.

## Verification
- `bash -n install.sh`
- `bash -n test_install_shared_skills.sh`
- `python3 -m json.tool skills/install-matrix.json`
- run-plan/pre-pr matrix assertions
- narrow conflict-marker grep
- active stale-reference grep for `scoped-plan-run|$scoped-plan-run` excluding plan artifacts
- `git diff --check`
- `bash test_install_shared_skills.sh` → 13 passed, 0 failed
- plan-reviewer Build Plan smoke: verified `plan-reviewer-build` payload for `thoughts/plans/run-plan-command-surface-cleanup.html`

## Reviews
- Scoped GPT/GLM quality rereviews: pass/no issues.
- Pre-PR GPT/GLM gate: final post-rebase cycle returned `CLEAN_FOR_PR` from both reviewers.
- Artifact: `thoughts/validation/pre-pr-reviews/2026-06-26-worktree-rapid-forest-d41e.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **/run-plan** as the end-to-end reviewed-plan execution path (implementation → review gates → PR creation → post-PR monitoring).
  * Updated execution handoffs and interactive flows to present **/run-plan** alongside **/dev:run** as the primary choices.
* **Documentation**
  * Refreshed workflow and step-by-step command guidance across the product to use **/run-plan** as the canonical reviewed-plan route, including updated “next step” instructions and examples.
* **Chores**
  * Updated shared-skill installation/cleanup to remove deprecated legacy plan-run surfaces and standardize on the new naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->