### PR TITLE
Recover pi-vcc no-cut hard backstop

### DIFF
--- a/_pi/README.md
+++ b/_pi/README.md
@@ -162,18 +162,19 @@ This repo also ships `simple-multi-status.ts`, a lightweight multi-line status w
 
 This repo also ships `percentage-compaction.ts`, which gives you percentage-based control over context compaction:
 
-- set a custom threshold (default 60%) for when compaction should trigger,
-- proactively auto-compacts with **pi-vcc** once usage crosses the threshold,
-- interrupts long tool-driven agent runs at the next turn boundary, then lets pi-vcc resume the agent after compaction,
+- sends soft/strong model-visible nudges at 60%/75% so agents can choose a safe `compact_context` boundary,
+- uses an 80% hard backstop for automatic pi-vcc compaction,
+- interrupts long tool-driven agent runs at a turn boundary, then lets pi-vcc resume the agent after successful compaction,
+- if the hard backstop finds no safe compaction cut during an active turn, treats it as a recoverable skip, waits for pending tool results when needed, sends one bounded-retry continuation steer, and suppresses immediate same-percent no-cut retry loops,
 - `/compact-status` to check current context usage,
 - `/compact-now [instructions]` to trigger compaction manually,
-- gates pi's built-in auto-compaction so it cannot fire below the configured threshold,
+- gates pi's built-in auto-compaction so repo-managed pi-vcc handles hard-backstop compaction with no-cut recovery,
 - cancels compaction instead of falling back to Pi's default compactor when pi-vcc is not loaded.
 
-To adjust the threshold, edit `COMPACTION_THRESHOLD_PERCENT` in the extension file (default is 60).
+To adjust nudge thresholds, edit `COMPACTION_NUDGE_PERCENT` / `COMPACTION_STRONG_NUDGE_PERCENT`; to adjust the automatic hard backstop, edit `HARD_AUTO_COMPACTION_PERCENT` in the extension file.
 To use with pi-vcc, run `./install.sh --pi`; `pi list` should show the stable mirror under `~/.pi/agent/local-packages/ai-configs/pi-vcc`.
 
-**Note:** With the vendored pi-vcc installed, no additional compaction configuration is needed. The extension now proactively starts a pi-vcc compaction at the configured percentage threshold, and pi-vcc handles the actual algorithmic compaction when triggered. This repo now ships the `/pi-vcc` manual-bypass marker and the agent-only-tail fallback directly in the vendored package, so rerunning `./install.sh --pi` refreshes both behaviors without patching global npm files.
+**Note:** With the vendored pi-vcc installed, no additional compaction configuration is needed. The extension proactively starts pi-vcc compaction at the configured hard-backstop percentage, and pi-vcc handles the actual algorithmic compaction when triggered. This repo now ships the `/pi-vcc` manual-bypass marker and the agent-only-tail fallback directly in the vendored package, so rerunning `./install.sh --pi` refreshes both behaviors without patching global npm files.
 
 This repo also vendors Pi's `questionnaire.ts` extension, which auto-loads on install and provides:
 

--- a/_pi/extensions/percentage-compaction.ts
+++ b/_pi/extensions/percentage-compaction.ts
@@ -25,6 +25,35 @@ interface PendingModelCompaction {
   sawSiblingTools: boolean;
 }
 
+interface PendingNoCutContinuation {
+  reason: "already_compacted" | "session_too_small";
+  usagePercent?: number;
+  flooredPercent?: number;
+  pendingToolCallIds: Set<string>;
+  queuedTurn: number;
+  attempts: number;
+  startedAt?: number;
+  timer?: ReturnType<typeof setTimeout>;
+  lastError?: string;
+}
+
+interface NoCutRecoveryOptions {
+  interruptedActiveTurn: boolean;
+  pendingToolCallIds: () => string[];
+  usagePercent?: number;
+}
+
+interface NoCutRetryState {
+  flooredPercent: number;
+  usagePercent?: number;
+  userMessageCount: number;
+  reason: "already_compacted" | "session_too_small";
+}
+
+const NO_CUT_CONTINUATION_DELAY_MS = 50;
+const NO_CUT_CONTINUATION_MAX_WAIT_MS = 5000;
+const NO_CUT_CONTINUATION_RETRY_MS = 100;
+
 const isPiVccLoaded = () => Boolean((globalThis as any)[PI_VCC_LOAD_MARKER]);
 
 const notifyMissingPiVcc = (ctx: ExtensionContext) => {
@@ -38,6 +67,10 @@ const isCompletedAssistantResponse = (message: TurnEndEvent["message"]) => {
   if (message.role !== "assistant") return false;
   return !("stopReason" in message && message.stopReason === "toolUse");
 };
+
+const isInterruptedAgentWork = (message: TurnEndEvent["message"]) =>
+  (message.role === "assistant" && "stopReason" in message && message.stopReason === "toolUse") ||
+  message.role === "toolResult";
 
 const isStaleAutoCompactionPercent = (percent: number, lastPercent: number | undefined) =>
   lastPercent !== undefined && percent === lastPercent;
@@ -73,6 +106,13 @@ const toolCallCount = (message: any): number => {
   return message.content.filter((part: any) => part?.type === "toolCall").length;
 };
 
+const assistantToolCallIds = (message: any): string[] => {
+  if (message?.role !== "assistant" || !Array.isArray(message?.content)) return [];
+  return message.content
+    .filter((part: any) => part?.type === "toolCall" && typeof part?.id === "string")
+    .map((part: any) => part.id);
+};
+
 const assistantToolBatchIncludes = (message: any, toolCallId: string | undefined): boolean => {
   if (!toolCallId || message?.role !== "assistant" || !Array.isArray(message?.content)) return false;
   return message.content.some((part: any) => part?.type === "toolCall" && part?.id === toolCallId);
@@ -80,6 +120,16 @@ const assistantToolBatchIncludes = (message: any, toolCallId: string | undefined
 
 const toolResultMatches = (result: any, toolCallId: string | undefined): boolean =>
   Boolean(toolCallId && result?.toolCallId === toolCallId);
+
+const deliveredToolCallIds = (event: TurnEndEvent): string[] => {
+  const ids = new Set<string>();
+  const add = (result: any) => {
+    if (typeof result?.toolCallId === "string") ids.add(result.toolCallId);
+  };
+  add(event.message);
+  if (Array.isArray(event.toolResults)) event.toolResults.forEach(add);
+  return [...ids];
+};
 
 const buildIntentInstructions = (pending: PendingModelCompaction) =>
   `${PI_VCC_MANUAL_BYPASS_MARKER}\n${JSON.stringify({
@@ -137,6 +187,15 @@ export default function (pi: ExtensionAPI) {
   let turnCounter = 0;
   let lastToolBatchId = 0;
   let lastAssistantToolCallCount = 0;
+  let outstandingAssistantToolCallIds = new Set<string>();
+  let userMessageCount = 0;
+  let pendingNoCutContinuation: PendingNoCutContinuation | undefined;
+  let noCutRetryState: NoCutRetryState | undefined;
+
+  const clearPendingNoCutContinuation = () => {
+    if (pendingNoCutContinuation?.timer) clearTimeout(pendingNoCutContinuation.timer);
+    pendingNoCutContinuation = undefined;
+  };
 
   const finishCompaction = (options: { compacted?: boolean } = {}) => {
     compactionInFlight = false;
@@ -144,6 +203,79 @@ export default function (pi: ExtensionAPI) {
     lastNudgePercentBand = undefined;
     if (options.compacted) awaitingPostCompactionAssistantResponse = true;
   };
+
+  const buildNoCutContinuationMessage = (pending: PendingNoCutContinuation) =>
+    `Pi VCC hard-backstop compaction was skipped because no safe compaction cut was available (${pending.reason}). ` +
+    "Continue from where you left off; do not summarize this recovery message unless it changes the task state.";
+
+  const sendPendingNoCutContinuation = (ctx: ExtensionContext) => {
+    const pending = pendingNoCutContinuation;
+    if (!pending) return;
+    if (!pending.startedAt) pending.startedAt = Date.now();
+    pending.attempts += 1;
+    try {
+      pi.sendMessage(
+        {
+          customType: "pi-vcc-no-cut-continuation",
+          content: buildNoCutContinuationMessage(pending),
+          display: true,
+          details: {
+            reason: pending.reason,
+            usagePercent: pending.usagePercent,
+            flooredPercent: pending.flooredPercent,
+            queuedTurn: pending.queuedTurn,
+            deliveryAttempts: pending.attempts,
+            pendingToolResultCount: pending.pendingToolCallIds.size,
+          },
+        },
+        { deliverAs: "steer", triggerTurn: true },
+      );
+      if (pending.timer) clearTimeout(pending.timer);
+      pendingNoCutContinuation = undefined;
+    } catch (err) {
+      pending.lastError = (err as Error).message;
+      const elapsed = Date.now() - pending.startedAt;
+      if (elapsed < NO_CUT_CONTINUATION_MAX_WAIT_MS) {
+        if (pending.timer) clearTimeout(pending.timer);
+        pending.timer = setTimeout(() => sendPendingNoCutContinuation(ctx), NO_CUT_CONTINUATION_RETRY_MS);
+        return;
+      }
+      if (pending.timer) clearTimeout(pending.timer);
+      ctx.ui.notify(
+        `No-cut continuation delivery failed after ${pending.attempts} attempts: ${pending.lastError}. Continue manually from the interrupted turn.`,
+        "warning",
+      );
+      pendingNoCutContinuation = undefined;
+    }
+  };
+
+  const queueNoCutContinuation = (
+    ctx: ExtensionContext,
+    reason: PendingNoCutContinuation["reason"],
+    recovery: NoCutRecoveryOptions,
+  ) => {
+    if (!recovery.interruptedActiveTurn || pendingNoCutContinuation) return;
+    pendingNoCutContinuation = {
+      reason,
+      usagePercent: recovery.usagePercent,
+      flooredPercent: recovery.usagePercent === undefined ? undefined : Math.floor(recovery.usagePercent),
+      pendingToolCallIds: new Set(recovery.pendingToolCallIds()),
+      queuedTurn: turnCounter,
+      attempts: 0,
+    };
+    if (pendingNoCutContinuation.pendingToolCallIds.size === 0) {
+      pendingNoCutContinuation.timer = setTimeout(() => sendPendingNoCutContinuation(ctx), NO_CUT_CONTINUATION_DELAY_MS);
+    }
+  };
+
+  const clearDeliveredNoCutTools = (event: TurnEndEvent) => {
+    if (!pendingNoCutContinuation) return;
+    for (const id of deliveredToolCallIds(event)) pendingNoCutContinuation.pendingToolCallIds.delete(id);
+  };
+
+  const noCutContinuationIsSafe = (event: TurnEndEvent) =>
+    Boolean(pendingNoCutContinuation) &&
+    (pendingNoCutContinuation.pendingToolCallIds.size === 0 || isCompletedAssistantResponse(event.message));
 
   const triggerCompaction = (
     ctx: ExtensionContext,
@@ -154,6 +286,7 @@ export default function (pi: ExtensionAPI) {
       ratchetPercent?: number;
       reason: string;
       resumeMessage?: string;
+      noCutRecovery?: NoCutRecoveryOptions;
     },
   ) => {
     if (compactionInFlight) return false;
@@ -162,6 +295,7 @@ export default function (pi: ExtensionAPI) {
       return false;
     }
 
+    clearPendingNoCutContinuation();
     compactionInFlight = true;
     lastCompactionReason = options.reason;
     ctx.ui.notify(options.startMessage, "info");
@@ -169,6 +303,7 @@ export default function (pi: ExtensionAPI) {
       customInstructions: options.customInstructions,
       onComplete: () => {
         if (options.ratchetPercent !== undefined) lastAutoCompactionPercent = options.ratchetPercent;
+        noCutRetryState = undefined;
         finishCompaction({ compacted: true });
         ctx.ui.notify(options.completionMessage, "info");
         if (options.resumeMessage) {
@@ -188,12 +323,27 @@ export default function (pi: ExtensionAPI) {
         }
       },
       onError: (err: Error) => {
-        if (err.message === "Already compacted" || err.message === "Nothing to compact (session too small)") {
-          if (options.ratchetPercent !== undefined) lastAutoCompactionPercent = options.ratchetPercent;
+        const noCutReason = err.message === "Already compacted"
+          ? "already_compacted"
+          : err.message === "Nothing to compact (session too small)"
+            ? "session_too_small"
+            : undefined;
+        if (noCutReason) {
+          if (options.ratchetPercent !== undefined) {
+            lastAutoCompactionPercent = options.ratchetPercent;
+            noCutRetryState = {
+              flooredPercent: Math.floor(options.ratchetPercent),
+              usagePercent: options.ratchetPercent,
+              userMessageCount,
+              reason: noCutReason,
+            };
+          }
+          awaitingPostCompactionAssistantResponse = false;
         }
         finishCompaction();
-        if (err.message === "Already compacted" || err.message === "Nothing to compact (session too small)") {
-          ctx.ui.notify("Nothing to compact", "info");
+        if (noCutReason) {
+          ctx.ui.notify("No safe compaction cut available; continuing session.", "info");
+          if (options.noCutRecovery) queueNoCutContinuation(ctx, noCutReason, options.noCutRecovery);
         } else {
           ctx.ui.notify(`Compaction failed: ${err.message}`, "error");
         }
@@ -324,6 +474,7 @@ export default function (pi: ExtensionAPI) {
     if (event.message.role === "assistant" && "stopReason" in event.message && event.message.stopReason === "toolUse") {
       lastToolBatchId += 1;
       lastAssistantToolCallCount = toolCallCount(event.message);
+      outstandingAssistantToolCallIds = new Set(assistantToolCallIds(event.message));
       if (pendingModelCompaction && assistantToolBatchIncludes(event.message, pendingModelCompaction.toolCallId)) {
         pendingModelCompaction.toolBatchId = lastToolBatchId;
         pendingModelCompaction.sawSiblingTools = lastAssistantToolCallCount > 1;
@@ -338,6 +489,11 @@ export default function (pi: ExtensionAPI) {
 
     const usage = ctx.getContextUsage();
     const usagePercent = usage?.percent ?? undefined;
+
+    for (const id of deliveredToolCallIds(event)) outstandingAssistantToolCallIds.delete(id);
+    if (completedResponse) outstandingAssistantToolCallIds.clear();
+    clearDeliveredNoCutTools(event);
+    if (noCutContinuationIsSafe(event)) sendPendingNoCutContinuation(ctx);
 
     if (compactionInFlight) return;
 
@@ -370,11 +526,22 @@ export default function (pi: ExtensionAPI) {
       lastAutoCompactionPercent = undefined;
       lastNudgePercentBand = undefined;
       awaitingPostCompactionAssistantResponse = false;
+      noCutRetryState = undefined;
       return;
     }
 
     if (usagePercent >= HARD_AUTO_COMPACTION_PERCENT) {
-      if (isStaleAutoCompactionPercent(usagePercent, lastAutoCompactionPercent)) return;
+      if (
+        isStaleAutoCompactionPercent(usagePercent, lastAutoCompactionPercent) &&
+        (!noCutRetryState || userMessageCount === noCutRetryState.userMessageCount)
+      ) return;
+      if (
+        noCutRetryState &&
+        currentPercent <= noCutRetryState.flooredPercent &&
+        userMessageCount === noCutRetryState.userMessageCount
+      ) {
+        return;
+      }
       triggerCompaction(ctx, {
         startMessage: completedResponse
           ? `✓ Auto-compacting at ${currentPercent}% (hard backstop: ${HARD_AUTO_COMPACTION_PERCENT}%)`
@@ -382,6 +549,11 @@ export default function (pi: ExtensionAPI) {
         completionMessage: "Compacted with pi-vcc",
         ratchetPercent: usagePercent,
         reason: "hard_backstop",
+        noCutRecovery: {
+          interruptedActiveTurn: isInterruptedAgentWork(event.message),
+          pendingToolCallIds: () => completedResponse ? [] : [...outstandingAssistantToolCallIds],
+          usagePercent,
+        },
       });
       return;
     }
@@ -394,7 +566,13 @@ export default function (pi: ExtensionAPI) {
     sendModelNudge(ctx, usagePercent, "soft");
   });
 
+  pi.on("message_end", async (event: any) => {
+    if (event?.message?.role === "user" && typeof event.message.customType !== "string") userMessageCount += 1;
+  });
+
   pi.on("session_compact", async () => {
+    noCutRetryState = undefined;
+    clearPendingNoCutContinuation();
     finishCompaction({ compacted: true });
   });
 
@@ -438,6 +616,17 @@ export default function (pi: ExtensionAPI) {
       return { cancel: true };
     }
 
+    if (compactionInFlight) {
+      lastAutoCompactionPercent = usage.percent;
+      awaitingPostCompactionAssistantResponse = true;
+      lastCompactionReason = "core_hard_backstop";
+      ctx.ui.notify(
+        `✓ Auto-compacting at ${Math.floor(usage.percent)}% (hard backstop: ${HARD_AUTO_COMPACTION_PERCENT}%)`,
+        "info",
+      );
+      return;
+    }
+
     if (isStaleAutoCompactionPercent(usage.percent, lastAutoCompactionPercent)) {
       ctx.ui.notify(
         `⏸️ Delayed auto-compaction: context usage is unchanged at ${usage.percent}% since the last pi-vcc compaction`,
@@ -446,12 +635,23 @@ export default function (pi: ExtensionAPI) {
       return { cancel: true };
     }
 
-    lastAutoCompactionPercent = usage.percent;
-    awaitingPostCompactionAssistantResponse = true;
-    lastCompactionReason = "core_hard_backstop";
+    const currentPercent = Math.floor(usage.percent);
+    if (
+      noCutRetryState &&
+      currentPercent <= noCutRetryState.flooredPercent &&
+      userMessageCount === noCutRetryState.userMessageCount
+    ) {
+      ctx.ui.notify(
+        `⏸️ Delayed auto-compaction: no safe cut was available at ${noCutRetryState.flooredPercent}%; waiting for higher usage or a new user message`,
+        "info",
+      );
+      return { cancel: true };
+    }
+
     ctx.ui.notify(
-      `✓ Auto-compacting at ${Math.floor(usage.percent)}% (hard backstop: ${HARD_AUTO_COMPACTION_PERCENT}%)`,
+      `⏸️ Delayed auto-compaction: repo-managed hard backstop handles ${Math.floor(usage.percent)}% compaction with no-cut recovery`,
       "info",
     );
+    return { cancel: true };
   });
 }

--- a/_pi/packages/pi-vcc/README.md
+++ b/_pi/packages/pi-vcc/README.md
@@ -9,7 +9,8 @@ Vendored into `ai-configs` from `sting8k/pi-vcc` so this repo can ship a pinned 
 - License: MIT
 - Local changes and selective uptake:
   - `/pi-vcc` carries the `__PI_VCC_MANUAL_BYPASS__` marker directly in-source so repo-managed auto-compaction and manual compaction both use pi-vcc without global patching
-  - the compaction hook keeps the repo-local agent-only fallback tail and shifts the cut backward so a live `toolResult` never outlives its matching assistant tool call
+  - the compaction hook keeps the repo-local agent-only fallback tail and shifts the cut backward so a live `toolResult` never outlives its matching assistant tool call; if the kept tail would contain an orphaned tool result, pi-vcc reports a no-cut classification instead of forcing an unsafe cut
+  - no-cut paths record diagnostic classifications such as `tiny_session`, `post_compaction_tail_too_short`, and `active_turn_no_safe_cut` for hook debugging and future extension status surfaces
   - when pi-vcc compacts before the assistant has finished its response, it sends a follow-up continue prompt after compaction so the agent resumes instead of stalling, with a reminder to use `vcc_recall` for pre-compaction details; compactions at the completed-response boundary stay silent
   - high-value upstream `0.3.18` uptake is intentionally selective: TUI-safe wrapping, `bashExecution` normalization/search/report correctness fixes, keep-token parsing, compaction reason/willRetry metadata, and overflow retry fallback; upstream commit extraction is intentionally skipped/deferred because commit details remain available through transcript and recall
   - this vendored copy preserves redaction, including compressed bash command redaction, even though upstream removed `src/core/redact.ts`

--- a/_pi/packages/pi-vcc/src/hooks/before-compact.ts
+++ b/_pi/packages/pi-vcc/src/hooks/before-compact.ts
@@ -6,7 +6,7 @@ import { homedir } from "os";
 import { compile } from "../core/summarize";
 import { parseKeepAndPrompt, PI_VCC_COMPACT_INSTRUCTION } from "../core/compact-args";
 import type { PiVccCompactionDetails } from "../details";
-import type { CompactionIntent, CompactionReason } from "../types";
+import type { CompactionIntent, CompactionReason, NoCutClassification } from "../types";
 
 export { PI_VCC_COMPACT_INSTRUCTION } from "../core/compact-args";
 
@@ -29,7 +29,9 @@ export interface CompactionStats {
 }
 
 let lastStats: CompactionStats | null = null;
+let lastNoCutClassification: NoCutClassification | null = null;
 export const getLastCompactionStats = () => lastStats;
+export const getLastNoCutClassification = () => lastNoCutClassification;
 
 export interface PiVccConfig {
   debug?: boolean;
@@ -109,21 +111,42 @@ const hasMatchingToolCall = (message: any, toolCallId: string): boolean => {
   return message.content.some((item: any) => item?.type === "toolCall" && item.id === toolCallId);
 };
 
-const adjustCutIdxForToolResult = (liveMessages: EntryWithMessage[], cutIdx: number): number => {
+const findMatchingToolCallIndex = (liveMessages: EntryWithMessage[], toolCallId: string, beforeIdx: number): number => {
+  for (let i = beforeIdx; i >= 0; i--) {
+    if (hasMatchingToolCall(liveMessages[i]?.message, toolCallId)) return i;
+    if (liveMessages[i]?.message?.role === "user") break;
+  }
+  return -1;
+};
+
+const adjustCutIdxForToolResult = (liveMessages: EntryWithMessage[], cutIdx: number): number | null => {
   if (cutIdx <= 0) return cutIdx;
 
   const firstKeptMessage = liveMessages[cutIdx]?.message;
   if (firstKeptMessage?.role !== "toolResult" || !firstKeptMessage.toolCallId) return cutIdx;
 
-  for (let i = cutIdx - 1; i >= 0; i--) {
-    if (hasMatchingToolCall(liveMessages[i]?.message, firstKeptMessage.toolCallId)) return i;
-    if (liveMessages[i]?.message?.role === "user") break;
-  }
+  const matchingIdx = findMatchingToolCallIndex(liveMessages, firstKeptMessage.toolCallId, cutIdx - 1);
+  return matchingIdx >= 0 ? matchingIdx : null;
+};
 
-  return cutIdx;
+const keptTailHasOrphanedToolResult = (liveMessages: EntryWithMessage[], cutIdx: number): boolean => {
+  for (let i = cutIdx; i < liveMessages.length; i++) {
+    const message = liveMessages[i]?.message;
+    if (message.role !== "toolResult" || !message.toolCallId) continue;
+    if (findMatchingToolCallIndex(liveMessages, message.toolCallId, i - 1) < cutIdx) return true;
+  }
+  return false;
 };
 
 const liveMessagesSinceLastCompaction = (branchEntries: any[]): EntryWithMessage[] => {
+  return readLiveMessagesSinceLastCompaction(branchEntries).liveMessages;
+};
+
+const readLiveMessagesSinceLastCompaction = (branchEntries: any[]): {
+  liveMessages: EntryWithMessage[];
+  firstKeptEntryId?: string;
+  hadPreviousCompaction: boolean;
+} => {
   let lastKeptId: string | undefined;
   for (let i = branchEntries.length - 1; i >= 0; i--) {
     if (branchEntries[i].type === "compaction") {
@@ -142,11 +165,10 @@ const liveMessagesSinceLastCompaction = (branchEntries: any[]): EntryWithMessage
       liveMessages.push({ entry: e, message: e.message });
     }
   }
-  return liveMessages;
+  return { liveMessages, firstKeptEntryId: lastKeptId, hadPreviousCompaction: Boolean(lastKeptId) };
 };
 
-const inferActiveTurnFromBranchEntries = (branchEntries: any[]): boolean => {
-  const liveMessages = liveMessagesSinceLastCompaction(branchEntries);
+const inferActiveTurnFromMessages = (liveMessages: EntryWithMessage[]): boolean => {
   const latest = liveMessages[liveMessages.length - 1]?.message as any;
   if (!latest) return false;
 
@@ -160,6 +182,35 @@ const inferActiveTurnFromBranchEntries = (branchEntries: any[]): boolean => {
   }
 
   return false;
+};
+
+const inferActiveTurnFromBranchEntries = (branchEntries: any[]): boolean =>
+  inferActiveTurnFromMessages(liveMessagesSinceLastCompaction(branchEntries));
+
+const classifyNoCut = (
+  branchEntries: any[],
+  eventContext: { reason?: CompactionReason; willRetry: boolean },
+): NoCutClassification => {
+  const { liveMessages, firstKeptEntryId, hadPreviousCompaction } = readLiveMessagesSinceLastCompaction(branchEntries);
+  const latestLiveRole = liveMessages[liveMessages.length - 1]?.message?.role;
+  const activeTurnInferred = inferActiveTurnFromMessages(liveMessages);
+  const reason = liveMessages.length < MIN_MESSAGES_TO_COMPACT
+    ? hadPreviousCompaction
+      ? "post_compaction_tail_too_short"
+      : "tiny_session"
+    : activeTurnInferred
+      ? "active_turn_no_safe_cut"
+      : "unknown_no_safe_cut";
+  return {
+    reason,
+    hadPreviousCompaction,
+    liveMessageCount: liveMessages.length,
+    latestLiveRole,
+    activeTurnInferred,
+    firstKeptEntryId,
+    compactionReason: eventContext.reason,
+    willRetry: eventContext.willRetry,
+  };
 };
 
 function buildOwnCut(
@@ -183,10 +234,13 @@ function buildOwnCut(
     if (keepUserTurnsExplicit) return null;
     if (liveMessages.length <= AGENT_ONLY_FALLBACK_TAIL_MESSAGES) return null;
     cutIdx = liveMessages.length - AGENT_ONLY_FALLBACK_TAIL_MESSAGES;
-    cutIdx = adjustCutIdxForToolResult(liveMessages, cutIdx);
+    const adjustedCutIdx = adjustCutIdxForToolResult(liveMessages, cutIdx);
+    if (adjustedCutIdx === null) return null;
+    cutIdx = adjustedCutIdx;
   }
 
   if (cutIdx <= 0) return null;
+  if (keptTailHasOrphanedToolResult(liveMessages, cutIdx)) return null;
 
   return {
     messages: liveMessages.slice(0, cutIdx).map((e) => e.message),
@@ -250,7 +304,8 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
 
   pi.on("session_before_compact", (event) => {
     const { preparation, branchEntries, customInstructions } = event;
-    const { reason, willRetry } = readCompactionEventContext(event);
+    const eventContext = readCompactionEventContext(event);
+    const { reason, willRetry } = eventContext;
     const compactionIntent = parseCompactionIntent(customInstructions);
     const compactingActiveTurn =
       (agentTurnActive && !activeAgentFinishedResponse) || inferActiveTurnFromBranchEntries(branchEntries as any[]);
@@ -259,9 +314,13 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI) => {
     const ownCut = buildOwnCut(branchEntries as any[], keepOptions.keepUserTurns, keepOptions.explicit);
     if (!ownCut) {
       const piVccBypass = customInstructions?.startsWith(PI_VCC_COMPACT_INSTRUCTION) ?? false;
+      lastNoCutClassification = classifyNoCut(branchEntries as any[], eventContext);
+      dbg(loadConfig(), { usedOwnCut: false, noCutClassification: lastNoCutClassification });
       if (!piVccBypass && (reason === "manual" || reason === "threshold" || reason === "overflow" || willRetry)) return;
       return { cancel: true };
     }
+
+    lastNoCutClassification = null;
 
     if (compactingActiveTurn) agentTurnActive = false;
 

--- a/_pi/packages/pi-vcc/src/types.ts
+++ b/_pi/packages/pi-vcc/src/types.ts
@@ -17,6 +17,24 @@ export type PiMessage = Message | BashExecutionMessage;
 
 export type CompactionReason = "manual" | "threshold" | "overflow";
 
+export type NoCutReason =
+  | "tiny_session"
+  | "already_compacted"
+  | "post_compaction_tail_too_short"
+  | "active_turn_no_safe_cut"
+  | "unknown_no_safe_cut";
+
+export interface NoCutClassification {
+  reason: NoCutReason;
+  hadPreviousCompaction: boolean;
+  liveMessageCount: number;
+  latestLiveRole?: string;
+  activeTurnInferred: boolean;
+  firstKeptEntryId?: string;
+  compactionReason?: CompactionReason;
+  willRetry?: boolean;
+}
+
 export interface CompactionIntent {
   source?: string;
   reason?: string;

--- a/_pi/packages/pi-vcc/tests/before-compact.test.ts
+++ b/_pi/packages/pi-vcc/tests/before-compact.test.ts
@@ -73,6 +73,8 @@ const compactableEntries = () => [
   messageEntry("4", assistantText("Working on it.")),
 ];
 
+const compactionEntry = (id: string, firstKeptEntryId: string) => ({ id, type: "compaction", firstKeptEntryId });
+
 const delay = (ms = 75) => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe("before-compact cut policy", () => {
@@ -98,6 +100,31 @@ describe("before-compact cut policy", () => {
     expect(result.compaction.summary).toContain("I found the hook.");
   });
 
+  it("falls back to compacting long post-compaction agent-only tails", async () => {
+    const handler = await getBeforeCompactHandler();
+    const result = handler({
+      preparation: basePreparation,
+      branchEntries: [
+        messageEntry("1", userMsg("Old request")),
+        messageEntry("2", assistantText("Old answer")),
+        compactionEntry("c1", "3"),
+        messageEntry("3", assistantText("Kept prior summary boundary.")),
+        messageEntry("4", assistantWithToolCall("Read", { path: "a.ts" }, "tc_a")),
+        messageEntry("5", toolResult("Read", "hook source", false, "tc_a")),
+        messageEntry("6", assistantText("Interpreted hook source.")),
+        messageEntry("7", assistantWithToolCall("Read", { path: "b.ts" }, "tc_b")),
+        messageEntry("8", toolResult("Read", "test source", false, "tc_b")),
+        messageEntry("9", assistantText("Ready to patch.")),
+      ],
+      reason: "threshold",
+    });
+
+    expect(result.cancel).toBeUndefined();
+    expect(result.compaction.firstKeptEntryId).toBe("6");
+    expect(result.compaction.summary).toContain("Kept prior summary boundary.");
+    expect(result.compaction.summary).toContain('Read "a.ts"');
+  });
+
   it("keeps the matching assistant tool call live when fallback would start at a tool result", async () => {
     const handler = await getBeforeCompactHandler();
     const result = handler({
@@ -115,6 +142,26 @@ describe("before-compact cut policy", () => {
 
     expect(result.cancel).toBeUndefined();
     expect(result.compaction.firstKeptEntryId).toBe("3");
+  });
+
+  it("does not cut when a fallback boundary would orphan a tool result without a matching call", async () => {
+    const handler = await getBeforeCompactHandler();
+    const result = handler({
+      preparation: basePreparation,
+      branchEntries: [
+        messageEntry("1", userMsg("Investigate the compaction bug")),
+        messageEntry("2", assistantText("I found the hook.")),
+        messageEntry("3", assistantText("More analysis.")),
+        messageEntry("4", assistantText("More setup.")),
+        messageEntry("5", toolResult("Read", "orphaned source", false, "tc_missing")),
+        messageEntry("6", assistantWithToolCall("Read", { path: "b.ts" }, "tc_b")),
+        messageEntry("7", toolResult("Read", "test source", false, "tc_b")),
+        messageEntry("8", assistantText("The fallback cannot safely keep an orphaned tool result.")),
+      ],
+      customInstructions: "__PI_VCC_MANUAL_BYPASS__",
+    });
+
+    expect(result).toEqual({ cancel: true });
   });
 
   it("still prefers the latest user boundary when one exists", async () => {
@@ -197,6 +244,99 @@ describe("compaction intent and overflow fallback", () => {
     });
 
     expect(result).toBeUndefined();
+  });
+
+  it("classifies tiny no-cut sessions for diagnosis", async () => {
+    const { registerBeforeCompactHook, getLastNoCutClassification } = await import("../src/hooks/before-compact");
+    const handlers: Record<string, Array<(event: any) => any>> = {};
+    registerBeforeCompactHook({
+      on: (eventName: string, callback: (event: any) => any) => {
+        handlers[eventName] ??= [];
+        handlers[eventName].push(callback);
+      },
+      sendMessage: () => {},
+    } as any);
+
+    const result = handlers.session_before_compact[0]({
+      preparation: basePreparation,
+      branchEntries: [messageEntry("1", userMsg("too small"))],
+      reason: "overflow",
+      willRetry: true,
+    });
+
+    expect(result).toBeUndefined();
+    expect(getLastNoCutClassification()).toMatchObject({
+      reason: "tiny_session",
+      liveMessageCount: 1,
+      hadPreviousCompaction: false,
+      activeTurnInferred: false,
+      compactionReason: "overflow",
+      willRetry: true,
+    });
+  });
+
+  it("classifies post-compaction tails that are too short", async () => {
+    const { registerBeforeCompactHook, getLastNoCutClassification } = await import("../src/hooks/before-compact");
+    const handlers: Record<string, Array<(event: any) => any>> = {};
+    registerBeforeCompactHook({
+      on: (eventName: string, callback: (event: any) => any) => {
+        handlers[eventName] ??= [];
+        handlers[eventName].push(callback);
+      },
+      sendMessage: () => {},
+    } as any);
+
+    const result = handlers.session_before_compact[0]({
+      preparation: basePreparation,
+      branchEntries: [
+        messageEntry("1", userMsg("old")),
+        messageEntry("2", assistantText("old response")),
+        compactionEntry("c1", "3"),
+        messageEntry("3", assistantText("kept tail")),
+        messageEntry("4", assistantText("short tail")),
+      ],
+      reason: "threshold",
+    });
+
+    expect(result).toBeUndefined();
+    expect(getLastNoCutClassification()).toMatchObject({
+      reason: "post_compaction_tail_too_short",
+      liveMessageCount: 2,
+      hadPreviousCompaction: true,
+      latestLiveRole: "assistant",
+      compactionReason: "threshold",
+    });
+  });
+
+  it("classifies active-turn no-safe-cut cancellations", async () => {
+    const { registerBeforeCompactHook, getLastNoCutClassification } = await import("../src/hooks/before-compact");
+    const handlers: Record<string, Array<(event: any) => any>> = {};
+    registerBeforeCompactHook({
+      on: (eventName: string, callback: (event: any) => any) => {
+        handlers[eventName] ??= [];
+        handlers[eventName].push(callback);
+      },
+      sendMessage: () => {},
+    } as any);
+
+    const result = handlers.session_before_compact[0]({
+      preparation: basePreparation,
+      branchEntries: [
+        messageEntry("1", userMsg("old")),
+        messageEntry("2", assistantWithToolCall("Read", { path: "a.ts" }, "tc_a")),
+        messageEntry("3", toolResult("Read", "source", false, "tc_a")),
+      ],
+      customInstructions: "__PI_VCC_MANUAL_BYPASS__\nkeep:2",
+    });
+
+    expect(result).toEqual({ cancel: true });
+    expect(getLastNoCutClassification()).toMatchObject({
+      reason: "active_turn_no_safe_cut",
+      liveMessageCount: 3,
+      hadPreviousCompaction: false,
+      latestLiveRole: "toolResult",
+      activeTurnInferred: true,
+    });
   });
 
   it("lets the hard backstop fall back when pi-vcc cannot form a cut", async () => {

--- a/scripts/percentage-compaction.test.ts
+++ b/scripts/percentage-compaction.test.ts
@@ -25,6 +25,10 @@ const setup = (
   const notifications: Array<{ message: string; level: string }> = [];
   const compactCalls: Array<any> = [];
   const sentMessages: Array<{ message: any; options: any }> = [];
+  let remainingSendMessageFailures = options.sendMessageThrows ? Number.POSITIVE_INFINITY : 0;
+  if (typeof (options as any).sendMessageFailures === "number") {
+    remainingSendMessageFailures = (options as any).sendMessageFailures;
+  }
 
   const ctx = {
     ui: {
@@ -52,7 +56,10 @@ const setup = (
       tools[tool.name] = tool;
     },
     sendMessage: (message: any, messageOptions: any) => {
-      if (options.sendMessageThrows) throw new Error("send failed");
+      if (remainingSendMessageFailures > 0) {
+        remainingSendMessageFailures -= 1;
+        throw new Error("send failed");
+      }
       sentMessages.push({ message, options: messageOptions });
     },
   } as any);
@@ -91,6 +98,11 @@ const assistantToolUse = (toolCount = 1, toolResults = [toolResult()]) => ({
   },
   toolResults,
 });
+const userTurn = (text = "new request") => ({
+  message: { role: "user", content: text },
+  toolResults: [],
+});
+const delay = (ms = 75) => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe("percentage-compaction extension", () => {
   test("does not auto-compact at 60%; sends a model-visible soft nudge", async () => {
@@ -286,6 +298,234 @@ describe("percentage-compaction extension", () => {
     percent = 80.123457;
     await handlers.turn_end?.(assistantStop, ctx);
     expect(compactCalls).toHaveLength(2);
+  });
+
+  test("active hard-backstop no-cut sends one continuation and clears state", async () => {
+    const { handlers, compactCalls, sentMessages, notifications, ctx } = setup(96.2);
+
+    await handlers.turn_end?.(assistantToolUse(1, [toolResult("tc_1", "read", "source")]), ctx);
+    expect(compactCalls).toHaveLength(1);
+    compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0].message.customType).toBe("pi-vcc-no-cut-continuation");
+    expect(sentMessages[0].message.content).toContain("no safe compaction cut was available");
+    expect(sentMessages[0].options).toEqual({ deliverAs: "steer", triggerTurn: true });
+    expect(notifications.some((entry) => entry.message.includes("No safe compaction cut available"))).toBe(true);
+
+    await handlers.turn_end?.(assistantStop, ctx);
+    expect(compactCalls).toHaveLength(1);
+  });
+
+  test("hard-backstop no-cut defers continuation until pending tool results are delivered", async () => {
+    const { handlers, compactCalls, sentMessages, ctx } = setup(96.2);
+
+    await handlers.turn_end?.(assistantToolUse(2, []), ctx);
+    await handlers.turn_end?.({ message: toolResult("tc_1", "compact_context", "queued"), toolResults: [] }, ctx);
+    compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+    expect(sentMessages).toHaveLength(0);
+
+    await handlers.turn_end?.({ message: toolResult("tc_2", "read", "source"), toolResults: [] }, ctx);
+    await delay();
+    expect(sentMessages).toHaveLength(1);
+  });
+
+  test("no-cut continuation retries once then succeeds", async () => {
+    const { handlers, compactCalls, sentMessages, notifications, ctx } = setup(96.2, true, { sendMessageFailures: 1 } as any);
+
+    await handlers.turn_end?.(assistantToolUse(1, [toolResult("tc_1", "read", "source")]), ctx);
+    compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay(700);
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0].message.details.deliveryAttempts).toBe(2);
+    expect(notifications.some((entry) => entry.message.includes("delivery failed after"))).toBe(false);
+  });
+
+  test("permanent no-cut continuation delivery failure warns without stuck compaction", async () => {
+    const originalDateNow = Date.now;
+    let now = 0;
+    Date.now = () => {
+      now += 6000;
+      return now;
+    };
+    try {
+      const { handlers, compactCalls, notifications, ctx } = setup(96.2, true, { sendMessageThrows: true });
+
+      await handlers.turn_end?.(assistantToolUse(1, [toolResult("tc_1", "read", "source")]), ctx);
+      compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+      await delay();
+
+      expect(notifications.some((entry) => entry.level === "warning" && entry.message.includes("No-cut continuation delivery failed"))).toBe(true);
+      await handlers.turn_end?.(assistantStop, ctx);
+      expect(compactCalls).toHaveLength(1);
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
+  test("idle hard-backstop no-cut does not auto-resume", async () => {
+    const { handlers, compactCalls, sentMessages, ctx } = setup(96.2);
+
+    await handlers.turn_end?.(assistantStop, ctx);
+    compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+
+    expect(sentMessages).toHaveLength(0);
+  });
+
+  test("user-message hard-backstop no-cut does not auto-resume", async () => {
+    const { handlers, compactCalls, sentMessages, ctx } = setup(96.2);
+
+    await handlers.turn_end?.(userTurn("new instruction"), ctx);
+    expect(compactCalls).toHaveLength(1);
+    compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+
+    expect(sentMessages).toHaveLength(0);
+  });
+
+  test("manual and compact_context no-cut do not auto-resume", async () => {
+    const manual = setup(96.2);
+    await manual.commands["compact-now"].handler("", manual.ctx);
+    manual.compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+    expect(manual.sentMessages).toHaveLength(0);
+
+    const model = setup(96.2);
+    await model.tools.compact_context.execute("tc_1", { reason: "boundary", boundary: "after_test_loop" });
+    await model.handlers.turn_end?.(assistantToolUse(1, [toolResult("tc_1")]), model.ctx);
+    model.compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+    expect(model.sentMessages).toHaveLength(0);
+  });
+
+  test("same floored no-cut percent is suppressed until usage rises or a user speaks", async () => {
+    let percent = 96.2;
+    const { handlers, compactCalls, ctx } = setup(() => percent);
+
+    await handlers.turn_end?.(assistantToolUse(1, [toolResult("tc_1", "read", "source")]), ctx);
+    compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+
+    percent = 95.9;
+    await handlers.turn_end?.(assistantStop, ctx);
+    expect(compactCalls).toHaveLength(1);
+
+    percent = 96.9;
+    await handlers.turn_end?.(assistantStop, ctx);
+    expect(compactCalls).toHaveLength(1);
+
+    percent = 97.0;
+    await handlers.turn_end?.(assistantStop, ctx);
+    expect(compactCalls).toHaveLength(2);
+
+    compactCalls[1].onError(new Error("Nothing to compact (session too small)"));
+    await handlers.message_end?.(userTurn("new instruction"), ctx);
+    await handlers.turn_end?.(assistantStop, ctx);
+    expect(compactCalls).toHaveLength(3);
+  });
+
+  test("model-visible no-cut continuation does not re-arm retry suppression as user input", async () => {
+    const { handlers, compactCalls, sentMessages, ctx } = setup(96.2);
+
+    await handlers.turn_end?.(assistantToolUse(1, [toolResult("tc_1", "read", "source")]), ctx);
+    compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+    expect(sentMessages).toHaveLength(1);
+
+    await handlers.message_end?.({ message: { role: "user", customType: "pi-vcc-no-cut-continuation" } }, ctx);
+    await handlers.turn_end?.(assistantStop, ctx);
+    expect(compactCalls).toHaveLength(1);
+  });
+
+  test("no-cut reset allows later interrupted hard-backstop attempt", async () => {
+    let percent = 96.2;
+    const { handlers, compactCalls, ctx } = setup(() => percent);
+
+    await handlers.turn_end?.(assistantToolUse(1, [toolResult("tc_1", "read", "source")]), ctx);
+    compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+
+    percent = 97.0;
+    await handlers.turn_end?.(assistantToolUse(1, []), ctx);
+    expect(compactCalls).toHaveLength(2);
+  });
+
+  test("core auto-compaction is canceled above hard threshold unless extension-managed", async () => {
+    const { handlers, notifications, ctx } = setup(96.9);
+
+    const result = await handlers.session_before_compact?.({ customInstructions: undefined }, ctx);
+
+    expect(result).toEqual({ cancel: true });
+    expect(notifications.some((entry) => entry.message.includes("repo-managed hard backstop handles 96%"))).toBe(true);
+  });
+
+  test("core auto-compaction honors same floored no-cut suppression", async () => {
+    let percent = 96.2;
+    const { handlers, compactCalls, notifications, ctx } = setup(() => percent);
+
+    await handlers.turn_end?.(assistantToolUse(1, [toolResult("tc_1", "read", "source")]), ctx);
+    compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+
+    percent = 96.9;
+    const suppressed = await handlers.session_before_compact?.({ customInstructions: undefined }, ctx);
+    expect(suppressed).toEqual({ cancel: true });
+    expect(notifications.some((entry) => entry.message.includes("no safe cut was available at 96%"))).toBe(true);
+
+    await handlers.message_end?.(userTurn("new instruction"), ctx);
+    percent = 96.2;
+    await handlers.turn_end?.(assistantStop, ctx);
+    expect(compactCalls).toHaveLength(2);
+    const extensionManaged = await handlers.session_before_compact?.({ customInstructions: undefined }, ctx);
+    expect(extensionManaged).toBeUndefined();
+    expect(notifications.some((entry) => entry.message.includes("Auto-compacting at 96%"))).toBe(true);
+
+    compactCalls[1].onError(new Error("Nothing to compact (session too small)"));
+    percent = 97.0;
+    const rearmedByUsage = await handlers.session_before_compact?.({ customInstructions: undefined }, ctx);
+    expect(rearmedByUsage).toEqual({ cancel: true });
+  });
+
+  test("successful core compaction clears no-cut retry suppression", async () => {
+    let percent = 96.2;
+    const { handlers, compactCalls, ctx } = setup(() => percent);
+
+    await handlers.turn_end?.(assistantToolUse(1, [toolResult("tc_1", "read", "source")]), ctx);
+    compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+
+    await handlers.session_compact?.({}, ctx);
+    percent = 80.5;
+    await handlers.turn_end?.(assistantStop, ctx);
+
+    expect(compactCalls).toHaveLength(2);
+  });
+
+  test("new compaction attempt clears stale pending no-cut continuation", async () => {
+    let percent = 96.2;
+    const { handlers, compactCalls, sentMessages, ctx } = setup(() => percent);
+
+    await handlers.turn_end?.(assistantToolUse(2, []), ctx);
+    expect(compactCalls).toHaveLength(1);
+    compactCalls[0].onError(new Error("Nothing to compact (session too small)"));
+    await delay();
+    expect(sentMessages).toHaveLength(0);
+
+    percent = 97.0;
+    await handlers.turn_end?.(assistantToolUse(1, []), ctx);
+    expect(compactCalls).toHaveLength(2);
+
+    await handlers.turn_end?.({
+      message: toolResult("tc_1", "compact_context", "queued"),
+      toolResults: [toolResult("tc_2", "read", "source")],
+    }, ctx);
+    await delay();
+
+    expect(sentMessages).toHaveLength(0);
   });
 
   test("does not compact during post-compaction tool turns even when usage changes", async () => {

--- a/thoughts/plans/pi-vcc-no-cut-hard-backstop-recovery.html
+++ b/thoughts/plans/pi-vcc-no-cut-hard-backstop-recovery.html
@@ -1,0 +1,493 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Pi VCC No-Cut Hard-Backstop Recovery Plan</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111f;
+      --panel: #101827;
+      --panel-2: #152235;
+      --panel-3: #1c2d45;
+      --text: #e6edf7;
+      --muted: #a8b3c7;
+      --accent: #70e1ff;
+      --accent-2: #a78bfa;
+      --ok: #58d68d;
+      --warn: #f6c453;
+      --danger: #ff7b7b;
+      --border: #2a3b55;
+      --code: #020817;
+      --shadow: rgba(0, 0, 0, 0.34);
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      background:
+        radial-gradient(circle at 12% 0%, rgba(112, 225, 255, 0.12), transparent 30rem),
+        radial-gradient(circle at 88% 12%, rgba(167, 139, 250, 0.12), transparent 28rem),
+        var(--bg);
+      color: var(--text);
+      font: 16px/1.62 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main { width: min(1220px, calc(100vw - 48px)); margin: 0 auto; padding: 40px 0 76px; }
+    header, section, article {
+      background: rgba(16, 24, 39, 0.88);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      box-shadow: 0 22px 70px var(--shadow);
+      margin: 18px 0;
+      padding: 24px;
+    }
+    header { padding: 32px; }
+    h1, h2, h3, h4 { line-height: 1.2; margin: 0 0 12px; }
+    h1 { font-size: clamp(2.1rem, 5vw, 4rem); letter-spacing: -0.045em; }
+    h2 { font-size: 1.55rem; color: #f8fbff; }
+    h3 { font-size: 1.15rem; color: #dbeafe; margin-top: 20px; }
+    h4 { font-size: 1rem; color: #c4d7ff; margin-top: 16px; }
+    p { margin: 0 0 12px; }
+    a { color: var(--accent); text-decoration-color: rgba(112, 225, 255, 0.45); }
+    code, pre { background: var(--code); color: #d1fae5; border-radius: 10px; }
+    code { padding: 0.15em 0.35em; }
+    pre { padding: 14px; overflow-x: auto; border: 1px solid var(--border); }
+    ul, ol { padding-left: 1.35rem; }
+    li { margin: 0.4rem 0; }
+    table { width: 100%; border-collapse: collapse; margin: 14px 0; }
+    th, td { border: 1px solid var(--border); padding: 10px; vertical-align: top; }
+    th { background: var(--panel-2); text-align: left; color: #f8fbff; }
+    .muted { color: var(--muted); }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 5px 11px;
+      margin: 0 8px 8px 0;
+      background: rgba(112, 225, 255, 0.08);
+      color: var(--accent);
+      font-size: 0.9rem;
+    }
+    .badge.warn { color: var(--warn); background: rgba(246, 196, 83, 0.1); }
+    .badge.ready { color: var(--ok); background: rgba(88, 214, 141, 0.1); }
+    .toc-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 14px; }
+    .toc-card { background: rgba(21, 34, 53, 0.78); border: 1px solid var(--border); border-radius: 16px; padding: 16px; }
+    .toc-card strong { display: block; color: #f8fbff; margin-bottom: 8px; }
+    .toc-card a { display: block; margin: 6px 0; text-decoration: none; }
+    .attention { border-left: 5px solid var(--warn); }
+    .criteria { border-left: 5px solid var(--ok); }
+    .phase { border-left: 5px solid var(--accent-2); }
+    .risk { border-left: 5px solid var(--danger); }
+    .progress-list label { display: block; padding: 8px 0; }
+    .callout { background: rgba(28, 45, 69, 0.72); border: 1px solid var(--border); border-radius: 14px; padding: 14px; }
+  </style>
+</head>
+<body>
+<main>
+  <header id="title">
+    <p>
+      <span class="badge">Doct review plan</span>
+      <span class="badge ready">Status: execution-ready</span>
+      <span class="badge ready">Execution-ready: true</span>
+    </p>
+    <h1>Pi VCC No-Cut Hard-Backstop Recovery Plan</h1>
+    <p class="muted">Plan to prevent Pi VCC hard-backstop compaction from halting active sessions when reported context is high but no safe compaction cut exists.</p>
+  </header>
+
+  <section id="toc" aria-labelledby="toc-heading">
+    <h2 id="toc-heading">Table of contents</h2>
+    <div class="toc-grid">
+      <div class="toc-card">
+        <strong>Readiness</strong>
+        <a href="#status">Status</a>
+        <a href="#goal">Goal</a>
+        <a href="#decision-attention">Decision Attention / Low-confidence Areas</a>
+        <a href="#why">Why this plan exists</a>
+      </div>
+      <div class="toc-card">
+        <strong>Evidence</strong>
+        <a href="#authority-inputs">Authority and inputs</a>
+        <a href="#current-reality">Current implementation reality</a>
+        <a href="#product-intent">Product intent alignment</a>
+        <a href="#locked-decisions">Locked decisions</a>
+      </div>
+      <div class="toc-card">
+        <strong>Execution</strong>
+        <a href="#progress">Progress</a>
+        <a href="#acceptance-criteria">Acceptance criteria</a>
+        <a href="#bdd-scenarios">BDD scenarios</a>
+        <a href="#phases">Phase-by-phase execution plan</a>
+      </div>
+      <div class="toc-card">
+        <strong>Handoff</strong>
+        <a href="#verification-strategy">Verification strategy</a>
+        <a href="#delivery-order">Delivery order</a>
+        <a href="#non-goals">Non-goals</a>
+        <a href="#resume-instructions">Resume instructions</a>
+        <a href="#decisions-log">Decisions / Deviations log</a>
+      </div>
+    </div>
+  </section>
+
+  <section id="status">
+    <h2>Status</h2>
+    <p><strong>Browser-review state:</strong> execution-ready request processed and resolved.</p>
+    <p><strong>Execution readiness:</strong> true. Browser action was processed, GPT and GLM readiness findings were integrated, and fresh independent GPT plus GLM rereviews returned <code>VERDICT: PLAN_EXECUTION_READY</code>. The plan has no known product decision blocker.</p>
+    <p><strong>Scope:</strong> repo-owned Pi VCC package and percentage-compaction extension only; no Pi core/provider accounting changes in this implementation plan.</p>
+  </section>
+
+  <section id="goal">
+    <h2>Goal</h2>
+    <p>Make hard-backstop compaction resilient: when Pi reports high context usage but pi-vcc/core cannot form a safe cut, the active agent session should continue instead of halting with <code>Compaction failed: Nothing to compact (session too small)</code>.</p>
+    <p>The fix should distinguish no-cut states, recover active turns with a continuation, avoid repeated no-cut loops, and preserve existing pi-vcc safety boundaries.</p>
+  </section>
+
+  <section id="decision-attention" class="attention">
+    <h2>Decision Attention / Low-confidence Areas</h2>
+    <ul>
+      <li><strong>No product decision required:</strong> this is a reliability bug in an agent workflow; default behavior should self-heal and continue.</li>
+      <li><strong>Low confidence to defer:</strong> Pi core/provider context accounting may still over-report usage after compaction. This plan intentionally mitigates halt behavior in pi-vcc first and records core accounting as a non-goal/follow-up.</li>
+      <li><strong>Review focus:</strong> ensure continuation is sent only when a compaction attempt likely interrupted an active turn, waits until tool-call/tool-result ordering is safe, and survives transient continuation delivery failures.</li>
+    </ul>
+  </section>
+
+  <section id="why">
+    <h2>Why this plan exists</h2>
+    <p>A real session in <code>jul5-quarantine-investigation</code> showed the extension interrupting an agent at high reported context:</p>
+    <pre><code>↻ Context at 96% (hard backstop: 80%). Interrupting agent for pi-vcc compaction...
+Error: Compaction failed: Nothing to compact (session too small)
+Nothing to compact</code></pre>
+    <p>Inspection showed a prior pi-vcc compaction had already summarized the old history, and the live post-compaction tail was mostly in-flight agent/tool turns. Core compaction could not find a safe old segment to summarize, but the extension still treated the hard-backstop attempt as an interrupting compaction. The result was a halted workflow instead of a recoverable no-op with continuation.</p>
+  </section>
+
+  <section id="authority-inputs">
+    <h2>Authority and inputs</h2>
+    <ul>
+      <li>User requirement: prioritize avoiding halted sessions; UI context mismatch can be fixed later.</li>
+      <li>Observed session file: <code>/Users/anichols/.pi/agent/sessions/--Users-anichols-.herdr-worktrees-heddle-jul5-quarantine-investigation--/2026-07-05T22-31-58-285Z_019f3468-e84d-7cfb-8998-8c9a80c4566f.jsonl</code>.</li>
+      <li>Repo guidance: <code>AGENTS.md</code> says work directly on <code>main</code> for ai-configs and update task/progress artifacts immediately when executing plans.</li>
+      <li>Existing plan context: <code>thoughts/plans/pi-vcc-semantic-compaction-plan.html</code>.</li>
+      <li>Relevant implementation files: <code>_pi/extensions/percentage-compaction.ts</code> and <code>_pi/packages/pi-vcc/src/hooks/before-compact.ts</code>.</li>
+      <li>Relevant tests: <code>scripts/percentage-compaction.test.ts</code> and <code>_pi/packages/pi-vcc/tests/before-compact.test.ts</code>.</li>
+    </ul>
+  </section>
+
+  <section id="current-reality">
+    <h2>Current implementation reality</h2>
+    <ul>
+      <li><code>_pi/extensions/percentage-compaction.ts</code> triggers hard-backstop compaction at <code>HARD_AUTO_COMPACTION_PERCENT = 80</code> and uses <code>ctx.compact(...)</code>.</li>
+      <li>The extension currently treats <code>Already compacted</code> and <code>Nothing to compact (session too small)</code> as no-op-ish errors by ratcheting the percent and notifying <code>Nothing to compact</code>, but it does not have a clear active-turn no-cut recovery contract.</li>
+      <li><code>_pi/packages/pi-vcc/src/hooks/before-compact.ts</code> has active-turn continuation for successful pi-vcc compactions through <code>session_compact</code>, plus agent-only fallback cuts and tool-result boundary adjustment.</li>
+      <li>When <code>buildOwnCut(...)</code> cannot form a pi-vcc cut, the hook currently lets core fallback for manual/threshold/overflow events without a pi-vcc-specific no-cut classification.</li>
+      <li>Existing tests cover active-turn continuation after successful compaction and some no-cut fallback behavior, but not hard-backstop no-cut recovery from the extension’s <code>onError</code> path.</li>
+      <li>Pi core’s <code>agent-session.js</code> throws <code>Nothing to compact (session too small)</code> when <code>prepareCompaction(...)</code> returns undefined, even when the true state is “post-compaction/no safe cut.” This plan does not edit Pi core.</li>
+    </ul>
+  </section>
+
+  <section id="product-intent">
+    <h2>Product intent alignment</h2>
+    <ul>
+      <li><strong>Golden path:</strong> a long-running Pi agent should continue doing the requested work even if compaction cannot safely reduce context at that instant.</li>
+      <li><strong>Self-healing:</strong> a no-cut hard-backstop attempt is a recoverable condition; the extension should explain it, suppress immediate retry loops, and resume the interrupted work.</li>
+      <li><strong>Fail-closed boundary:</strong> pi-vcc must not force unsafe compaction cuts or drop tool-call/tool-result evidence just to satisfy a context percentage.</li>
+      <li><strong>Agent-legible status:</strong> notifications and continuation content must say what happened and what to do next without requiring source-code inspection.</li>
+      <li><strong>UI impact triage:</strong> no app/browser UI changes. User-visible surfaces are Pi TUI notifications, model-visible steer/follow-up messages, and debug metadata.</li>
+    </ul>
+  </section>
+
+  <section id="locked-decisions">
+    <h2>Locked decisions</h2>
+    <ul>
+      <li>Do not wait for Pi core/provider accounting fixes to prevent halted sessions.</li>
+      <li>Do not broaden this plan into changing context percentage calculation or footer rendering.</li>
+      <li>No-cut recovery must not rewrite existing history, create a compaction entry, mark compaction successful, or drop/cut messages.</li>
+      <li>No-cut recovery may add one model-visible custom continuation event with diagnostic metadata when an active turn was interrupted and continuation delivery is safe.</li>
+      <li>No-cut recovery must not mark a compaction as successful; it should be a recoverable skip with continuation when appropriate.</li>
+      <li>Hard-backstop no-cut retry suppression is required to avoid immediate repeated interruption loops, with an explicit re-arm predicate defined in P4.</li>
+    </ul>
+  </section>
+
+  <section id="progress" class="progress-list">
+    <h2>Progress</h2>
+    <label><input type="checkbox" checked /> P1 — Add no-cut hard-backstop regression coverage</label>
+    <label><input type="checkbox" checked /> P2 — Classify no-cut states in pi-vcc</label>
+    <label><input type="checkbox" checked /> P3 — Recover active hard-backstop no-cut attempts</label>
+    <label><input type="checkbox" checked /> P4 — Add retry suppression and diagnostics</label>
+    <label><input type="checkbox" checked /> P5 — Strengthen pi-vcc fallback cuts safely</label>
+    <label><input type="checkbox" checked /> P6 — Verify, install, and document behavior</label>
+  </section>
+
+  <section id="acceptance-criteria" class="criteria">
+    <h2>Acceptance criteria</h2>
+    <table>
+      <thead><tr><th>ID</th><th>Criterion</th><th>Evidence</th></tr></thead>
+      <tbody>
+        <tr id="ac-1"><td>AC-1</td><td>When hard-backstop compaction gets <code>Nothing to compact (session too small)</code> during an active turn, the extension sends exactly one continuation and clears in-flight state.</td><td>New test in <code>scripts/percentage-compaction.test.ts</code>.</td></tr>
+        <tr id="ac-2"><td>AC-2</td><td>Idle or manual no-cut cases do not auto-resume arbitrary work.</td><td>New negative tests in <code>scripts/percentage-compaction.test.ts</code>.</td></tr>
+        <tr id="ac-3"><td>AC-3</td><td>No-cut states are classified at the pi-vcc hook layer with enough metadata for debug and future diagnosis.</td><td>New tests in <code>_pi/packages/pi-vcc/tests/before-compact.test.ts</code>.</td></tr>
+        <tr id="ac-4"><td>AC-4</td><td>Repeated high usage with the same/no materially changed percent does not immediately interrupt the agent again after a no-cut recovery.</td><td>Retry suppression tests in <code>scripts/percentage-compaction.test.ts</code>.</td></tr>
+        <tr id="ac-5"><td>AC-5</td><td>Successful compactable hard-backstop and <code>compact_context</code> paths keep existing behavior.</td><td>Existing percentage-compaction and pi-vcc tests still pass.</td></tr>
+        <tr id="ac-6"><td>AC-6</td><td>Tool-call/tool-result integrity remains protected when fallback cuts are improved and when no-cut continuation is injected.</td><td>Before-compact tests cover cut boundaries; percentage-extension tests cover continuation deferral until pending tool results are delivered.</td></tr>
+        <tr id="ac-7"><td>AC-7</td><td>Transient no-cut continuation delivery failure is retried boundedly and produces exactly one successfully delivered model-visible continuation; permanent failure leaves an actionable warning and diagnostic state.</td><td>New delivery-failure tests in <code>scripts/percentage-compaction.test.ts</code>.</td></tr>
+        <tr id="ac-8"><td>AC-8</td><td>No-cut recovery resets any post-compaction waiting gate because no compaction occurred.</td><td>Regression test proves a later eligible hard-backstop attempt is not blocked by stale <code>awaitingPostCompactionAssistantResponse</code>.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="bdd-scenarios">
+    <h2>BDD scenarios</h2>
+    <article id="bdd-active-no-cut">
+      <h3>BDD-1 — Active hard-backstop no-cut continues</h3>
+      <p><strong>Given</strong> a prior pi-vcc compaction and a live post-compaction active tool turn, <strong>when</strong> hard-backstop compaction fails with <code>Nothing to compact (session too small)</code>, <strong>then</strong> the extension clears compaction state, resets stale post-compaction wait state, records the no-cut ratchet, shows an agent-legible skip notification, and sends one successfully delivered continuation steer/follow-up after tool-result ordering is safe.</p>
+    </article>
+    <article id="bdd-idle-no-cut">
+      <h3>BDD-2 — Idle no-cut does not resume</h3>
+      <p><strong>Given</strong> no active interrupted agent turn, <strong>when</strong> a no-cut compaction error occurs, <strong>then</strong> the extension reports a recoverable no-op and does not trigger a new agent turn.</p>
+    </article>
+    <article id="bdd-loop-suppression">
+      <h3>BDD-3 — No immediate retry loop</h3>
+      <p><strong>Given</strong> a no-cut hard-backstop recovery at 96%, <strong>when</strong> subsequent tool turns report the same floored percent and no re-arm signal occurred, <strong>then</strong> the extension does not repeatedly interrupt the agent for the same no-cut condition.</p>
+    </article>
+    <article id="bdd-later-compactable">
+      <h3>BDD-4 — Later compactable tail still compacts</h3>
+      <p><strong>Given</strong> a no-cut hard-backstop was recovered earlier, <strong>when</strong> the floored usage percent rises by at least one point or a new user message arrives and enough live history accumulates to form a safe cut, <strong>then</strong> pi-vcc compaction still runs normally and successful continuation behavior remains intact.</p>
+    </article>
+    <article id="bdd-safety-boundary">
+      <h3>BDD-5 — Safety boundary beats forced compaction</h3>
+      <p><strong>Given</strong> a live tail where cutting would orphan a tool result or drop un-interpreted evidence, <strong>when</strong> usage is above the hard backstop, <strong>then</strong> pi-vcc must prefer no-cut recovery over unsafe summary/cut behavior.</p>
+    </article>
+  </section>
+
+  <section id="phases">
+    <h2>Phase-by-phase execution plan</h2>
+
+    <article id="phase-p1-regressions" class="phase">
+      <h2>P1 — Add no-cut hard-backstop regression coverage</h2>
+      <h3>End State</h3>
+      <p>Tests fail on current behavior for the real halt shape and define the required recovery semantics.</p>
+      <h3>Tests first</h3>
+      <ul>
+        <li>Add tests in <code>scripts/percentage-compaction.test.ts</code> for active hard-backstop <code>onError(new Error("Nothing to compact (session too small)"))</code>.</li>
+        <li>Add tests where hard-backstop no-cut happens while an assistant <code>toolUse</code> still has pending tool results; continuation must be deferred until the matching/sibling tool results are delivered or otherwise proven safe by the event state.</li>
+        <li>Add tests where no-cut continuation delivery throws once, then succeeds; assert exactly one successfully delivered model-visible continuation, no stuck <code>compactionInFlight</code>, and preserved retry diagnostics.</li>
+        <li>Add permanent-delivery-failure coverage asserting an actionable warning and no silent loss of recovery state.</li>
+        <li>Add idle/manual and <code>compact_context</code> negative tests proving no unsolicited continuation.</li>
+        <li>Add retry-loop test for repeated no-cut at the same/floored high usage.</li>
+      </ul>
+      <h3>Expected files</h3>
+      <ul><li><code>scripts/percentage-compaction.test.ts</code></li></ul>
+      <h3>Work</h3>
+      <p>Extend the test harness to let tests invoke captured <code>ctx.compact</code> callbacks and inspect <code>pi.sendMessage</code>, notifications, and repeated <code>turn_end</code> behavior.</p>
+      <h3>Open questions / decision dependencies</h3>
+      <p>None.</p>
+      <h3>Verify</h3>
+      <pre><code>bun test scripts/percentage-compaction.test.ts</code></pre>
+    </article>
+
+    <article id="phase-p2-classification" class="phase">
+      <h2>P2 — Classify no-cut states in pi-vcc</h2>
+      <h3>End State</h3>
+      <p>pi-vcc can explain why it cannot form a cut without overloading the core message “session too small.”</p>
+      <h3>Tests first</h3>
+      <ul>
+        <li>Add before-compact tests for <code>tiny_session</code>, <code>post_compaction_tail_too_short</code>, and <code>active_turn_no_safe_cut</code>.</li>
+        <li>Assert classification appears in debug/details for pi-vcc-controlled no-cut paths where available.</li>
+        <li>Add a test proving the hook records the latest no-cut classification when it returns <code>undefined</code> for core fallback, rather than leaving stale successful compaction stats.</li>
+      </ul>
+      <h3>Expected files</h3>
+      <ul>
+        <li><code>_pi/packages/pi-vcc/src/hooks/before-compact.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/src/details.ts</code> if detail typing needs extension</li>
+        <li><code>_pi/packages/pi-vcc/tests/before-compact.test.ts</code></li>
+      </ul>
+      <h3>Work</h3>
+      <ul>
+        <li>Add a <code>NoCutReason</code> union such as <code>tiny_session</code>, <code>already_compacted</code>, <code>post_compaction_tail_too_short</code>, <code>active_turn_no_safe_cut</code>, and <code>unknown_no_safe_cut</code>.</li>
+        <li>Add a small helper that inspects previous compaction presence, live message count since <code>firstKeptEntryId</code>, latest live role, and active-turn inference.</li>
+        <li>Define the cross-package bridge explicitly: export a small <code>getLastNoCutClassification()</code> or extend <code>getLastCompactionStats()</code> so no-cut fallback paths record fresh classification metadata even when the hook returns <code>undefined</code>. The percentage extension may use this when available; otherwise it must report classification as unavailable, not stale.</li>
+        <li>Keep existing fallback-to-core behavior where required; classification should improve diagnosis, not force unsafe compaction.</li>
+      </ul>
+      <h3>Open questions / decision dependencies</h3>
+      <p>None.</p>
+      <h3>Verify</h3>
+      <pre><code>cd _pi/packages/pi-vcc && bun test tests/before-compact.test.ts</code></pre>
+    </article>
+
+    <article id="phase-p3-recovery" class="phase">
+      <h2>P3 — Recover active hard-backstop no-cut attempts</h2>
+      <h3>End State</h3>
+      <p>The extension treats no-cut hard-backstop errors as recoverable skips and resumes active interrupted work.</p>
+      <h3>Tests first</h3>
+      <p>Use the failing P1 tests as the RED contract.</p>
+      <h3>Expected files</h3>
+      <ul><li><code>_pi/extensions/percentage-compaction.ts</code></li></ul>
+      <h3>Work</h3>
+      <ul>
+        <li>Add <code>interruptedActiveTurn</code>, <code>recoverNoCutWithContinuation</code>, and enough pending-tool-result state to <code>triggerCompaction</code> / the surrounding state machine.</li>
+        <li>For hard-backstop calls, set <code>interruptedActiveTurn = !completedResponse</code> and enable no-cut recovery continuation, but defer delivery until pending tool results from the interrupted assistant tool batch have been delivered or a completed assistant boundary proves it is safe.</li>
+        <li>On <code>Already compacted</code> or <code>Nothing to compact (session too small)</code>, clear <code>compactionInFlight</code>, reset <code>awaitingPostCompactionAssistantResponse</code> because no compaction occurred, ratchet the percent, notify <code>No safe compaction cut available; continuing session.</code>, and send a continuation only when the recovery options say the agent was interrupted and delivery is safe.</li>
+        <li>Use <code>pi.sendMessage(..., { deliverAs: "steer", triggerTurn: true })</code> with content that says compaction was skipped because no safe cut was available and the agent should continue from where it left off.</li>
+        <li>Continuation delivery must use bounded retry on transient <code>sendMessage</code> failure, mirroring the existing pi-vcc continuation retry pattern: retry briefly when the session is not ready, deliver exactly one successful continuation, and emit an actionable warning plus diagnostics if delivery permanently fails.</li>
+        <li>Manual <code>/compact-now</code> and <code>compact_context</code> tool paths pass <code>recoverNoCutWithContinuation: false</code> or omit the option so no-cut errors there remain notify-only.</li>
+      </ul>
+      <h3>Open questions / decision dependencies</h3>
+      <p>None.</p>
+      <h3>Verify</h3>
+      <pre><code>bun test scripts/percentage-compaction.test.ts</code></pre>
+    </article>
+
+    <article id="phase-p4-retry-diagnostics" class="phase">
+      <h2>P4 — Add retry suppression and diagnostics</h2>
+      <h3>End State</h3>
+      <p>No-cut recovery does not immediately loop, and future incidents are diagnosable without reading the whole session JSONL.</p>
+      <h3>Tests first</h3>
+      <ul>
+        <li>Add tests for same exact percent and same floored percent retry suppression after no-cut recovery.</li>
+        <li>Add tests that a later materially changed usage or completed assistant boundary can eventually allow another attempt when appropriate.</li>
+      </ul>
+      <h3>Expected files</h3>
+      <ul>
+        <li><code>_pi/extensions/percentage-compaction.ts</code></li>
+        <li><code>scripts/percentage-compaction.test.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/src/hooks/before-compact.ts</code> for debug metadata if needed</li>
+      </ul>
+      <h3>Work</h3>
+      <ul>
+        <li>Track no-cut retry state separately from successful compaction if exact-percent ratchet is not enough.</li>
+        <li>Suppress repeated hard-backstop attempts for the same floored usage percentage, e.g. repeated 96.x, until a concrete re-arm signal occurs.</li>
+        <li>Re-arm no-cut retry suppression when either the floored usage percent increases by at least one point or a new user message is observed since the last no-cut recovery, whichever comes first. A completed assistant boundary alone is not sufficient unless paired with one of those re-arm signals.</li>
+        <li>Include debug facts: reason, usage percent, no-cut classification if available, active-turn flag, pending-tool-result state, delivery retry count, and whether continuation was queued/delivered.</li>
+      </ul>
+      <h3>Open questions / decision dependencies</h3>
+      <p>None.</p>
+      <h3>Verify</h3>
+      <pre><code>bun test scripts/percentage-compaction.test.ts
+cd _pi/packages/pi-vcc && bun test tests/before-compact.test.ts</code></pre>
+    </article>
+
+    <article id="phase-p5-cut-fallback" class="phase">
+      <h2>P5 — Strengthen pi-vcc fallback cuts safely</h2>
+      <h3>End State</h3>
+      <p>When there is genuinely summarizable post-compaction live history, pi-vcc can cut an older prefix without orphaning tool pairs.</p>
+      <h3>Tests first</h3>
+      <ul>
+        <li>Add tests with prior compaction plus long agent-only tail that should become compactable.</li>
+        <li>Add counterexample tests where fallback would orphan tool calls/results and must instead no-cut.</li>
+      </ul>
+      <h3>Expected files</h3>
+      <ul>
+        <li><code>_pi/packages/pi-vcc/src/hooks/before-compact.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/tests/before-compact.test.ts</code></li>
+      </ul>
+      <h3>Work</h3>
+      <ul>
+        <li>Review <code>buildOwnCut(...)</code> and <code>adjustCutIdxForToolResult(...)</code> against the real session shape.</li>
+        <li>Permit summarizing an older prefix of agent/tool messages when enough live messages exist and the kept tail remains coherent.</li>
+        <li>Preserve current safety rule: do not cut in a way that keeps a tool result without its matching assistant tool call or drops fresh un-interpreted evidence.</li>
+      </ul>
+      <h3>Open questions / decision dependencies</h3>
+      <p>None.</p>
+      <h3>Verify</h3>
+      <pre><code>cd _pi/packages/pi-vcc && bun test tests/before-compact.test.ts</code></pre>
+    </article>
+
+    <article id="phase-p6-verify-rollout" class="phase">
+      <h2>P6 — Verify, install, and document behavior</h2>
+      <h3>End State</h3>
+      <p>The implementation is tested, pi-vcc drift remains intentional, and the behavior is available to local Pi after install.</p>
+      <h3>Tests first</h3>
+      <p>No new RED tests expected beyond P1–P5; this phase is integration verification.</p>
+      <h3>Expected files</h3>
+      <ul>
+        <li><code>_pi/extensions/percentage-compaction.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/src/hooks/before-compact.ts</code></li>
+        <li><code>scripts/percentage-compaction.test.ts</code></li>
+        <li><code>_pi/packages/pi-vcc/tests/before-compact.test.ts</code></li>
+        <li><code>_pi/README.md</code> or pi-vcc README only if behavior docs need an update</li>
+      </ul>
+      <h3>Work</h3>
+      <ul>
+        <li>Run full relevant tests.</li>
+        <li>Run pi-vcc upstream drift check.</li>
+        <li>If installable artifacts changed, run the repo’s Pi install path as appropriate for local validation.</li>
+        <li>Record final behavior in documentation only if the operator-visible command/status semantics changed.</li>
+      </ul>
+      <h3>Open questions / decision dependencies</h3>
+      <p>None.</p>
+      <h3>Verify</h3>
+      <pre><code>bun test scripts/percentage-compaction.test.ts
+cd _pi/packages/pi-vcc && bun test
+bash scripts/check-pi-vcc-upstream.sh --summary</code></pre>
+      <p class="muted">There is no repo-local <code>package.json</code> or <code>tsconfig.json</code> typecheck target for these TypeScript extension files. A direct <code>tsc --noEmit</code> probe currently fails on missing ambient Pi/Bun/Node package typings and an existing upstream <code>SegmentData</code> optional-property typing issue, so targeted Bun tests are the authoritative verification unless the implementer first adds a real typecheck harness as a separate prerequisite.</p>
+    </article>
+  </section>
+
+  <section id="verification-strategy">
+    <h2>Verification strategy</h2>
+    <ul>
+      <li><strong>Unit behavior:</strong> percentage extension tests cover nudge, hard-backstop, no-cut, continuation, and retry suppression behavior.</li>
+      <li><strong>pi-vcc hook behavior:</strong> before-compact tests cover cut/no-cut classification and safe cut boundaries.</li>
+      <li><strong>Drift safety:</strong> upstream check proves local pi-vcc deltas remain intentional.</li>
+      <li><strong>Typecheck reality:</strong> no supported repo typecheck command exists for this surface today; do not invent one during implementation. If typecheck support is added, use it as an additional gate, not as a substitute for the targeted behavior tests.</li>
+      <li><strong>Manual smoke:</strong> optional local Pi smoke can be done by triggering a high-context no-cut fixture and confirming the agent receives continuation instead of halting.</li>
+    </ul>
+  </section>
+
+  <section id="delivery-order">
+    <h2>Delivery order</h2>
+    <ol>
+      <li>P1 regression tests lock the halt-prevention contract.</li>
+      <li>P3 extension recovery fixes the user-impacting halt quickly.</li>
+      <li>P4 retry suppression prevents loops.</li>
+      <li>P2 classification and P5 cut fallback improve diagnosis and reduce no-cut frequency.</li>
+      <li>P6 verifies and documents/install-validates the result.</li>
+    </ol>
+    <p class="muted">If implementation sequencing benefits from doing P2 before P3, that is acceptable as long as P1 tests remain the first behavior gate and the user-impacting halt fix is not delayed behind broader refactoring.</p>
+  </section>
+
+  <section id="non-goals">
+    <h2>Non-goals</h2>
+    <ul>
+      <li>No Pi core change to <code>agent-session.js</code>.</li>
+      <li>No provider usage-accounting or footer/UI percentage fix.</li>
+      <li>No replacement of pi-vcc with default Pi compaction.</li>
+      <li>No broad compaction-summary format rewrite outside no-cut diagnostics and safe cut behavior.</li>
+      <li>No changes to unrelated Pi prompts, agents, or skills.</li>
+    </ul>
+  </section>
+
+  <section id="resume-instructions">
+    <h2>Resume instructions</h2>
+    <p>Read this document fully, then execute the first unchecked Progress item. Keep implementation scoped to the files listed in each phase. Update the checkbox for a completed phase immediately after its verification passes. Do not implement Pi core/provider context accounting fixes under this plan; record them as a follow-up if they become necessary.</p>
+  </section>
+
+  <section id="decisions-log">
+    <h2>Decisions / Deviations log</h2>
+    <table>
+      <thead><tr><th>Date</th><th>Decision or deviation</th><th>Reason</th></tr></thead>
+      <tbody>
+        <tr><td>2026-07-06</td><td>Create a dedicated no-cut hard-backstop recovery plan.</td><td>The user’s priority is avoiding halted sessions; UI context mismatch is deferred.</td></tr>
+        <tr><td>2026-07-06</td><td>Keep Pi core/provider usage accounting out of scope.</td><td>The halt can be mitigated in pi-vcc/extension first with smaller blast radius.</td></tr>
+        <tr><td>2026-07-06</td><td>Integrated execution-readiness review findings.</td><td>Added bounded continuation retry, safe continuation timing, no-cut wait-state reset, explicit retry re-arm predicate, classification bridge, manual/compact_context opt-out, and typecheck reality notes.</td></tr>
+        <tr><td>2026-07-06</td><td>Upstream drift check remains blocked by pre-existing stale reviewed-upstream metadata.</td><td><code>bash scripts/check-pi-vcc-upstream.sh --summary</code> exits 2 because reviewed <code>0.3.18</code>/<code>45e93e8</code> no longer matches npm <code>0.4.0</code>/upstream <code>b9e0bab</code>; this run does not re-review upstream uptake.</td></tr>
+        <tr><td>2026-07-06</td><td>Pre-PR review findings were integrated.</td><td>GPT pre-PR review identified core-fallback and user re-arm gaps in the <code>session_before_compact</code> gate; the gate now cancels core hard-backstop fallback and leaves repo-managed <code>turn_end</code> compaction as the recovery path. GLM noted a benign retry-timer cleanup, also fixed. Remaining deferred hardening: optional pre-delivery timeout diagnostics for no-cut continuations that never become safe to send.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="review-record">
+    <h2>Review record</h2>
+    <p><strong>Current state:</strong> GPT and GLM readiness review findings were integrated, then fresh independent GPT and GLM rereviews both returned <code>VERDICT: PLAN_EXECUTION_READY</code> with no readiness issues found.</p>
+    <ul>
+      <li>Initial GPT review: <code>VERDICT: PLAN_NEEDS_REVISION</code>; findings integrated for continuation delivery retry, safe continuation timing, and history-mutation wording.</li>
+      <li>Initial GLM review: <code>VERDICT: PLAN_NEEDS_REVISION</code>; findings integrated for no-cut wait-state reset, retry re-arm predicate, classification bridge, manual path opt-out, and typecheck reality.</li>
+      <li>Final GPT rereview: <code>VERDICT: PLAN_EXECUTION_READY</code>; no readiness issues found.</li>
+      <li>Final GLM rereview: <code>VERDICT: PLAN_EXECUTION_READY</code>; no readiness issues found.</li>
+    </ul>
+  </section>
+</main>
+</body>
+</html>

--- a/thoughts/validation/pre-pr-reviews/2026-07-06-pi-vcc-no-cut-hard-backstop.md
+++ b/thoughts/validation/pre-pr-reviews/2026-07-06-pi-vcc-no-cut-hard-backstop.md
@@ -1,0 +1,64 @@
+# Pre-PR Implementation Review — pi-vcc-no-cut-hard-backstop
+
+Date: 2026-07-06
+Branch: `pi-vcc-no-cut-hard-backstop`
+Plan: `thoughts/plans/pi-vcc-no-cut-hard-backstop-recovery.html`
+Comparison: current branch working tree against repository base; includes committed, staged, and unstaged changes at review time.
+
+## Changed files
+
+- `_pi/README.md`
+- `_pi/extensions/percentage-compaction.ts`
+- `_pi/packages/pi-vcc/README.md`
+- `_pi/packages/pi-vcc/src/hooks/before-compact.ts`
+- `_pi/packages/pi-vcc/src/types.ts`
+- `_pi/packages/pi-vcc/tests/before-compact.test.ts`
+- `scripts/percentage-compaction.test.ts`
+- `thoughts/plans/pi-vcc-no-cut-hard-backstop-recovery.html`
+
+## Scope summary
+
+Implements Pi VCC no-cut hard-backstop recovery so active agent sessions continue when high reported context cannot produce a safe compaction cut. Scope is limited to repo-owned percentage compaction extension, vendored pi-vcc hook/types/tests/docs, and the execution plan. Pi core/provider accounting and UI/footer percentage fixes remain out of scope.
+
+## Verification after final fixes
+
+| Command | Result |
+|---|---|
+| `bun test scripts/percentage-compaction.test.ts` | PASS — 38 pass |
+| `cd _pi/packages/pi-vcc && bun test` | PASS — 156 pass |
+| `git diff --check` | PASS |
+| `bash scripts/check-pi-vcc-upstream.sh --summary` | Expected exit 2 due pre-existing stale upstream metadata: reviewed `0.3.18`/`45e93e8`, latest `0.4.0`/`b9e0bab`; documented in plan decision log |
+
+## Review cycles
+
+| Cycle | GPT verdict | GLM verdict | Notes |
+|---|---|---|---|
+| Scoped implementation review | `PASS_WITH_DOCUMENTED_OUT_OF_SCOPE_FOLLOW_UPS` | `PASS_WITH_DOCUMENTED_OUT_OF_SCOPE_FOLLOW_UPS` | GLM prior findings resolved; GPT noted core-gate/README follow-ups, GLM noted optional pre-delivery timeout hardening. Core-gate and README items were fixed; optional timeout remains deferred. |
+| Pre-PR initial gate | `FINDINGS_TO_RESOLVE` | `CLEAN_FOR_PR` | GPT found P2 core high-usage fallback halt path and P3 exact unchanged user re-arm gap. GLM noted non-blocking retry timer cleanup. |
+| Pre-PR follow-up | `FINDINGS_TO_RESOLVE` | `CLEAN_FOR_PR` | GPT found exact unchanged user re-arm still blocked by `session_before_compact` stale check. GLM noted conditional non-blocking user counter issue from injected continuation messages. |
+| Final narrow gate | `CLEAN_FOR_PR` | `CLEAN_FOR_PR` | Both prior findings resolved with tests. |
+
+## Triage table
+
+| Finding | Reviewer | Severity | Scope | Decision | Evidence |
+|---|---|---|---|---|---|
+| `noCutRetryState` not cleared on successful non-extension/core compaction | GLM scoped review | P2 | IN_PLAN | Fixed | `session_compact` now clears `noCutRetryState`; regression `successful core compaction clears no-cut retry suppression`. |
+| Stale `pendingNoCutContinuation` could outlive a new compaction | GLM scoped review | P3 | IN_PLAN | Fixed | `triggerCompaction` and `session_compact` clear pending no-cut continuation; regression `new compaction attempt clears stale pending no-cut continuation`. |
+| Unused `noCutClassification` details field | GLM scoped review | P3 | IN_PLAN | Fixed | Removed unused field from details typing; classification bridge remains `getLastNoCutClassification()`. |
+| Core `session_before_compact` same-floored suppression gap | GPT scoped review | P3 | OUT_OF_SCOPE_FOLLOW_UP then fixed | Fixed | Core gate now suppresses same-floored no-cut and cancels non-extension hard-backstop fallback; regression coverage added. |
+| README threshold wording stale | GPT scoped review | P3 | OUT_OF_SCOPE_FOLLOW_UP then fixed | Fixed | `_pi/README.md` now distinguishes nudge thresholds from `HARD_AUTO_COMPACTION_PERCENT`. |
+| Core high-usage compaction could fall through to unhandled core no-cut halt | GPT pre-PR initial gate | P2 | IN_PLAN | Fixed | `session_before_compact` cancels non-extension core hard-backstop attempts and leaves extension-managed `turn_end` compaction as recovery path; regression `core auto-compaction is canceled above hard threshold unless extension-managed`. |
+| Core gate ignored new-user re-arm when usage exactly unchanged | GPT pre-PR initial/follow-up | P3 | IN_PLAN | Fixed | `session_before_compact` allows extension-managed `compactionInFlight` attempts before stale cancellation; regression covers exact `96.2%` user re-arm. |
+| Retry catch replaced pending timer without clearing | GLM pre-PR initial gate | P3 | REGRESSION_FROM_THIS_DIFF | Fixed | Catch path clears `pending.timer` before scheduling retry. |
+| Injected no-cut continuation might self-increment `userMessageCount` | GLM pre-PR follow-up | P3 | REGRESSION_FROM_THIS_DIFF | Fixed | `message_end` ignores role=user messages with string `customType`; regression confirms no retry re-arm from `pi-vcc-no-cut-continuation`. |
+
+## Remaining non-blocking follow-up
+
+- Optional hardening: add pre-delivery timeout diagnostics for no-cut continuations that never become safe to send because pending tool results never arrive and no completed assistant boundary occurs. This is outside the plan acceptance criteria; current behavior safely defers until safe and clears stale continuations when a later compaction starts or succeeds.
+
+## Final gate result
+
+- GPT verdict: `CLEAN_FOR_PR`
+- GLM verdict: `CLEAN_FOR_PR`
+- Final verification rerun after last fix: PASS for targeted extension tests, pi-vcc package tests, and diff whitespace check.
+- Next step: `OPEN_PR_READY`


### PR DESCRIPTION
## Summary
- Add recoverable hard-backstop no-cut handling in the Pi percentage-compaction extension, including active-turn continuation, pending tool-result ordering, bounded retry, stale continuation cleanup, and retry suppression/re-arm.
- Add pi-vcc no-cut classification metadata plus safer agent-only fallback cuts that avoid orphaned tool results.
- Update docs, execution plan progress, and pre-PR review artifact.

## Verification
- `bun test scripts/percentage-compaction.test.ts` — PASS (38 pass)
- `cd _pi/packages/pi-vcc && bun test` — PASS (156 pass)
- `git diff --check` — PASS
- `./install.sh --pi` — PASS; vendored pi-vcc installed to the stable mirror

## Notes
- `bash scripts/check-pi-vcc-upstream.sh --summary` still exits 2 because reviewed upstream metadata is stale (reviewed 0.3.18/45e93e8 vs latest 0.4.0/b9e0bab). This is pre-existing and documented in the plan decision log.
- Pre-PR implementation review artifact: `thoughts/validation/pre-pr-reviews/2026-07-06-pi-vcc-no-cut-hard-backstop.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compaction behavior to better handle near-full sessions, including safer continuation when compaction cannot make a clean cut.
  * Added clearer compaction status and manual trigger commands.

* **Bug Fixes**
  * Prevented unsafe compactions that could leave behind incomplete tool interactions.
  * Reduced repeated compaction attempts when no safe cut is available.

* **Documentation**
  * Updated compaction guidance to reflect the new thresholds, recovery behavior, and configuration notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->